### PR TITLE
Release v0.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## 0.1.5 - 2026-06-21
+
+Patch release for PMX material split host import and parser API parity.
+
+### Added
+
+- Added `split_pmx_model_by_material` and `PmxMaterialSplit` DTOs to
+  `mmd-anim-format` for Maya-style per-material mesh import. Each split mesh
+  remaps vertices to local indices and prunes/remaps morphs: vertex, UV, and
+  material morphs are filtered to the split mesh and remapped to local indices;
+  group/flip morphs are pruned to surviving children through a fixpoint pass
+  that preserves forward references; bone morphs are excluded as
+  skeleton-shared, and impulse morphs are diagnostic-only.
+- Added an opaque PMX material split C ABI handle to `mmd-anim-ffi`
+  (`create`/`free`/`mesh_count`/`manifest_json` plus mesh-indexed geometry
+  getters). `manifest_json` carries `originalMaterialIndex`,
+  `originalVertexIndices`, `morphIndexMap`, and diagnostics.
+- Added one-shot PMX geometry C ABI getters for parity with `WasmPmxGeometry`:
+  `edge_scale`, additional UVs (with count, per channel), `material_groups`,
+  SDEF `rw0`/`rw1`, and `qdef_enabled`.
+- Added `parseVmdAnimationJson` and `WasmPmxGeometry.skinningModes` to
+  `mmd-anim-wasm` for parser surface parity with the C ABI.
+
 ## 0.1.4 - 2026-06-19
 
 Patch release for host-facing parser JSON and PMX geometry FFI.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,7 +79,7 @@ checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "mmd-anim"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "mmd-anim-format",
  "mmd-anim-runtime",
@@ -87,7 +87,7 @@ dependencies = [
 
 [[package]]
 name = "mmd-anim-cli"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "glam",
  "mmd-anim-format",
@@ -98,7 +98,7 @@ dependencies = [
 
 [[package]]
 name = "mmd-anim-ffi"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "glam",
  "mmd-anim-format",
@@ -108,7 +108,7 @@ dependencies = [
 
 [[package]]
 name = "mmd-anim-format"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "encoding_rs",
  "glam",
@@ -120,7 +120,7 @@ dependencies = [
 
 [[package]]
 name = "mmd-anim-runtime"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "glam",
  "thiserror",
@@ -128,7 +128,7 @@ dependencies = [
 
 [[package]]
 name = "mmd-anim-schema"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "glam",
  "serde",
@@ -138,7 +138,7 @@ dependencies = [
 
 [[package]]
 name = "mmd-anim-wasm"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "glam",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.1.4"
+version = "0.1.5"
 edition = "2024"
 rust-version = "1.87"
 license = "MIT"
@@ -28,7 +28,7 @@ serde_json = "1.0.145"
 wasm-bindgen = "0.2.105"
 js-sys = "0.3"
 encoding_rs = "0.8"
-mmd-anim-runtime = { path = "crates/mmd-anim-runtime", version = "0.1.4" }
-mmd-anim-schema = { path = "crates/mmd-anim-schema", version = "0.1.4" }
-mmd-anim-format = { path = "crates/mmd-anim-format", version = "0.1.4" }
+mmd-anim-runtime = { path = "crates/mmd-anim-runtime", version = "0.1.5" }
+mmd-anim-schema = { path = "crates/mmd-anim-schema", version = "0.1.5" }
+mmd-anim-format = { path = "crates/mmd-anim-format", version = "0.1.5" }
  

--- a/crates/mmd-anim-cli/Cargo.toml
+++ b/crates/mmd-anim-cli/Cargo.toml
@@ -19,6 +19,6 @@ doc = false
 [dependencies]
 glam.workspace = true
 mmd-anim-runtime.workspace = true
-mmd-anim-format = { path = "../mmd-anim-format", version = "0.1.4" }
+mmd-anim-format = { path = "../mmd-anim-format", version = "0.1.5" }
 mmd-anim-schema.workspace = true
 serde_json.workspace = true

--- a/crates/mmd-anim-ffi/Cargo.toml
+++ b/crates/mmd-anim-ffi/Cargo.toml
@@ -17,5 +17,5 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 glam.workspace = true
 mmd-anim-runtime.workspace = true
-mmd-anim-format = { path = "../mmd-anim-format", version = "0.1.4" }
+mmd-anim-format = { path = "../mmd-anim-format", version = "0.1.5" }
 serde_json.workspace = true

--- a/crates/mmd-anim-ffi/include/mmd_runtime.h
+++ b/crates/mmd-anim-ffi/include/mmd_runtime.h
@@ -22,6 +22,7 @@ extern "C" {
 typedef struct mmd_runtime_model_t    mmd_runtime_model_t;
 typedef struct mmd_runtime_instance_t mmd_runtime_instance_t;
 typedef struct mmd_runtime_clip_t     mmd_runtime_clip_t;
+typedef struct mmd_runtime_pmx_material_split_t mmd_runtime_pmx_material_split_t;
 
 /* ------------------------------------------------------------------ */
 /*  Flag constants                                                    */
@@ -143,7 +144,20 @@ mmd_runtime_ffi_byte_buffer_t mmd_runtime_parse_pmx_uvs_buffer(
     const uint8_t* data,
     size_t         len);
 
+size_t mmd_runtime_parse_pmx_additional_uv_count(
+    const uint8_t* data,
+    size_t         len);
+
+mmd_runtime_ffi_byte_buffer_t mmd_runtime_parse_pmx_additional_uvs_buffer(
+    const uint8_t* data,
+    size_t         len,
+    size_t         uv_index);
+
 mmd_runtime_ffi_byte_buffer_t mmd_runtime_parse_pmx_indices_buffer(
+    const uint8_t* data,
+    size_t         len);
+
+mmd_runtime_ffi_byte_buffer_t mmd_runtime_parse_pmx_material_groups_buffer(
     const uint8_t* data,
     size_t         len);
 
@@ -152,6 +166,10 @@ mmd_runtime_ffi_byte_buffer_t mmd_runtime_parse_pmx_skin_indices_buffer(
     size_t         len);
 
 mmd_runtime_ffi_byte_buffer_t mmd_runtime_parse_pmx_skin_weights_buffer(
+    const uint8_t* data,
+    size_t         len);
+
+mmd_runtime_ffi_byte_buffer_t mmd_runtime_parse_pmx_edge_scale_buffer(
     const uint8_t* data,
     size_t         len);
 
@@ -171,10 +189,105 @@ mmd_runtime_ffi_byte_buffer_t mmd_runtime_parse_pmx_sdef_r1_buffer(
     const uint8_t* data,
     size_t         len);
 
+mmd_runtime_ffi_byte_buffer_t mmd_runtime_parse_pmx_sdef_rw0_buffer(
+    const uint8_t* data,
+    size_t         len);
+
+mmd_runtime_ffi_byte_buffer_t mmd_runtime_parse_pmx_sdef_rw1_buffer(
+    const uint8_t* data,
+    size_t         len);
+
+mmd_runtime_ffi_byte_buffer_t mmd_runtime_parse_pmx_qdef_enabled_buffer(
+    const uint8_t* data,
+    size_t         len);
+
 /* Returns JSON: {"skinningModes": ["bdef1", ...]} */
 mmd_runtime_ffi_byte_buffer_t mmd_runtime_parse_pmx_skinning_modes_json(
     const uint8_t* data,
     size_t         len);
+
+/* PMX material split handle API.
+   mmd_runtime_pmx_material_split_create parses PMX bytes once and returns an
+   owned opaque handle. Free it with mmd_runtime_pmx_material_split_free.
+   All returned byte buffers are owned by Rust and must be freed with
+   mmd_runtime_byte_buffer_free. Geometry buffers are native-endian flat arrays.
+   Invalid input, invalid handles, or out-of-range mesh/UV indices return null
+   handles, zero counts, or empty buffers. */
+
+mmd_runtime_pmx_material_split_t* mmd_runtime_pmx_material_split_create(
+    const uint8_t* data,
+    size_t         len,
+    uint32_t       flags);
+
+void mmd_runtime_pmx_material_split_free(
+    mmd_runtime_pmx_material_split_t* split);
+
+size_t mmd_runtime_pmx_material_split_mesh_count(
+    const mmd_runtime_pmx_material_split_t* split);
+
+mmd_runtime_ffi_byte_buffer_t mmd_runtime_pmx_material_split_manifest_json(
+    const mmd_runtime_pmx_material_split_t* split);
+
+mmd_runtime_ffi_byte_buffer_t mmd_runtime_pmx_material_split_positions_buffer(
+    const mmd_runtime_pmx_material_split_t* split,
+    size_t                                  mesh_index);
+
+mmd_runtime_ffi_byte_buffer_t mmd_runtime_pmx_material_split_normals_buffer(
+    const mmd_runtime_pmx_material_split_t* split,
+    size_t                                  mesh_index);
+
+mmd_runtime_ffi_byte_buffer_t mmd_runtime_pmx_material_split_uvs_buffer(
+    const mmd_runtime_pmx_material_split_t* split,
+    size_t                                  mesh_index);
+
+mmd_runtime_ffi_byte_buffer_t mmd_runtime_pmx_material_split_additional_uvs_buffer(
+    const mmd_runtime_pmx_material_split_t* split,
+    size_t                                  mesh_index,
+    size_t                                  uv_index);
+
+mmd_runtime_ffi_byte_buffer_t mmd_runtime_pmx_material_split_indices_buffer(
+    const mmd_runtime_pmx_material_split_t* split,
+    size_t                                  mesh_index);
+
+mmd_runtime_ffi_byte_buffer_t mmd_runtime_pmx_material_split_skin_indices_buffer(
+    const mmd_runtime_pmx_material_split_t* split,
+    size_t                                  mesh_index);
+
+mmd_runtime_ffi_byte_buffer_t mmd_runtime_pmx_material_split_skin_weights_buffer(
+    const mmd_runtime_pmx_material_split_t* split,
+    size_t                                  mesh_index);
+
+mmd_runtime_ffi_byte_buffer_t mmd_runtime_pmx_material_split_edge_scale_buffer(
+    const mmd_runtime_pmx_material_split_t* split,
+    size_t                                  mesh_index);
+
+mmd_runtime_ffi_byte_buffer_t mmd_runtime_pmx_material_split_sdef_enabled_buffer(
+    const mmd_runtime_pmx_material_split_t* split,
+    size_t                                  mesh_index);
+
+mmd_runtime_ffi_byte_buffer_t mmd_runtime_pmx_material_split_sdef_c_buffer(
+    const mmd_runtime_pmx_material_split_t* split,
+    size_t                                  mesh_index);
+
+mmd_runtime_ffi_byte_buffer_t mmd_runtime_pmx_material_split_sdef_r0_buffer(
+    const mmd_runtime_pmx_material_split_t* split,
+    size_t                                  mesh_index);
+
+mmd_runtime_ffi_byte_buffer_t mmd_runtime_pmx_material_split_sdef_r1_buffer(
+    const mmd_runtime_pmx_material_split_t* split,
+    size_t                                  mesh_index);
+
+mmd_runtime_ffi_byte_buffer_t mmd_runtime_pmx_material_split_sdef_rw0_buffer(
+    const mmd_runtime_pmx_material_split_t* split,
+    size_t                                  mesh_index);
+
+mmd_runtime_ffi_byte_buffer_t mmd_runtime_pmx_material_split_sdef_rw1_buffer(
+    const mmd_runtime_pmx_material_split_t* split,
+    size_t                                  mesh_index);
+
+mmd_runtime_ffi_byte_buffer_t mmd_runtime_pmx_material_split_qdef_enabled_buffer(
+    const mmd_runtime_pmx_material_split_t* split,
+    size_t                                  mesh_index);
 
 mmd_runtime_model_t* mmd_runtime_model_create(
     const int32_t* parent_indices,

--- a/crates/mmd-anim-ffi/src/lib.rs
+++ b/crates/mmd-anim-ffi/src/lib.rs
@@ -53,6 +53,11 @@ pub struct MmdRuntimeClip {
     clip: AnimationClip,
 }
 
+pub struct MmdRuntimePmxMaterialSplit {
+    split: mmd_anim_format::PmxMaterialSplitResult,
+    manifest_json: Vec<u8>,
+}
+
 #[repr(C)]
 pub struct MmdRuntimeFfiBoneTrack {
     pub bone_index: u32,
@@ -407,6 +412,56 @@ pub unsafe extern "C" fn mmd_runtime_parse_pmx_uvs_buffer(
     }
 }
 
+/// Parses PMX bytes and returns the number of additional UV channels.
+///
+/// Returns zero on parse failure, null input, or zero length.
+///
+/// # Safety
+/// `data` must point to `len` readable bytes when `len` is non-zero.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn mmd_runtime_parse_pmx_additional_uv_count(
+    data: *const u8,
+    len: usize,
+) -> usize {
+    if data.is_null() || len == 0 {
+        return 0;
+    }
+    let bytes = unsafe { slice::from_raw_parts(data, len) };
+    match mmd_anim_format::parse_pmx_model(bytes) {
+        Ok(parsed) => parsed.geometry.additional_uvs.len(),
+        Err(_) => 0,
+    }
+}
+
+/// Parses PMX bytes and returns one additional-UV channel as a native-endian byte buffer.
+///
+/// The buffer contains `vertex_count * 4` f32 values for the requested channel.
+/// Returns an empty buffer on parse failure, null input, zero length, or
+/// out-of-range `uv_index`.
+///
+/// # Safety
+/// `data` must point to `len` readable bytes when `len` is non-zero.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn mmd_runtime_parse_pmx_additional_uvs_buffer(
+    data: *const u8,
+    len: usize,
+    uv_index: usize,
+) -> MmdRuntimeFfiByteBuffer {
+    if data.is_null() || len == 0 {
+        return empty_byte_buffer();
+    }
+    let bytes = unsafe { slice::from_raw_parts(data, len) };
+    match mmd_anim_format::parse_pmx_model(bytes) {
+        Ok(parsed) => {
+            let Some(values) = parsed.geometry.additional_uvs.get(uv_index) else {
+                return empty_byte_buffer();
+            };
+            byte_buffer_from_f32_slice(values)
+        }
+        Err(_) => empty_byte_buffer(),
+    }
+}
+
 /// Parses PMX bytes and returns face indices as a native-endian byte buffer.
 ///
 /// The buffer contains `index_count` u32 values.
@@ -431,6 +486,42 @@ pub unsafe extern "C" fn mmd_runtime_parse_pmx_indices_buffer(
                 .flat_map(|v| v.to_ne_bytes())
                 .collect();
             byte_buffer_from_vec(buf)
+        }
+        Err(_) => empty_byte_buffer(),
+    }
+}
+
+/// Parses PMX bytes and returns material groups as a native-endian byte buffer.
+///
+/// The buffer contains `group_count * 3` u32 values as
+/// `[start, count, material_index]` triples.
+///
+/// # Safety
+/// `data` must point to `len` readable bytes when `len` is non-zero.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn mmd_runtime_parse_pmx_material_groups_buffer(
+    data: *const u8,
+    len: usize,
+) -> MmdRuntimeFfiByteBuffer {
+    if data.is_null() || len == 0 {
+        return empty_byte_buffer();
+    }
+    let bytes = unsafe { slice::from_raw_parts(data, len) };
+    match mmd_anim_format::parse_pmx_model(bytes) {
+        Ok(parsed) => {
+            let groups: Vec<u32> = parsed
+                .geometry
+                .material_groups
+                .iter()
+                .flat_map(|group| {
+                    [
+                        group.start as u32,
+                        group.count as u32,
+                        group.material_index as u32,
+                    ]
+                })
+                .collect();
+            byte_buffer_from_u32_slice(&groups)
         }
         Err(_) => empty_byte_buffer(),
     }
@@ -490,6 +581,27 @@ pub unsafe extern "C" fn mmd_runtime_parse_pmx_skin_weights_buffer(
                 .collect();
             byte_buffer_from_vec(buf)
         }
+        Err(_) => empty_byte_buffer(),
+    }
+}
+
+/// Parses PMX bytes and returns per-vertex edge scale as a native-endian byte buffer.
+///
+/// The buffer contains `vertex_count` f32 values.
+///
+/// # Safety
+/// `data` must point to `len` readable bytes when `len` is non-zero.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn mmd_runtime_parse_pmx_edge_scale_buffer(
+    data: *const u8,
+    len: usize,
+) -> MmdRuntimeFfiByteBuffer {
+    if data.is_null() || len == 0 {
+        return empty_byte_buffer();
+    }
+    let bytes = unsafe { slice::from_raw_parts(data, len) };
+    match mmd_anim_format::parse_pmx_model(bytes) {
+        Ok(parsed) => byte_buffer_from_f32_slice(&parsed.geometry.edge_scale),
         Err(_) => empty_byte_buffer(),
     }
 }
@@ -615,6 +727,78 @@ pub unsafe extern "C" fn mmd_runtime_parse_pmx_sdef_r1_buffer(
     }
 }
 
+/// Parses PMX bytes and returns derived SDEF RW0 vectors as a native-endian byte buffer.
+///
+/// The buffer contains `vertex_count * 3` f32 values.
+///
+/// # Safety
+/// `data` must point to `len` readable bytes when `len` is non-zero.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn mmd_runtime_parse_pmx_sdef_rw0_buffer(
+    data: *const u8,
+    len: usize,
+) -> MmdRuntimeFfiByteBuffer {
+    if data.is_null() || len == 0 {
+        return empty_byte_buffer();
+    }
+    let bytes = unsafe { slice::from_raw_parts(data, len) };
+    match mmd_anim_format::parse_pmx_model(bytes) {
+        Ok(parsed) => byte_buffer_from_f32_slice(&parsed.geometry.sdef.rw0),
+        Err(_) => empty_byte_buffer(),
+    }
+}
+
+/// Parses PMX bytes and returns derived SDEF RW1 vectors as a native-endian byte buffer.
+///
+/// The buffer contains `vertex_count * 3` f32 values.
+///
+/// # Safety
+/// `data` must point to `len` readable bytes when `len` is non-zero.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn mmd_runtime_parse_pmx_sdef_rw1_buffer(
+    data: *const u8,
+    len: usize,
+) -> MmdRuntimeFfiByteBuffer {
+    if data.is_null() || len == 0 {
+        return empty_byte_buffer();
+    }
+    let bytes = unsafe { slice::from_raw_parts(data, len) };
+    match mmd_anim_format::parse_pmx_model(bytes) {
+        Ok(parsed) => byte_buffer_from_f32_slice(&parsed.geometry.sdef.rw1),
+        Err(_) => empty_byte_buffer(),
+    }
+}
+
+/// Parses PMX bytes and returns QDEF-enabled flags as a byte buffer.
+///
+/// Each byte is `1` when QDEF is enabled for that vertex, or `0` otherwise.
+/// The buffer length equals `vertex_count`.
+///
+/// # Safety
+/// `data` must point to `len` readable bytes when `len` is non-zero.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn mmd_runtime_parse_pmx_qdef_enabled_buffer(
+    data: *const u8,
+    len: usize,
+) -> MmdRuntimeFfiByteBuffer {
+    if data.is_null() || len == 0 {
+        return empty_byte_buffer();
+    }
+    let bytes = unsafe { slice::from_raw_parts(data, len) };
+    match mmd_anim_format::parse_pmx_model(bytes) {
+        Ok(parsed) => byte_buffer_from_vec(
+            parsed
+                .geometry
+                .qdef
+                .enabled
+                .iter()
+                .map(|&v| if v > 0.5 { 1u8 } else { 0u8 })
+                .collect(),
+        ),
+        Err(_) => empty_byte_buffer(),
+    }
+}
+
 /// Parses PMX bytes and returns skinning mode names as a JSON object.
 ///
 /// The returned JSON has the shape `{"skinningModes": ["bdef1", ...]}`.
@@ -677,6 +861,381 @@ pub unsafe extern "C" fn mmd_runtime_parse_pmx_skinning_modes_json(
         }
         Err(_) => empty_byte_buffer(),
     }
+}
+
+/// Parses PMX bytes once and creates an opaque material-split handle.
+///
+/// # Safety
+/// `data` must point to `len` readable bytes when `len` is non-zero.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn mmd_runtime_pmx_material_split_create(
+    data: *const u8,
+    len: usize,
+    flags: u32,
+) -> *mut MmdRuntimePmxMaterialSplit {
+    if data.is_null() || len == 0 {
+        return ptr::null_mut();
+    }
+    let bytes = unsafe { slice::from_raw_parts(data, len) };
+    let split = match mmd_anim_format::parse_pmx_material_split(bytes, flags) {
+        Ok(split) => split,
+        Err(_) => return ptr::null_mut(),
+    };
+    let manifest_json = match serde_json::to_vec(&split.manifest) {
+        Ok(json) => json,
+        Err(_) => return ptr::null_mut(),
+    };
+    Box::into_raw(Box::new(MmdRuntimePmxMaterialSplit {
+        split,
+        manifest_json,
+    }))
+}
+
+/// Frees a PMX material-split handle.
+///
+/// # Safety
+/// `split` must be null or a handle returned by
+/// `mmd_runtime_pmx_material_split_create` that has not already been freed.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn mmd_runtime_pmx_material_split_free(
+    split: *mut MmdRuntimePmxMaterialSplit,
+) {
+    if split.is_null() {
+        return;
+    }
+    unsafe {
+        drop(Box::from_raw(split));
+    }
+}
+
+/// Returns the number of material-split meshes owned by a split handle.
+///
+/// # Safety
+/// `split` must be null or a valid handle returned by
+/// `mmd_runtime_pmx_material_split_create`. Passing any other pointer is
+/// undefined behavior. A null handle returns zero.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn mmd_runtime_pmx_material_split_mesh_count(
+    split: *const MmdRuntimePmxMaterialSplit,
+) -> usize {
+    let Some(split) = (unsafe { split.as_ref() }) else {
+        return 0;
+    };
+    split.split.meshes.len()
+}
+
+/// Returns the serialized material-split manifest JSON.
+///
+/// # Safety
+/// `split` must be null or a valid handle returned by
+/// `mmd_runtime_pmx_material_split_create`. Passing any other pointer is
+/// undefined behavior. The returned buffer is owned by the caller and must be
+/// freed with `mmd_runtime_byte_buffer_free`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn mmd_runtime_pmx_material_split_manifest_json(
+    split: *const MmdRuntimePmxMaterialSplit,
+) -> MmdRuntimeFfiByteBuffer {
+    let Some(split) = (unsafe { split.as_ref() }) else {
+        return empty_byte_buffer();
+    };
+    byte_buffer_from_vec(split.manifest_json.clone())
+}
+
+/// Returns split mesh vertex positions as a native-endian byte buffer.
+///
+/// # Safety
+/// `split` must be null or a valid handle returned by
+/// `mmd_runtime_pmx_material_split_create`. Passing any other pointer is
+/// undefined behavior. The returned buffer is owned by the caller and must be
+/// freed with `mmd_runtime_byte_buffer_free`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn mmd_runtime_pmx_material_split_positions_buffer(
+    split: *const MmdRuntimePmxMaterialSplit,
+    mesh_index: usize,
+) -> MmdRuntimeFfiByteBuffer {
+    pmx_material_split_f32_buffer(split, mesh_index, |mesh| &mesh.geometry.positions)
+}
+
+/// Returns split mesh vertex normals as a native-endian byte buffer.
+///
+/// # Safety
+/// `split` must be null or a valid handle returned by
+/// `mmd_runtime_pmx_material_split_create`. Passing any other pointer is
+/// undefined behavior. The returned buffer is owned by the caller and must be
+/// freed with `mmd_runtime_byte_buffer_free`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn mmd_runtime_pmx_material_split_normals_buffer(
+    split: *const MmdRuntimePmxMaterialSplit,
+    mesh_index: usize,
+) -> MmdRuntimeFfiByteBuffer {
+    pmx_material_split_f32_buffer(split, mesh_index, |mesh| &mesh.geometry.normals)
+}
+
+/// Returns split mesh vertex UVs as a native-endian byte buffer.
+///
+/// # Safety
+/// `split` must be null or a valid handle returned by
+/// `mmd_runtime_pmx_material_split_create`. Passing any other pointer is
+/// undefined behavior. The returned buffer is owned by the caller and must be
+/// freed with `mmd_runtime_byte_buffer_free`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn mmd_runtime_pmx_material_split_uvs_buffer(
+    split: *const MmdRuntimePmxMaterialSplit,
+    mesh_index: usize,
+) -> MmdRuntimeFfiByteBuffer {
+    pmx_material_split_f32_buffer(split, mesh_index, |mesh| &mesh.geometry.uvs)
+}
+
+/// Returns one split mesh additional-UV layer as a native-endian byte buffer.
+///
+/// # Safety
+/// `split` must be null or a valid handle returned by
+/// `mmd_runtime_pmx_material_split_create`. Passing any other pointer is
+/// undefined behavior. The returned buffer is owned by the caller and must be
+/// freed with `mmd_runtime_byte_buffer_free`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn mmd_runtime_pmx_material_split_additional_uvs_buffer(
+    split: *const MmdRuntimePmxMaterialSplit,
+    mesh_index: usize,
+    uv_index: usize,
+) -> MmdRuntimeFfiByteBuffer {
+    let Some(split) = (unsafe { split.as_ref() }) else {
+        return empty_byte_buffer();
+    };
+    let Some(mesh) = split.split.meshes.get(mesh_index) else {
+        return empty_byte_buffer();
+    };
+    let Some(values) = mesh.geometry.additional_uvs.get(uv_index) else {
+        return empty_byte_buffer();
+    };
+    byte_buffer_from_f32_slice(values)
+}
+
+/// Returns split mesh triangle indices as a native-endian byte buffer.
+///
+/// # Safety
+/// `split` must be null or a valid handle returned by
+/// `mmd_runtime_pmx_material_split_create`. Passing any other pointer is
+/// undefined behavior. The returned buffer is owned by the caller and must be
+/// freed with `mmd_runtime_byte_buffer_free`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn mmd_runtime_pmx_material_split_indices_buffer(
+    split: *const MmdRuntimePmxMaterialSplit,
+    mesh_index: usize,
+) -> MmdRuntimeFfiByteBuffer {
+    pmx_material_split_u32_buffer(split, mesh_index, |mesh| &mesh.geometry.indices)
+}
+
+/// Returns split mesh skin bone indices as a native-endian byte buffer.
+///
+/// # Safety
+/// `split` must be null or a valid handle returned by
+/// `mmd_runtime_pmx_material_split_create`. Passing any other pointer is
+/// undefined behavior. The returned buffer is owned by the caller and must be
+/// freed with `mmd_runtime_byte_buffer_free`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn mmd_runtime_pmx_material_split_skin_indices_buffer(
+    split: *const MmdRuntimePmxMaterialSplit,
+    mesh_index: usize,
+) -> MmdRuntimeFfiByteBuffer {
+    pmx_material_split_u32_buffer(split, mesh_index, |mesh| &mesh.geometry.skin_indices)
+}
+
+/// Returns split mesh skin weights as a native-endian byte buffer.
+///
+/// # Safety
+/// `split` must be null or a valid handle returned by
+/// `mmd_runtime_pmx_material_split_create`. Passing any other pointer is
+/// undefined behavior. The returned buffer is owned by the caller and must be
+/// freed with `mmd_runtime_byte_buffer_free`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn mmd_runtime_pmx_material_split_skin_weights_buffer(
+    split: *const MmdRuntimePmxMaterialSplit,
+    mesh_index: usize,
+) -> MmdRuntimeFfiByteBuffer {
+    pmx_material_split_f32_buffer(split, mesh_index, |mesh| &mesh.geometry.skin_weights)
+}
+
+/// Returns split mesh edge scale values as a native-endian byte buffer.
+///
+/// # Safety
+/// `split` must be null or a valid handle returned by
+/// `mmd_runtime_pmx_material_split_create`. Passing any other pointer is
+/// undefined behavior. The returned buffer is owned by the caller and must be
+/// freed with `mmd_runtime_byte_buffer_free`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn mmd_runtime_pmx_material_split_edge_scale_buffer(
+    split: *const MmdRuntimePmxMaterialSplit,
+    mesh_index: usize,
+) -> MmdRuntimeFfiByteBuffer {
+    pmx_material_split_f32_buffer(split, mesh_index, |mesh| &mesh.geometry.edge_scale)
+}
+
+/// Returns split mesh SDEF-enabled flags as a byte buffer.
+///
+/// # Safety
+/// `split` must be null or a valid handle returned by
+/// `mmd_runtime_pmx_material_split_create`. Passing any other pointer is
+/// undefined behavior. The returned buffer is owned by the caller and must be
+/// freed with `mmd_runtime_byte_buffer_free`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn mmd_runtime_pmx_material_split_sdef_enabled_buffer(
+    split: *const MmdRuntimePmxMaterialSplit,
+    mesh_index: usize,
+) -> MmdRuntimeFfiByteBuffer {
+    let Some(split) = (unsafe { split.as_ref() }) else {
+        return empty_byte_buffer();
+    };
+    let Some(mesh) = split.split.meshes.get(mesh_index) else {
+        return empty_byte_buffer();
+    };
+    byte_buffer_from_vec(
+        mesh.geometry
+            .sdef
+            .enabled
+            .iter()
+            .map(|&v| if v > 0.5 { 1u8 } else { 0u8 })
+            .collect(),
+    )
+}
+
+/// Returns split mesh SDEF C vectors as a native-endian byte buffer.
+///
+/// # Safety
+/// `split` must be null or a valid handle returned by
+/// `mmd_runtime_pmx_material_split_create`. Passing any other pointer is
+/// undefined behavior. The returned buffer is owned by the caller and must be
+/// freed with `mmd_runtime_byte_buffer_free`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn mmd_runtime_pmx_material_split_sdef_c_buffer(
+    split: *const MmdRuntimePmxMaterialSplit,
+    mesh_index: usize,
+) -> MmdRuntimeFfiByteBuffer {
+    pmx_material_split_f32_buffer(split, mesh_index, |mesh| &mesh.geometry.sdef.c)
+}
+
+/// Returns split mesh SDEF R0 vectors as a native-endian byte buffer.
+///
+/// # Safety
+/// `split` must be null or a valid handle returned by
+/// `mmd_runtime_pmx_material_split_create`. Passing any other pointer is
+/// undefined behavior. The returned buffer is owned by the caller and must be
+/// freed with `mmd_runtime_byte_buffer_free`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn mmd_runtime_pmx_material_split_sdef_r0_buffer(
+    split: *const MmdRuntimePmxMaterialSplit,
+    mesh_index: usize,
+) -> MmdRuntimeFfiByteBuffer {
+    pmx_material_split_f32_buffer(split, mesh_index, |mesh| &mesh.geometry.sdef.r0)
+}
+
+/// Returns split mesh SDEF R1 vectors as a native-endian byte buffer.
+///
+/// # Safety
+/// `split` must be null or a valid handle returned by
+/// `mmd_runtime_pmx_material_split_create`. Passing any other pointer is
+/// undefined behavior. The returned buffer is owned by the caller and must be
+/// freed with `mmd_runtime_byte_buffer_free`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn mmd_runtime_pmx_material_split_sdef_r1_buffer(
+    split: *const MmdRuntimePmxMaterialSplit,
+    mesh_index: usize,
+) -> MmdRuntimeFfiByteBuffer {
+    pmx_material_split_f32_buffer(split, mesh_index, |mesh| &mesh.geometry.sdef.r1)
+}
+
+/// Returns split mesh derived SDEF RW0 vectors as a native-endian byte buffer.
+///
+/// # Safety
+/// `split` must be null or a valid handle returned by
+/// `mmd_runtime_pmx_material_split_create`. Passing any other pointer is
+/// undefined behavior. The returned buffer is owned by the caller and must be
+/// freed with `mmd_runtime_byte_buffer_free`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn mmd_runtime_pmx_material_split_sdef_rw0_buffer(
+    split: *const MmdRuntimePmxMaterialSplit,
+    mesh_index: usize,
+) -> MmdRuntimeFfiByteBuffer {
+    pmx_material_split_f32_buffer(split, mesh_index, |mesh| &mesh.geometry.sdef.rw0)
+}
+
+/// Returns split mesh derived SDEF RW1 vectors as a native-endian byte buffer.
+///
+/// # Safety
+/// `split` must be null or a valid handle returned by
+/// `mmd_runtime_pmx_material_split_create`. Passing any other pointer is
+/// undefined behavior. The returned buffer is owned by the caller and must be
+/// freed with `mmd_runtime_byte_buffer_free`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn mmd_runtime_pmx_material_split_sdef_rw1_buffer(
+    split: *const MmdRuntimePmxMaterialSplit,
+    mesh_index: usize,
+) -> MmdRuntimeFfiByteBuffer {
+    pmx_material_split_f32_buffer(split, mesh_index, |mesh| &mesh.geometry.sdef.rw1)
+}
+
+/// Returns split mesh QDEF-enabled flags as a byte buffer.
+///
+/// # Safety
+/// `split` must be null or a valid handle returned by
+/// `mmd_runtime_pmx_material_split_create`. Passing any other pointer is
+/// undefined behavior. The returned buffer is owned by the caller and must be
+/// freed with `mmd_runtime_byte_buffer_free`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn mmd_runtime_pmx_material_split_qdef_enabled_buffer(
+    split: *const MmdRuntimePmxMaterialSplit,
+    mesh_index: usize,
+) -> MmdRuntimeFfiByteBuffer {
+    let Some(split) = (unsafe { split.as_ref() }) else {
+        return empty_byte_buffer();
+    };
+    let Some(mesh) = split.split.meshes.get(mesh_index) else {
+        return empty_byte_buffer();
+    };
+    byte_buffer_from_vec(
+        mesh.geometry
+            .qdef
+            .enabled
+            .iter()
+            .map(|&v| if v > 0.5 { 1u8 } else { 0u8 })
+            .collect(),
+    )
+}
+
+fn pmx_material_split_f32_buffer(
+    split: *const MmdRuntimePmxMaterialSplit,
+    mesh_index: usize,
+    accessor: fn(&mmd_anim_format::PmxMaterialSplitMesh) -> &Vec<f32>,
+) -> MmdRuntimeFfiByteBuffer {
+    let Some(split) = (unsafe { split.as_ref() }) else {
+        return empty_byte_buffer();
+    };
+    let Some(mesh) = split.split.meshes.get(mesh_index) else {
+        return empty_byte_buffer();
+    };
+    byte_buffer_from_f32_slice(accessor(mesh))
+}
+
+fn pmx_material_split_u32_buffer(
+    split: *const MmdRuntimePmxMaterialSplit,
+    mesh_index: usize,
+    accessor: fn(&mmd_anim_format::PmxMaterialSplitMesh) -> &Vec<u32>,
+) -> MmdRuntimeFfiByteBuffer {
+    let Some(split) = (unsafe { split.as_ref() }) else {
+        return empty_byte_buffer();
+    };
+    let Some(mesh) = split.split.meshes.get(mesh_index) else {
+        return empty_byte_buffer();
+    };
+    byte_buffer_from_u32_slice(accessor(mesh))
+}
+
+fn byte_buffer_from_f32_slice(values: &[f32]) -> MmdRuntimeFfiByteBuffer {
+    byte_buffer_from_vec(values.iter().flat_map(|v| v.to_ne_bytes()).collect())
+}
+
+fn byte_buffer_from_u32_slice(values: &[u32]) -> MmdRuntimeFfiByteBuffer {
+    byte_buffer_from_vec(values.iter().flat_map(|v| v.to_ne_bytes()).collect())
 }
 
 /// Exports a minimal PMX model from flat geometry arrays and a JSON descriptor.
@@ -3695,13 +4254,45 @@ mod tests {
         check_rejects!(mmd_runtime_parse_pmx_normals_buffer);
         check_rejects!(mmd_runtime_parse_pmx_uvs_buffer);
         check_rejects!(mmd_runtime_parse_pmx_indices_buffer);
+        check_rejects!(mmd_runtime_parse_pmx_material_groups_buffer);
         check_rejects!(mmd_runtime_parse_pmx_skin_indices_buffer);
         check_rejects!(mmd_runtime_parse_pmx_skin_weights_buffer);
+        check_rejects!(mmd_runtime_parse_pmx_edge_scale_buffer);
         check_rejects!(mmd_runtime_parse_pmx_sdef_enabled_buffer);
         check_rejects!(mmd_runtime_parse_pmx_sdef_c_buffer);
         check_rejects!(mmd_runtime_parse_pmx_sdef_r0_buffer);
         check_rejects!(mmd_runtime_parse_pmx_sdef_r1_buffer);
+        check_rejects!(mmd_runtime_parse_pmx_sdef_rw0_buffer);
+        check_rejects!(mmd_runtime_parse_pmx_sdef_rw1_buffer);
+        check_rejects!(mmd_runtime_parse_pmx_qdef_enabled_buffer);
         check_rejects!(mmd_runtime_parse_pmx_skinning_modes_json);
+
+        assert_eq!(
+            unsafe { mmd_runtime_parse_pmx_additional_uv_count(ptr::null(), 0) },
+            0
+        );
+        let d = 0u8;
+        assert_eq!(
+            unsafe { mmd_runtime_parse_pmx_additional_uv_count(&d as *const u8, 0) },
+            0
+        );
+        let garbage = [0u8; 16];
+        assert_eq!(
+            unsafe { mmd_runtime_parse_pmx_additional_uv_count(garbage.as_ptr(), garbage.len()) },
+            0
+        );
+
+        let null = unsafe { mmd_runtime_parse_pmx_additional_uvs_buffer(ptr::null(), 0, 0) };
+        assert!(null.data.is_null(), "additional UV null");
+        assert_eq!(null.len, 0, "additional UV null len");
+
+        let empty = unsafe { mmd_runtime_parse_pmx_additional_uvs_buffer(&d as *const u8, 0, 0) };
+        assert!(empty.data.is_null(), "additional UV empty");
+
+        let invalid = unsafe {
+            mmd_runtime_parse_pmx_additional_uvs_buffer(garbage.as_ptr(), garbage.len(), 0)
+        };
+        assert!(invalid.data.is_null(), "additional UV invalid");
     }
 
     #[test]
@@ -3711,6 +4302,8 @@ mod tests {
         let parsed = mmd_anim_format::parse_pmx_model(bytes).unwrap();
         let vertex_count = parsed.metadata.counts.vertices as usize;
         let index_count = parsed.metadata.counts.faces as usize * 3;
+        let additional_uv_count = parsed.geometry.additional_uvs.len();
+        let material_group_count = parsed.geometry.material_groups.len();
 
         macro_rules! check_buf {
             ($fn:ident, $expected_bytes:expr) => {{
@@ -3730,6 +4323,10 @@ mod tests {
         check_buf!(mmd_runtime_parse_pmx_uvs_buffer, vertex_count * 2 * 4);
         check_buf!(mmd_runtime_parse_pmx_indices_buffer, index_count * 4);
         check_buf!(
+            mmd_runtime_parse_pmx_material_groups_buffer,
+            material_group_count * 3 * 4
+        );
+        check_buf!(
             mmd_runtime_parse_pmx_skin_indices_buffer,
             vertex_count * 4 * 4
         );
@@ -3737,10 +4334,43 @@ mod tests {
             mmd_runtime_parse_pmx_skin_weights_buffer,
             vertex_count * 4 * 4
         );
+        check_buf!(mmd_runtime_parse_pmx_edge_scale_buffer, vertex_count * 4);
         check_buf!(mmd_runtime_parse_pmx_sdef_enabled_buffer, vertex_count);
         check_buf!(mmd_runtime_parse_pmx_sdef_c_buffer, vertex_count * 3 * 4);
         check_buf!(mmd_runtime_parse_pmx_sdef_r0_buffer, vertex_count * 3 * 4);
         check_buf!(mmd_runtime_parse_pmx_sdef_r1_buffer, vertex_count * 3 * 4);
+        check_buf!(mmd_runtime_parse_pmx_sdef_rw0_buffer, vertex_count * 3 * 4);
+        check_buf!(mmd_runtime_parse_pmx_sdef_rw1_buffer, vertex_count * 3 * 4);
+        check_buf!(mmd_runtime_parse_pmx_qdef_enabled_buffer, vertex_count);
+
+        assert_eq!(
+            unsafe { mmd_runtime_parse_pmx_additional_uv_count(bytes.as_ptr(), bytes.len()) },
+            additional_uv_count
+        );
+        for uv_index in 0..additional_uv_count {
+            let buf = unsafe {
+                mmd_runtime_parse_pmx_additional_uvs_buffer(bytes.as_ptr(), bytes.len(), uv_index)
+            };
+            assert!(
+                !buf.data.is_null(),
+                "additional UV channel {uv_index} must not be null"
+            );
+            assert_eq!(
+                buf.len,
+                vertex_count * 4 * 4,
+                "additional UV channel {uv_index} dimension mismatch"
+            );
+            unsafe { mmd_runtime_byte_buffer_free(buf) };
+        }
+        let invalid_uv = unsafe {
+            mmd_runtime_parse_pmx_additional_uvs_buffer(
+                bytes.as_ptr(),
+                bytes.len(),
+                additional_uv_count,
+            )
+        };
+        assert!(invalid_uv.data.is_null(), "invalid additional UV index");
+        assert_eq!(invalid_uv.len, 0, "invalid additional UV index len");
     }
 
     #[test]

--- a/crates/mmd-anim-ffi/src/lib.rs
+++ b/crates/mmd-anim-ffi/src/lib.rs
@@ -4295,6 +4295,293 @@ mod tests {
         assert!(invalid.data.is_null(), "additional UV invalid");
     }
 
+    fn ffi_buffer_to_vec(buffer: MmdRuntimeFfiByteBuffer) -> Vec<u8> {
+        let bytes = if buffer.data.is_null() || buffer.len == 0 {
+            Vec::new()
+        } else {
+            unsafe { slice::from_raw_parts(buffer.data, buffer.len).to_vec() }
+        };
+        unsafe { mmd_runtime_byte_buffer_free(buffer) };
+        bytes
+    }
+
+    fn assert_empty_ffi_buffer(buffer: MmdRuntimeFfiByteBuffer, context: &str) {
+        assert!(buffer.data.is_null(), "{context}: data must be null");
+        assert_eq!(buffer.len, 0, "{context}: len must be zero");
+    }
+
+    fn assert_material_split_geometry_invariants(
+        split: *mut MmdRuntimePmxMaterialSplit,
+        manifest: &serde_json::Value,
+        context: &str,
+    ) {
+        let mesh_count = unsafe { mmd_runtime_pmx_material_split_mesh_count(split) };
+        assert!(mesh_count > 0, "{context}: mesh_count must be positive");
+        assert_eq!(
+            manifest.get("meshCount").and_then(|v| v.as_u64()),
+            Some(mesh_count as u64),
+            "{context}: manifest meshCount must match mesh_count"
+        );
+
+        let meshes = manifest
+            .get("meshes")
+            .and_then(|v| v.as_array())
+            .unwrap_or_else(|| panic!("{context}: manifest meshes must be an array"));
+        assert_eq!(
+            meshes.len(),
+            mesh_count,
+            "{context}: manifest mesh array length must match mesh_count"
+        );
+
+        for mesh_index in 0..mesh_count {
+            let mesh_context = format!("{context}: mesh {mesh_index}");
+            let mesh_manifest = meshes
+                .iter()
+                .find(|mesh| {
+                    mesh.get("meshIndex").and_then(|v| v.as_u64()) == Some(mesh_index as u64)
+                })
+                .unwrap_or_else(|| panic!("{mesh_context}: manifest mesh entry missing"));
+
+            let positions = ffi_buffer_to_vec(unsafe {
+                mmd_runtime_pmx_material_split_positions_buffer(split, mesh_index)
+            });
+            assert_eq!(
+                positions.len() % (3 * 4),
+                0,
+                "{mesh_context}: positions len must be xyz f32 aligned"
+            );
+            let vertex_count = positions.len() / (3 * 4);
+
+            let normals = ffi_buffer_to_vec(unsafe {
+                mmd_runtime_pmx_material_split_normals_buffer(split, mesh_index)
+            });
+            assert_eq!(
+                normals.len(),
+                positions.len(),
+                "{mesh_context}: normals len"
+            );
+
+            let uvs = ffi_buffer_to_vec(unsafe {
+                mmd_runtime_pmx_material_split_uvs_buffer(split, mesh_index)
+            });
+            assert_eq!(uvs.len(), vertex_count * 2 * 4, "{mesh_context}: uvs len");
+
+            let skin_indices = ffi_buffer_to_vec(unsafe {
+                mmd_runtime_pmx_material_split_skin_indices_buffer(split, mesh_index)
+            });
+            assert_eq!(
+                skin_indices.len(),
+                vertex_count * 4 * 4,
+                "{mesh_context}: skin_indices len"
+            );
+
+            let skin_weights = ffi_buffer_to_vec(unsafe {
+                mmd_runtime_pmx_material_split_skin_weights_buffer(split, mesh_index)
+            });
+            assert_eq!(
+                skin_weights.len(),
+                vertex_count * 4 * 4,
+                "{mesh_context}: skin_weights len"
+            );
+
+            let edge_scale = ffi_buffer_to_vec(unsafe {
+                mmd_runtime_pmx_material_split_edge_scale_buffer(split, mesh_index)
+            });
+            assert_eq!(
+                edge_scale.len(),
+                vertex_count * 4,
+                "{mesh_context}: edge_scale len"
+            );
+
+            let sdef_enabled = ffi_buffer_to_vec(unsafe {
+                mmd_runtime_pmx_material_split_sdef_enabled_buffer(split, mesh_index)
+            });
+            assert_eq!(
+                sdef_enabled.len(),
+                vertex_count,
+                "{mesh_context}: sdef_enabled len"
+            );
+
+            let qdef_enabled = ffi_buffer_to_vec(unsafe {
+                mmd_runtime_pmx_material_split_qdef_enabled_buffer(split, mesh_index)
+            });
+            assert_eq!(
+                qdef_enabled.len(),
+                vertex_count,
+                "{mesh_context}: qdef_enabled len"
+            );
+
+            macro_rules! check_vec3_f32_buffer {
+                ($fn:ident, $name:literal) => {{
+                    let buf = ffi_buffer_to_vec(unsafe { $fn(split, mesh_index) });
+                    assert_eq!(
+                        buf.len(),
+                        vertex_count * 3 * 4,
+                        "{}: {} len",
+                        mesh_context,
+                        $name
+                    );
+                }};
+            }
+
+            check_vec3_f32_buffer!(mmd_runtime_pmx_material_split_sdef_c_buffer, "sdef_c");
+            check_vec3_f32_buffer!(mmd_runtime_pmx_material_split_sdef_r0_buffer, "sdef_r0");
+            check_vec3_f32_buffer!(mmd_runtime_pmx_material_split_sdef_r1_buffer, "sdef_r1");
+            check_vec3_f32_buffer!(mmd_runtime_pmx_material_split_sdef_rw0_buffer, "sdef_rw0");
+            check_vec3_f32_buffer!(mmd_runtime_pmx_material_split_sdef_rw1_buffer, "sdef_rw1");
+
+            let indices = ffi_buffer_to_vec(unsafe {
+                mmd_runtime_pmx_material_split_indices_buffer(split, mesh_index)
+            });
+            assert_eq!(
+                indices.len() % 4,
+                0,
+                "{mesh_context}: indices len must be u32 aligned"
+            );
+            for (index_offset, index_bytes) in indices.chunks_exact(4).enumerate() {
+                let index = u32::from_ne_bytes(index_bytes.try_into().unwrap()) as usize;
+                assert!(
+                    index < vertex_count,
+                    "{mesh_context}: index {index_offset} value {index} must be < vertex_count {vertex_count}"
+                );
+            }
+
+            for uv_index in 0..4 {
+                let additional_uvs = ffi_buffer_to_vec(unsafe {
+                    mmd_runtime_pmx_material_split_additional_uvs_buffer(
+                        split, mesh_index, uv_index,
+                    )
+                });
+                if !additional_uvs.is_empty() {
+                    assert_eq!(
+                        additional_uvs.len(),
+                        vertex_count * 4 * 4,
+                        "{mesh_context}: additional_uvs[{uv_index}] len"
+                    );
+                }
+            }
+
+            let original_vertex_indices = mesh_manifest
+                .get("originalVertexIndices")
+                .and_then(|v| v.as_array())
+                .unwrap_or_else(|| {
+                    panic!("{mesh_context}: originalVertexIndices must be an array")
+                });
+            assert_eq!(
+                original_vertex_indices.len(),
+                vertex_count,
+                "{mesh_context}: originalVertexIndices len"
+            );
+
+            let morph_index_map = mesh_manifest
+                .get("morphIndexMap")
+                .and_then(|v| v.as_array())
+                .unwrap_or_else(|| panic!("{mesh_context}: morphIndexMap must be an array"));
+            let mut seen_local_indices = vec![false; morph_index_map.len()];
+            for entry in morph_index_map {
+                let local_index = entry
+                    .get("localIndex")
+                    .and_then(|v| v.as_u64())
+                    .unwrap_or_else(|| panic!("{mesh_context}: localIndex missing"))
+                    as usize;
+                assert!(
+                    local_index < morph_index_map.len(),
+                    "{mesh_context}: localIndex {local_index} out of range"
+                );
+                assert!(
+                    !seen_local_indices[local_index],
+                    "{mesh_context}: duplicate localIndex {local_index}"
+                );
+                seen_local_indices[local_index] = true;
+            }
+            assert!(
+                seen_local_indices.iter().all(|seen| *seen),
+                "{mesh_context}: localIndex values must be contiguous from zero"
+            );
+        }
+    }
+
+    fn assert_material_split_rejects_null_and_out_of_range(
+        split: *mut MmdRuntimePmxMaterialSplit,
+        mesh_count: usize,
+    ) {
+        assert_eq!(
+            unsafe { mmd_runtime_pmx_material_split_mesh_count(ptr::null()) },
+            0
+        );
+        assert_empty_ffi_buffer(
+            unsafe { mmd_runtime_pmx_material_split_manifest_json(ptr::null()) },
+            "null material split manifest",
+        );
+
+        macro_rules! check_empty_getter {
+            ($fn:ident) => {{
+                assert_empty_ffi_buffer(
+                    unsafe { $fn(ptr::null(), 0) },
+                    concat!(stringify!($fn), " null"),
+                );
+                assert_empty_ffi_buffer(
+                    unsafe { $fn(split, mesh_count) },
+                    concat!(stringify!($fn), " out of range"),
+                );
+            }};
+        }
+
+        check_empty_getter!(mmd_runtime_pmx_material_split_positions_buffer);
+        check_empty_getter!(mmd_runtime_pmx_material_split_normals_buffer);
+        check_empty_getter!(mmd_runtime_pmx_material_split_uvs_buffer);
+        check_empty_getter!(mmd_runtime_pmx_material_split_indices_buffer);
+        check_empty_getter!(mmd_runtime_pmx_material_split_skin_indices_buffer);
+        check_empty_getter!(mmd_runtime_pmx_material_split_skin_weights_buffer);
+        check_empty_getter!(mmd_runtime_pmx_material_split_edge_scale_buffer);
+        check_empty_getter!(mmd_runtime_pmx_material_split_sdef_enabled_buffer);
+        check_empty_getter!(mmd_runtime_pmx_material_split_sdef_c_buffer);
+        check_empty_getter!(mmd_runtime_pmx_material_split_sdef_r0_buffer);
+        check_empty_getter!(mmd_runtime_pmx_material_split_sdef_r1_buffer);
+        check_empty_getter!(mmd_runtime_pmx_material_split_sdef_rw0_buffer);
+        check_empty_getter!(mmd_runtime_pmx_material_split_sdef_rw1_buffer);
+        check_empty_getter!(mmd_runtime_pmx_material_split_qdef_enabled_buffer);
+
+        assert_empty_ffi_buffer(
+            unsafe { mmd_runtime_pmx_material_split_additional_uvs_buffer(ptr::null(), 0, 0) },
+            "additional_uvs null",
+        );
+        assert_empty_ffi_buffer(
+            unsafe { mmd_runtime_pmx_material_split_additional_uvs_buffer(split, mesh_count, 0) },
+            "additional_uvs out of range",
+        );
+    }
+
+    fn material_split_manifest_json(
+        split: *mut MmdRuntimePmxMaterialSplit,
+        context: &str,
+    ) -> serde_json::Value {
+        let manifest_bytes =
+            ffi_buffer_to_vec(unsafe { mmd_runtime_pmx_material_split_manifest_json(split) });
+        assert!(
+            !manifest_bytes.is_empty(),
+            "{context}: manifest_json must not be empty"
+        );
+        serde_json::from_slice(&manifest_bytes)
+            .unwrap_or_else(|err| panic!("{context}: manifest_json parse failed: {err}"))
+    }
+
+    #[test]
+    fn pmx_material_split_buffers_have_consistent_dimensions() {
+        let bytes: &[u8] =
+            include_bytes!("../../mmd-anim-format/fixtures/pmx/ik_multi_axis_limit.pmx");
+        let split =
+            unsafe { mmd_runtime_pmx_material_split_create(bytes.as_ptr(), bytes.len(), 0) };
+        assert!(!split.is_null(), "material split handle must not be null");
+
+        let mesh_count = unsafe { mmd_runtime_pmx_material_split_mesh_count(split) };
+        let manifest = material_split_manifest_json(split, "fixture material split");
+        assert_material_split_geometry_invariants(split, &manifest, "fixture material split");
+        assert_material_split_rejects_null_and_out_of_range(split, mesh_count);
+
+        unsafe { mmd_runtime_pmx_material_split_free(split) };
+    }
+
     #[test]
     fn pmx_geometry_buffers_have_correct_dimensions() {
         let bytes: &[u8] =

--- a/crates/mmd-anim-format/src/lib.rs
+++ b/crates/mmd-anim-format/src/lib.rs
@@ -27,12 +27,15 @@ pub use pmm::{
     export_pmm_scene_from_pmx_vmd, parse_pmm_manifest,
 };
 pub use pmx::{
-    PmxBoneImport, PmxMorphNames, PmxParsedModel, PmxPartsBoneDescriptor, PmxPartsDescriptor,
-    PmxPartsDisplayFrameDescriptor, PmxPartsDisplayFrameItem, PmxPartsGroupMorphOffset,
-    PmxPartsIndexSizes, PmxPartsInput, PmxPartsJointDescriptor, PmxPartsMaterialDescriptor,
-    PmxPartsMaterialFlags, PmxPartsMorphDescriptor, PmxPartsRigidBodyDescriptor,
-    PmxPartsVertexMorphOffset, PmxRuntimeImport, build_pmx_model_from_parts, export_pmx_model,
-    import_pmx_model, import_pmx_runtime, parse_pmx_model, validate_pmx_export_model,
+    PmxBoneImport, PmxMaterialSplit, PmxMaterialSplitManifest, PmxMaterialSplitManifestMesh,
+    PmxMaterialSplitMesh, PmxMaterialSplitMorphIndexMap, PmxMaterialSplitResult, PmxMorphNames,
+    PmxParsedModel, PmxPartsBoneDescriptor, PmxPartsDescriptor, PmxPartsDisplayFrameDescriptor,
+    PmxPartsDisplayFrameItem, PmxPartsGroupMorphOffset, PmxPartsIndexSizes, PmxPartsInput,
+    PmxPartsJointDescriptor, PmxPartsMaterialDescriptor, PmxPartsMaterialFlags,
+    PmxPartsMorphDescriptor, PmxPartsRigidBodyDescriptor, PmxPartsVertexMorphOffset,
+    PmxRuntimeImport, build_pmx_model_from_parts, export_pmx_model, import_pmx_model,
+    import_pmx_runtime, parse_pmx_material_split, parse_pmx_model, split_pmx_model_by_material,
+    validate_pmx_export_model,
 };
 pub use vmd::{
     VmdCameraState, VmdClipBuildOptions, VmdIkEntry, VmdImportResult, VmdParsedAnimation,

--- a/crates/mmd-anim-format/src/pmx/mod.rs
+++ b/crates/mmd-anim-format/src/pmx/mod.rs
@@ -1096,6 +1096,56 @@ pub struct PmxParsedImpulseMorphOffset {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+pub struct PmxMaterialSplitResult {
+    pub meshes: Vec<PmxMaterialSplitMesh>,
+    pub manifest: PmxMaterialSplitManifest,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PmxMaterialSplitMesh {
+    pub original_material_index: usize,
+    pub original_vertex_indices: Vec<u32>,
+    pub geometry: PmxParsedGeometry,
+    pub material: PmxParsedMaterial,
+    pub morphs: Vec<PmxParsedMorph>,
+    pub morph_index_map: Vec<PmxMaterialSplitMorphIndexMap>,
+    pub diagnostics: Vec<PmxParserDiagnostic>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PmxMaterialSplit {
+    pub mesh: PmxMaterialSplitMesh,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PmxMaterialSplitManifest {
+    pub mesh_count: usize,
+    pub meshes: Vec<PmxMaterialSplitManifestMesh>,
+    pub diagnostics: Vec<PmxParserDiagnostic>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PmxMaterialSplitManifestMesh {
+    pub mesh_index: usize,
+    pub original_material_index: usize,
+    pub original_vertex_indices: Vec<u32>,
+    pub morph_index_map: Vec<PmxMaterialSplitMorphIndexMap>,
+    pub diagnostics: Vec<PmxParserDiagnostic>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct PmxMaterialSplitMorphIndexMap {
+    pub original_index: usize,
+    pub local_index: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct PmxParsedDisplayFrame {
     pub name: String,
     pub english_name: String,
@@ -3038,6 +3088,458 @@ fn normalize_nonnegative_index(index: i32) -> u32 {
     if index < 0 { 0 } else { index as u32 }
 }
 
+pub fn parse_pmx_material_split(
+    data: &[u8],
+    _flags: u32,
+) -> Result<PmxMaterialSplitResult, ImportError> {
+    let model = parse_pmx_model(data)?;
+    Ok(split_pmx_model_by_material(&model))
+}
+
+pub fn split_pmx_model_by_material(model: &PmxParsedModel) -> PmxMaterialSplitResult {
+    let mut meshes = Vec::with_capacity(model.geometry.material_groups.len());
+    let mut manifest_meshes = Vec::with_capacity(model.geometry.material_groups.len());
+    let mut diagnostics = Vec::new();
+
+    for (mesh_index, group) in model.geometry.material_groups.iter().enumerate() {
+        if group.material_index >= model.materials.len() {
+            let diagnostic = pmx_material_split_diagnostic(
+                "PMX_MATERIAL_SPLIT_MATERIAL_INDEX_OUT_OF_RANGE",
+                format!(
+                    "material group {mesh_index} references material {} but material count is {}",
+                    group.material_index,
+                    model.materials.len()
+                ),
+            );
+            diagnostics.push(diagnostic);
+            continue;
+        }
+
+        let mesh = split_pmx_material_group(model, group, mesh_index);
+        manifest_meshes.push(PmxMaterialSplitManifestMesh {
+            mesh_index,
+            original_material_index: mesh.original_material_index,
+            original_vertex_indices: mesh.original_vertex_indices.clone(),
+            morph_index_map: mesh.morph_index_map.clone(),
+            diagnostics: mesh.diagnostics.clone(),
+        });
+        diagnostics.extend(mesh.diagnostics.iter().cloned());
+        meshes.push(mesh);
+    }
+
+    PmxMaterialSplitResult {
+        manifest: PmxMaterialSplitManifest {
+            mesh_count: meshes.len(),
+            meshes: manifest_meshes,
+            diagnostics,
+        },
+        meshes,
+    }
+}
+
+fn split_pmx_material_group(
+    model: &PmxParsedModel,
+    group: &PmxParsedMaterialGroup,
+    mesh_index: usize,
+) -> PmxMaterialSplitMesh {
+    let mut diagnostics = Vec::new();
+    let index_end = group.start.saturating_add(group.count);
+    let index_slice = match model.geometry.indices.get(group.start..index_end) {
+        Some(slice) => slice,
+        None => {
+            diagnostics.push(pmx_material_split_diagnostic(
+                "PMX_MATERIAL_SPLIT_INDEX_RANGE_OUT_OF_RANGE",
+                format!(
+                    "material group {mesh_index} index range {}..{} exceeds index count {}",
+                    group.start,
+                    index_end,
+                    model.geometry.indices.len()
+                ),
+            ));
+            &[][..]
+        }
+    };
+
+    let vertex_count = model.geometry.positions.len() / 3;
+    let mut original_vertex_indices = Vec::new();
+    let mut vertex_remap = HashMap::<u32, u32>::new();
+    let mut local_indices = Vec::with_capacity(index_slice.len());
+    for &original_index in index_slice {
+        if original_index as usize >= vertex_count {
+            diagnostics.push(pmx_material_split_diagnostic(
+                "PMX_MATERIAL_SPLIT_VERTEX_INDEX_OUT_OF_RANGE",
+                format!(
+                    "material group {mesh_index} references vertex {original_index} but vertex count is {vertex_count}"
+                ),
+            ));
+            continue;
+        }
+        let local_index = match vertex_remap.get(&original_index) {
+            Some(&local_index) => local_index,
+            None => {
+                let local_index = original_vertex_indices.len() as u32;
+                vertex_remap.insert(original_index, local_index);
+                original_vertex_indices.push(original_index);
+                local_index
+            }
+        };
+        local_indices.push(local_index);
+    }
+
+    let local_index_count = local_indices.len();
+    let geometry = remap_pmx_geometry(
+        &model.geometry,
+        &original_vertex_indices,
+        local_indices,
+        local_index_count,
+    );
+    let material = {
+        let mut material = model.materials[group.material_index].clone();
+        material.face_count = (geometry.indices.len() / 3) as i32;
+        material
+    };
+    let (morphs, morph_index_map, morph_diagnostics) =
+        remap_pmx_material_split_morphs(model, &vertex_remap, group.material_index, mesh_index);
+    diagnostics.extend(morph_diagnostics);
+
+    PmxMaterialSplitMesh {
+        original_material_index: group.material_index,
+        original_vertex_indices,
+        geometry,
+        material,
+        morphs,
+        morph_index_map,
+        diagnostics,
+    }
+}
+
+fn remap_pmx_geometry(
+    geometry: &PmxParsedGeometry,
+    original_vertex_indices: &[u32],
+    indices: Vec<u32>,
+    local_index_count: usize,
+) -> PmxParsedGeometry {
+    PmxParsedGeometry {
+        positions: gather_vertex_f32(&geometry.positions, 3, original_vertex_indices),
+        normals: gather_vertex_f32(&geometry.normals, 3, original_vertex_indices),
+        uvs: gather_vertex_f32(&geometry.uvs, 2, original_vertex_indices),
+        additional_uvs: geometry
+            .additional_uvs
+            .iter()
+            .map(|uvs| gather_vertex_f32(uvs, 4, original_vertex_indices))
+            .collect(),
+        indices,
+        skin_indices: gather_vertex_u32(&geometry.skin_indices, 4, original_vertex_indices),
+        skin_weights: gather_vertex_f32(&geometry.skin_weights, 4, original_vertex_indices),
+        edge_scale: gather_vertex_f32(&geometry.edge_scale, 1, original_vertex_indices),
+        material_groups: vec![PmxParsedMaterialGroup {
+            start: 0,
+            count: local_index_count,
+            material_index: 0,
+        }],
+        sdef: PmxParsedSdef {
+            enabled: gather_vertex_f32(&geometry.sdef.enabled, 1, original_vertex_indices),
+            c: gather_vertex_f32(&geometry.sdef.c, 3, original_vertex_indices),
+            r0: gather_vertex_f32(&geometry.sdef.r0, 3, original_vertex_indices),
+            r1: gather_vertex_f32(&geometry.sdef.r1, 3, original_vertex_indices),
+            rw0: gather_vertex_f32(&geometry.sdef.rw0, 3, original_vertex_indices),
+            rw1: gather_vertex_f32(&geometry.sdef.rw1, 3, original_vertex_indices),
+        },
+        qdef: PmxParsedQdef {
+            enabled: gather_vertex_f32(&geometry.qdef.enabled, 1, original_vertex_indices),
+        },
+    }
+}
+
+fn gather_vertex_f32(values: &[f32], stride: usize, original_vertex_indices: &[u32]) -> Vec<f32> {
+    let mut out = Vec::with_capacity(original_vertex_indices.len() * stride);
+    for &index in original_vertex_indices {
+        let start = index as usize * stride;
+        let end = start + stride;
+        if let Some(slice) = values.get(start..end) {
+            out.extend_from_slice(slice);
+        }
+    }
+    out
+}
+
+fn gather_vertex_u32(values: &[u32], stride: usize, original_vertex_indices: &[u32]) -> Vec<u32> {
+    let mut out = Vec::with_capacity(original_vertex_indices.len() * stride);
+    for &index in original_vertex_indices {
+        let start = index as usize * stride;
+        let end = start + stride;
+        if let Some(slice) = values.get(start..end) {
+            out.extend_from_slice(slice);
+        }
+    }
+    out
+}
+
+fn remap_pmx_material_split_morphs(
+    model: &PmxParsedModel,
+    vertex_remap: &HashMap<u32, u32>,
+    original_material_index: usize,
+    mesh_index: usize,
+) -> (
+    Vec<PmxParsedMorph>,
+    Vec<PmxMaterialSplitMorphIndexMap>,
+    Vec<PmxParserDiagnostic>,
+) {
+    let mut diagnostics = Vec::new();
+    let mut direct_morphs = vec![None; model.morphs.len()];
+    let mut survives = vec![false; model.morphs.len()];
+    let mut morph_remap = HashMap::<usize, usize>::new();
+
+    for (original_index, morph) in model.morphs.iter().enumerate() {
+        match morph.kind.as_str() {
+            "vertex" | "uv" | "additionalUv" | "material" => {
+                let remapped = remap_direct_pmx_material_split_morph(
+                    morph,
+                    vertex_remap,
+                    original_material_index,
+                );
+                if pmx_material_split_morph_has_offsets(&remapped) {
+                    direct_morphs[original_index] = Some(remapped);
+                    survives[original_index] = true;
+                }
+            }
+            "bone" => {
+                if !morph.bone_offsets.is_empty() {
+                    diagnostics.push(pmx_material_split_diagnostic(
+                        "PMX_MATERIAL_SPLIT_BONE_MORPH_SHARED_SKELETON",
+                        format!(
+                            "mesh {mesh_index} excludes bone morph {original_index} because skeleton morphs are shared"
+                        ),
+                    ));
+                }
+            }
+            "impulse" => {
+                if !morph.impulse_offsets.is_empty() {
+                    diagnostics.push(pmx_material_split_diagnostic(
+                        "PMX_MATERIAL_SPLIT_IMPULSE_MORPH_UNSUPPORTED",
+                        format!(
+                            "mesh {mesh_index} excludes impulse morph {original_index} because physics morphs are not exposed in the initial material split ABI"
+                        ),
+                    ));
+                }
+            }
+            "group" | "flip" => {}
+            _ => {
+                diagnostics.push(pmx_material_split_diagnostic(
+                    "PMX_MATERIAL_SPLIT_MORPH_KIND_UNSUPPORTED",
+                    format!(
+                        "mesh {mesh_index} excludes morph {original_index} with unsupported kind {}",
+                        morph.kind
+                    ),
+                ));
+            }
+        }
+    }
+
+    let mut changed = true;
+    while changed {
+        changed = false;
+        for (original_index, morph) in model.morphs.iter().enumerate() {
+            if survives[original_index] || (morph.kind != "group" && morph.kind != "flip") {
+                continue;
+            }
+            if pmx_material_split_reference_offsets(morph)
+                .iter()
+                .any(|offset| {
+                    offset.morph_index >= 0
+                        && survives
+                            .get(offset.morph_index as usize)
+                            .copied()
+                            .unwrap_or(false)
+                })
+            {
+                survives[original_index] = true;
+                changed = true;
+            }
+        }
+    }
+
+    for (original_index, survives) in survives.iter().copied().enumerate() {
+        if survives {
+            let local_index = morph_remap.len();
+            morph_remap.insert(original_index, local_index);
+        }
+    }
+
+    let mut morphs = Vec::with_capacity(morph_remap.len());
+    for (original_index, morph) in model.morphs.iter().enumerate() {
+        if !morph_remap.contains_key(&original_index) {
+            continue;
+        }
+        let remapped = match direct_morphs[original_index].take() {
+            Some(remapped) => remapped,
+            None => remap_reference_pmx_material_split_morph(morph, &morph_remap),
+        };
+        morphs.push((original_index, remapped));
+    }
+
+    let morph_index_map = morphs
+        .iter()
+        .enumerate()
+        .map(
+            |(local_index, (original_index, _))| PmxMaterialSplitMorphIndexMap {
+                original_index: *original_index,
+                local_index,
+            },
+        )
+        .collect();
+    let morphs = morphs
+        .into_iter()
+        .map(|(_, morph)| morph)
+        .collect::<Vec<_>>();
+
+    (morphs, morph_index_map, diagnostics)
+}
+
+fn remap_direct_pmx_material_split_morph(
+    morph: &PmxParsedMorph,
+    vertex_remap: &HashMap<u32, u32>,
+    original_material_index: usize,
+) -> PmxParsedMorph {
+    let mut remapped = empty_pmx_material_split_morph_like(morph);
+    remapped.vertex_offsets = morph
+        .vertex_offsets
+        .iter()
+        .filter_map(|offset| {
+            vertex_remap
+                .get(&offset.vertex_index)
+                .map(|&vertex_index| PmxParsedVertexMorphOffset {
+                    vertex_index,
+                    position: offset.position,
+                })
+        })
+        .collect();
+    remapped.uv_offsets = morph
+        .uv_offsets
+        .iter()
+        .filter_map(|offset| {
+            vertex_remap
+                .get(&offset.vertex_index)
+                .map(|&vertex_index| PmxParsedUvMorphOffset {
+                    vertex_index,
+                    uv: offset.uv,
+                })
+        })
+        .collect();
+    remapped.additional_uv_offsets = morph
+        .additional_uv_offsets
+        .iter()
+        .filter_map(|offset| {
+            vertex_remap.get(&offset.vertex_index).map(|&vertex_index| {
+                PmxParsedAdditionalUvMorphOffset {
+                    vertex_index,
+                    uv_index: offset.uv_index,
+                    uv: offset.uv,
+                }
+            })
+        })
+        .collect();
+    remapped.material_offsets = morph
+        .material_offsets
+        .iter()
+        .filter_map(|offset| {
+            if offset.material_index == -1
+                || offset.material_index as usize == original_material_index
+            {
+                let mut remapped = offset.clone();
+                if remapped.material_index >= 0 {
+                    remapped.material_index = 0;
+                }
+                Some(remapped)
+            } else {
+                None
+            }
+        })
+        .collect();
+    remapped
+}
+
+fn remap_reference_pmx_material_split_morph(
+    morph: &PmxParsedMorph,
+    morph_remap: &HashMap<usize, usize>,
+) -> PmxParsedMorph {
+    let mut remapped = empty_pmx_material_split_morph_like(morph);
+    if morph.kind == "group" {
+        remapped.group_offsets =
+            remap_pmx_material_split_morph_refs(&morph.group_offsets, morph_remap);
+    } else {
+        remapped.flip_offsets =
+            remap_pmx_material_split_morph_refs(&morph.flip_offsets, morph_remap);
+    }
+    remapped
+}
+
+fn pmx_material_split_reference_offsets(morph: &PmxParsedMorph) -> &[PmxParsedGroupMorphOffset] {
+    if morph.kind == "group" {
+        &morph.group_offsets
+    } else {
+        &morph.flip_offsets
+    }
+}
+
+fn remap_pmx_material_split_morph_refs(
+    offsets: &[PmxParsedGroupMorphOffset],
+    morph_remap: &HashMap<usize, usize>,
+) -> Vec<PmxParsedGroupMorphOffset> {
+    offsets
+        .iter()
+        .filter_map(|offset| {
+            if offset.morph_index < 0 {
+                return None;
+            }
+            morph_remap
+                .get(&(offset.morph_index as usize))
+                .map(|&morph_index| PmxParsedGroupMorphOffset {
+                    morph_index: morph_index as i32,
+                    weight: offset.weight,
+                })
+        })
+        .collect()
+}
+
+fn empty_pmx_material_split_morph_like(morph: &PmxParsedMorph) -> PmxParsedMorph {
+    PmxParsedMorph {
+        name: morph.name.clone(),
+        english_name: morph.english_name.clone(),
+        kind: morph.kind.clone(),
+        vertex_offsets: Vec::new(),
+        group_offsets: Vec::new(),
+        bone_offsets: Vec::new(),
+        uv_offsets: Vec::new(),
+        additional_uv_offsets: Vec::new(),
+        material_offsets: Vec::new(),
+        flip_offsets: Vec::new(),
+        impulse_offsets: Vec::new(),
+    }
+}
+
+fn pmx_material_split_morph_has_offsets(morph: &PmxParsedMorph) -> bool {
+    !morph.vertex_offsets.is_empty()
+        || !morph.group_offsets.is_empty()
+        || !morph.bone_offsets.is_empty()
+        || !morph.uv_offsets.is_empty()
+        || !morph.additional_uv_offsets.is_empty()
+        || !morph.material_offsets.is_empty()
+        || !morph.flip_offsets.is_empty()
+        || !morph.impulse_offsets.is_empty()
+}
+
+fn pmx_material_split_diagnostic(
+    code: impl Into<String>,
+    message: impl Into<String>,
+) -> PmxParserDiagnostic {
+    PmxParserDiagnostic {
+        level: "info".to_owned(),
+        code: code.into(),
+        message: message.into(),
+    }
+}
+
 fn read_parsed_textures(
     r: &mut Reader<'_>,
     encoding: TextEncoding,
@@ -4132,6 +4634,184 @@ mod tests {
         }
     }
 
+    fn material_morph_offset(material_index: i32) -> PmxParsedMaterialMorphOffset {
+        PmxParsedMaterialMorphOffset {
+            material_index,
+            operation: "add".to_owned(),
+            diffuse: [0.1, 0.2, 0.3, 0.4],
+            specular: [0.5, 0.6, 0.7],
+            specular_power: 0.8,
+            ambient: [0.9, 1.0, 1.1],
+            edge_color: [0.0, 0.1, 0.2, 0.3],
+            edge_size: 0.4,
+            texture_factor: [1.0, 0.0, 0.0, 1.0],
+            sphere_texture_factor: [0.0, 1.0, 0.0, 1.0],
+            toon_texture_factor: [0.0, 0.0, 1.0, 1.0],
+        }
+    }
+
+    fn material_split_fixture() -> PmxParsedModel {
+        let mut model = parsed_pmx_fixture();
+        model.metadata.counts.vertices = 4;
+        model.metadata.counts.faces = 2;
+        model.metadata.counts.materials = 2;
+        model.metadata.counts.morphs = 5;
+        model.metadata.additional_uv_count = 1;
+        model.geometry = PmxParsedGeometry {
+            positions: vec![
+                0.0, 0.0, 0.0, //
+                1.0, 0.0, 0.0, //
+                0.0, 1.0, 0.0, //
+                1.0, 1.0, 0.0,
+            ],
+            normals: vec![
+                0.0, 0.0, 1.0, //
+                0.0, 0.0, 1.0, //
+                0.0, 0.0, 1.0, //
+                0.0, 0.0, 1.0,
+            ],
+            uvs: vec![0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 1.0, 1.0],
+            additional_uvs: vec![vec![
+                0.0, 0.0, 0.0, 0.0, //
+                1.0, 0.0, 0.0, 0.0, //
+                0.0, 1.0, 0.0, 0.0, //
+                1.0, 1.0, 0.0, 0.0,
+            ]],
+            indices: vec![0, 1, 2, 2, 3, 0],
+            skin_indices: vec![
+                0, 0, 0, 0, //
+                0, 0, 0, 0, //
+                0, 0, 0, 0, //
+                0, 0, 0, 0,
+            ],
+            skin_weights: vec![
+                1.0, 0.0, 0.0, 0.0, //
+                1.0, 0.0, 0.0, 0.0, //
+                1.0, 0.0, 0.0, 0.0, //
+                1.0, 0.0, 0.0, 0.0,
+            ],
+            edge_scale: vec![1.0, 1.1, 1.2, 1.3],
+            material_groups: vec![
+                PmxParsedMaterialGroup {
+                    start: 0,
+                    count: 3,
+                    material_index: 0,
+                },
+                PmxParsedMaterialGroup {
+                    start: 3,
+                    count: 3,
+                    material_index: 1,
+                },
+            ],
+            sdef: PmxParsedSdef {
+                enabled: vec![0.0, 1.0, 0.0, 0.0],
+                c: vec![0.0; 12],
+                r0: vec![0.0; 12],
+                r1: vec![0.0; 12],
+                rw0: vec![0.0; 12],
+                rw1: vec![0.0; 12],
+            },
+            qdef: PmxParsedQdef {
+                enabled: vec![0.0, 0.0, 0.0, 1.0],
+            },
+        };
+        let mut material_b = model.materials[0].clone();
+        material_b.name = "mat-b".to_owned();
+        material_b.english_name = "mat-b-en".to_owned();
+        model.materials = vec![model.materials[0].clone(), material_b];
+        model.morphs = vec![
+            PmxParsedMorph {
+                name: "left-raise".to_owned(),
+                english_name: "left-raise-en".to_owned(),
+                kind: "vertex".to_owned(),
+                vertex_offsets: vec![PmxParsedVertexMorphOffset {
+                    vertex_index: 1,
+                    position: [0.0, 0.5, 0.0],
+                }],
+                group_offsets: Vec::new(),
+                bone_offsets: Vec::new(),
+                uv_offsets: Vec::new(),
+                additional_uv_offsets: Vec::new(),
+                material_offsets: Vec::new(),
+                flip_offsets: Vec::new(),
+                impulse_offsets: Vec::new(),
+            },
+            PmxParsedMorph {
+                name: "right-raise".to_owned(),
+                english_name: "right-raise-en".to_owned(),
+                kind: "vertex".to_owned(),
+                vertex_offsets: vec![PmxParsedVertexMorphOffset {
+                    vertex_index: 3,
+                    position: [0.0, 0.75, 0.0],
+                }],
+                group_offsets: Vec::new(),
+                bone_offsets: Vec::new(),
+                uv_offsets: Vec::new(),
+                additional_uv_offsets: Vec::new(),
+                material_offsets: Vec::new(),
+                flip_offsets: Vec::new(),
+                impulse_offsets: Vec::new(),
+            },
+            PmxParsedMorph {
+                name: "right-material".to_owned(),
+                english_name: "right-material-en".to_owned(),
+                kind: "material".to_owned(),
+                vertex_offsets: Vec::new(),
+                group_offsets: Vec::new(),
+                bone_offsets: Vec::new(),
+                uv_offsets: Vec::new(),
+                additional_uv_offsets: Vec::new(),
+                material_offsets: vec![material_morph_offset(1)],
+                flip_offsets: Vec::new(),
+                impulse_offsets: Vec::new(),
+            },
+            PmxParsedMorph {
+                name: "all-material".to_owned(),
+                english_name: "all-material-en".to_owned(),
+                kind: "material".to_owned(),
+                vertex_offsets: Vec::new(),
+                group_offsets: Vec::new(),
+                bone_offsets: Vec::new(),
+                uv_offsets: Vec::new(),
+                additional_uv_offsets: Vec::new(),
+                material_offsets: vec![material_morph_offset(-1)],
+                flip_offsets: Vec::new(),
+                impulse_offsets: Vec::new(),
+            },
+            PmxParsedMorph {
+                name: "combo".to_owned(),
+                english_name: "combo-en".to_owned(),
+                kind: "group".to_owned(),
+                vertex_offsets: Vec::new(),
+                group_offsets: vec![
+                    PmxParsedGroupMorphOffset {
+                        morph_index: 0,
+                        weight: 0.25,
+                    },
+                    PmxParsedGroupMorphOffset {
+                        morph_index: 1,
+                        weight: 0.5,
+                    },
+                    PmxParsedGroupMorphOffset {
+                        morph_index: 2,
+                        weight: 0.75,
+                    },
+                    PmxParsedGroupMorphOffset {
+                        morph_index: 3,
+                        weight: 1.0,
+                    },
+                ],
+                bone_offsets: Vec::new(),
+                uv_offsets: Vec::new(),
+                additional_uv_offsets: Vec::new(),
+                material_offsets: Vec::new(),
+                flip_offsets: Vec::new(),
+                impulse_offsets: Vec::new(),
+            },
+        ];
+        model
+    }
+
     fn ik_multi_axis_limit_pmx_fixture() -> &'static [u8] {
         include_bytes!("../../fixtures/pmx/ik_multi_axis_limit.pmx")
     }
@@ -4152,6 +4832,199 @@ mod tests {
             .collect::<Vec<_>>();
         keys.sort();
         keys
+    }
+
+    #[test]
+    fn pmx_material_split_remaps_geometry_and_prunes_morphs() {
+        let model = material_split_fixture();
+        let split = split_pmx_model_by_material(&model);
+
+        assert_eq!(split.meshes.len(), 2);
+        assert_eq!(split.manifest.mesh_count, 2);
+        assert_eq!(split.manifest.meshes[0].original_material_index, 0);
+        assert_eq!(
+            split.manifest.meshes[0].original_vertex_indices,
+            vec![0, 1, 2]
+        );
+        assert_eq!(split.manifest.meshes[1].original_material_index, 1);
+        assert_eq!(
+            split.manifest.meshes[1].original_vertex_indices,
+            vec![2, 3, 0]
+        );
+
+        let left = &split.meshes[0];
+        assert_eq!(left.geometry.indices, vec![0, 1, 2]);
+        assert_eq!(
+            left.geometry.positions,
+            vec![0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0]
+        );
+        assert_eq!(left.geometry.uvs, vec![0.0, 0.0, 1.0, 0.0, 0.0, 1.0]);
+        assert_eq!(left.geometry.edge_scale, vec![1.0, 1.1, 1.2]);
+        assert_eq!(left.geometry.sdef.enabled, vec![0.0, 1.0, 0.0]);
+        assert_eq!(left.geometry.qdef.enabled, vec![0.0, 0.0, 0.0]);
+        assert_eq!(
+            left.morph_index_map,
+            vec![
+                PmxMaterialSplitMorphIndexMap {
+                    original_index: 0,
+                    local_index: 0,
+                },
+                PmxMaterialSplitMorphIndexMap {
+                    original_index: 3,
+                    local_index: 1,
+                },
+                PmxMaterialSplitMorphIndexMap {
+                    original_index: 4,
+                    local_index: 2,
+                },
+            ]
+        );
+        assert_eq!(left.morphs.len(), 3);
+        assert_eq!(left.morphs[0].name, "left-raise");
+        assert_eq!(left.morphs[0].vertex_offsets[0].vertex_index, 1);
+        assert_eq!(left.morphs[1].name, "all-material");
+        assert_eq!(left.morphs[1].material_offsets[0].material_index, -1);
+        assert_eq!(left.morphs[2].name, "combo");
+        assert_eq!(
+            left.morphs[2]
+                .group_offsets
+                .iter()
+                .map(|offset| (offset.morph_index, offset.weight))
+                .collect::<Vec<_>>(),
+            vec![(0, 0.25), (1, 1.0)]
+        );
+
+        let right = &split.meshes[1];
+        assert_eq!(right.geometry.indices, vec![0, 1, 2]);
+        assert_eq!(
+            right.geometry.positions,
+            vec![0.0, 1.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0]
+        );
+        assert_eq!(right.geometry.uvs, vec![0.0, 1.0, 1.0, 1.0, 0.0, 0.0]);
+        assert_eq!(right.geometry.edge_scale, vec![1.2, 1.3, 1.0]);
+        assert_eq!(right.geometry.sdef.enabled, vec![0.0, 0.0, 0.0]);
+        assert_eq!(right.geometry.qdef.enabled, vec![0.0, 1.0, 0.0]);
+        assert_eq!(
+            right.morph_index_map,
+            vec![
+                PmxMaterialSplitMorphIndexMap {
+                    original_index: 1,
+                    local_index: 0,
+                },
+                PmxMaterialSplitMorphIndexMap {
+                    original_index: 2,
+                    local_index: 1,
+                },
+                PmxMaterialSplitMorphIndexMap {
+                    original_index: 3,
+                    local_index: 2,
+                },
+                PmxMaterialSplitMorphIndexMap {
+                    original_index: 4,
+                    local_index: 3,
+                },
+            ]
+        );
+        assert_eq!(right.morphs.len(), 4);
+        assert_eq!(right.morphs[0].name, "right-raise");
+        assert_eq!(right.morphs[0].vertex_offsets[0].vertex_index, 1);
+        assert_eq!(right.morphs[1].name, "right-material");
+        assert_eq!(right.morphs[1].material_offsets[0].material_index, 0);
+        assert_eq!(right.morphs[2].name, "all-material");
+        assert_eq!(right.morphs[2].material_offsets[0].material_index, -1);
+        assert_eq!(
+            right.morphs[3]
+                .group_offsets
+                .iter()
+                .map(|offset| (offset.morph_index, offset.weight))
+                .collect::<Vec<_>>(),
+            vec![(0, 0.5), (1, 0.75), (2, 1.0)]
+        );
+    }
+
+    #[test]
+    fn pmx_material_split_preserves_forward_group_morph_references() {
+        let mut model = material_split_fixture();
+        model.morphs.push(PmxParsedMorph {
+            name: "forward-combo".to_owned(),
+            english_name: "forward-combo-en".to_owned(),
+            kind: "group".to_owned(),
+            vertex_offsets: Vec::new(),
+            group_offsets: vec![PmxParsedGroupMorphOffset {
+                morph_index: 6,
+                weight: 0.8,
+            }],
+            bone_offsets: Vec::new(),
+            uv_offsets: Vec::new(),
+            additional_uv_offsets: Vec::new(),
+            material_offsets: Vec::new(),
+            flip_offsets: Vec::new(),
+            impulse_offsets: Vec::new(),
+        });
+        model.morphs.push(PmxParsedMorph {
+            name: "later-combo".to_owned(),
+            english_name: "later-combo-en".to_owned(),
+            kind: "group".to_owned(),
+            vertex_offsets: Vec::new(),
+            group_offsets: vec![PmxParsedGroupMorphOffset {
+                morph_index: 0,
+                weight: 0.4,
+            }],
+            bone_offsets: Vec::new(),
+            uv_offsets: Vec::new(),
+            additional_uv_offsets: Vec::new(),
+            material_offsets: Vec::new(),
+            flip_offsets: Vec::new(),
+            impulse_offsets: Vec::new(),
+        });
+        model.metadata.counts.morphs = model.morphs.len();
+
+        let split = split_pmx_model_by_material(&model);
+        let left = &split.meshes[0];
+
+        assert_eq!(
+            left.morph_index_map,
+            vec![
+                PmxMaterialSplitMorphIndexMap {
+                    original_index: 0,
+                    local_index: 0,
+                },
+                PmxMaterialSplitMorphIndexMap {
+                    original_index: 3,
+                    local_index: 1,
+                },
+                PmxMaterialSplitMorphIndexMap {
+                    original_index: 4,
+                    local_index: 2,
+                },
+                PmxMaterialSplitMorphIndexMap {
+                    original_index: 5,
+                    local_index: 3,
+                },
+                PmxMaterialSplitMorphIndexMap {
+                    original_index: 6,
+                    local_index: 4,
+                },
+            ]
+        );
+        assert_eq!(left.morphs[3].name, "forward-combo");
+        assert_eq!(
+            left.morphs[3]
+                .group_offsets
+                .iter()
+                .map(|offset| (offset.morph_index, offset.weight))
+                .collect::<Vec<_>>(),
+            vec![(4, 0.8)]
+        );
+        assert_eq!(left.morphs[4].name, "later-combo");
+        assert_eq!(
+            left.morphs[4]
+                .group_offsets
+                .iter()
+                .map(|offset| (offset.morph_index, offset.weight))
+                .collect::<Vec<_>>(),
+            vec![(0, 0.4)]
+        );
     }
 
     #[test]

--- a/crates/mmd-anim-wasm/Cargo.toml
+++ b/crates/mmd-anim-wasm/Cargo.toml
@@ -17,7 +17,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 glam.workspace = true
 mmd-anim-runtime.workspace = true
-mmd-anim-format = { path = "../mmd-anim-format", version = "0.1.4" }
+mmd-anim-format = { path = "../mmd-anim-format", version = "0.1.5" }
 wasm-bindgen.workspace = true
 js-sys.workspace = true
 serde_json.workspace = true

--- a/crates/mmd-anim-wasm/harness/smoke.mjs
+++ b/crates/mmd-anim-wasm/harness/smoke.mjs
@@ -38,6 +38,20 @@ function assertClose(actual, expected, tol, msg) {
   assert(Math.abs(actual - expected) < tol, `${msg} (got ${actual}, expected ${expected})`);
 }
 
+function buildMinimalVmdBytes() {
+  const magicText = 'Vocaloid Motion Data 0002';
+  const bytes = [];
+  for (let i = 0; i < magicText.length; i++) bytes.push(magicText.charCodeAt(i));
+  while (bytes.length < 30) bytes.push(0);
+  const modelName = 'smoke';
+  for (let i = 0; i < modelName.length; i++) bytes.push(modelName.charCodeAt(i));
+  while (bytes.length < 50) bytes.push(0);
+  for (let section = 0; section < 6; section++) {
+    bytes.push(0, 0, 0, 0);
+  }
+  return new Uint8Array(bytes);
+}
+
 console.log('=== Wasm Smoke Test ===\n');
 
 console.log('1. wasm_wrapper_version');
@@ -141,6 +155,14 @@ assert(runtime2.ikEnabledLen() === 0, 'ikEnabledLen === 0');
 const ikView = runtime2.ikEnabledView();
 assert(ikView instanceof Uint8Array, 'ikEnabledView returns Uint8Array');
 assert(ikView.length === 0, 'ikEnabledView.length === 0');
+
+console.log('\n11. parseVmdAnimationJson dedicated parser API');
+const minimalVmd = buildMinimalVmdBytes();
+const vmdJson = JSON.parse(wasm.parseVmdAnimationJson(minimalVmd));
+assert(vmdJson.kind === 'vmd', 'parseVmdAnimationJson returns VMD DTO kind');
+assert(vmdJson.metadata.format === 'vmd', 'parseVmdAnimationJson metadata.format === vmd');
+assert(vmdJson.boneFrames.length === 0, 'parseVmdAnimationJson bone frame count === 0');
+assert(vmdJson.metadata.counts.bones === 0, 'parseVmdAnimationJson metadata.counts.bones === 0');
 
 console.log(`\n=== Results: ${passed} passed, ${failed} failed ===`);
 if (failed > 0) process.exit(1);

--- a/crates/mmd-anim-wasm/src/lib.rs
+++ b/crates/mmd-anim-wasm/src/lib.rs
@@ -83,6 +83,16 @@ pub fn parse_pmx_model_non_geometry_json(data: &[u8]) -> Result<String, JsValue>
         .map_err(|error| js_parser_error("PMX", "parsePmxModelNonGeometryJson", None, error))
 }
 
+#[wasm_bindgen(js_name = parseVmdAnimationJson)]
+pub fn parse_vmd_animation_json(data: &[u8]) -> Result<String, JsValue> {
+    if data.is_empty() {
+        return Err(JsValue::from_str("VMD data is empty"));
+    }
+    let parsed = mmd_anim_format::parse_vmd_animation(data)
+        .map_err(|error| js_parser_error("VMD", "parseVmdAnimationJson", None, error))?;
+    serde_json::to_string(&parsed).map_err(js_error)
+}
+
 #[wasm_bindgen(js_name = parseMmdFormatJson)]
 pub fn parse_mmd_format_json(data: &[u8], file_name: Option<String>) -> Result<String, JsValue> {
     if data.is_empty() {
@@ -273,6 +283,7 @@ pub struct WasmPmxGeometry {
     sdef_rw0: Vec<f32>,
     sdef_rw1: Vec<f32>,
     qdef_enabled: Vec<u8>,
+    skinning_modes: Vec<String>,
 }
 
 impl WasmPmxGeometry {
@@ -305,6 +316,7 @@ impl WasmPmxGeometry {
             sdef_rw0: g.sdef.rw0.clone(),
             sdef_rw1: g.sdef.rw1.clone(),
             qdef_enabled: g.qdef.enabled.iter().map(|&v| u8::from(v != 0.0)).collect(),
+            skinning_modes: pmx_skinning_modes(g),
         }
     }
 
@@ -441,6 +453,40 @@ impl WasmPmxGeometry {
     pub fn qdef_enabled(&self) -> Vec<u8> {
         self.qdef_enabled.clone()
     }
+
+    /// Copy of derived per-vertex skinning mode names.
+    ///
+    /// Values match the C ABI `mmd_runtime_parse_pmx_skinning_modes_json`
+    /// payload: `bdef1`, `bdef2`, `bdef4`, `sdef`, or `qdef`.
+    #[wasm_bindgen(js_name = skinningModes)]
+    pub fn skinning_modes(&self) -> Vec<String> {
+        self.skinning_modes.clone()
+    }
+}
+
+fn pmx_skinning_modes(g: &mmd_anim_format::pmx::PmxParsedGeometry) -> Vec<String> {
+    let vertex_count = g.positions.len() / 3;
+    (0..vertex_count)
+        .map(|i| {
+            if g.sdef.enabled.get(i).copied().unwrap_or(0.0) > 0.5 {
+                "sdef"
+            } else if g.qdef.enabled.get(i).copied().unwrap_or(0.0) > 0.5 {
+                "qdef"
+            } else {
+                let w2 = g.skin_weights.get(i * 4 + 2).copied().unwrap_or(0.0);
+                let w3 = g.skin_weights.get(i * 4 + 3).copied().unwrap_or(0.0);
+                let w1 = g.skin_weights.get(i * 4 + 1).copied().unwrap_or(0.0);
+                if w2 != 0.0 || w3 != 0.0 {
+                    "bdef4"
+                } else if w1 != 0.0 {
+                    "bdef2"
+                } else {
+                    "bdef1"
+                }
+            }
+            .to_owned()
+        })
+        .collect()
 }
 
 /// Parsed PMX handle for the split loader ABI.
@@ -1622,6 +1668,17 @@ mod tests {
     }
 
     #[test]
+    fn parses_vmd_animation_json_through_wasm_wrapper() {
+        let bytes: &[u8] = include_bytes!("../../mmd-anim-format/fixtures/vmd/simple_camera.vmd");
+        let json = parse_vmd_animation_json(bytes).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(value["kind"], "vmd");
+        assert_eq!(value["metadata"]["format"], "vmd");
+        assert!(value["cameraFrames"].as_array().unwrap().len() >= 2);
+    }
+
+    #[test]
     fn exports_pmx_json_bytes_through_wasm_wrapper() {
         let json = serde_json::json!({
             "metadata": {
@@ -2466,6 +2523,7 @@ TextureFilename { "tex/main.png"; }
         assert_eq!(geo.sdef_rw0().len(), 9);
         assert_eq!(geo.sdef_rw1().len(), 9);
         assert_eq!(geo.qdef_enabled(), vec![0u8, 0, 0]);
+        assert_eq!(geo.skinning_modes(), vec!["bdef1", "bdef1", "bdef1"]);
     }
 
     #[test]

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -48,6 +48,10 @@ crate.
   behavior, API examples, limitations, and publish scope. When one README is
   changed, translate the same user-visible change into the other before
   release.
+- If parser APIs changed in `mmd-anim-format`, `mmd-anim-ffi`, or
+  `mmd-anim-wasm`, confirm `docs/PARSER_API.md` Parser API Matrix was updated
+  with the C ABI/WASM mapping, output shape, error behavior, and lifetime/free
+  policy.
 - Confirm the working tree is clean.
 - Confirm `origin` points to `git@github.com:yohawing/mmd-anim.git`.
 - Confirm `develop` is up to date with `origin/develop` before preparing the

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -49,9 +49,10 @@ crate.
   changed, translate the same user-visible change into the other before
   release.
 - If parser APIs changed in `mmd-anim-format`, `mmd-anim-ffi`, or
-  `mmd-anim-wasm`, confirm `docs/PARSER_API.md` Parser API Matrix was updated
-  with the C ABI/WASM mapping, output shape, error behavior, and lifetime/free
-  policy.
+  `mmd-anim-wasm`, confirm the C ABI and WASM parser surfaces stay in sync:
+  matching semantic names, inputs, output shape, error behavior, and
+  lifetime/free policy, with intentional one-sided APIs noted in the commit or
+  PR.
 - Confirm the working tree is clean.
 - Confirm `origin` points to `git@github.com:yohawing/mmd-anim.git`.
 - Confirm `develop` is up to date with `origin/develop` before preparing the


### PR DESCRIPTION
## Release v0.1.5

Patch release for PMX material split host import and parser API parity.

### Added
- `split_pmx_model_by_material` / `PmxMaterialSplit` DTOs in `mmd-anim-format` for Maya-style per-material mesh import (vertex remap + morph prune/remap).
- Opaque PMX material split C ABI handle in `mmd-anim-ffi` (`create`/`free`/`mesh_count`/`manifest_json` + mesh-indexed geometry getters).
- One-shot PMX geometry C ABI getters for parity with `WasmPmxGeometry` (edge scale, additional UVs, material groups, SDEF rw0/rw1, qdef_enabled).
- `parseVmdAnimationJson` and `WasmPmxGeometry.skinningModes` in `mmd-anim-wasm`.

### Release prep
- Bump workspace + published crates (`mmd-anim-runtime`, `mmd-anim-format`, `mmd-anim`) to `0.1.5`.
- CHANGELOG entry for 0.1.5.
- Decouple the release-time parser-surface gate in `docs/RELEASE.md` from a specific doc file; it now tracks C ABI / WASM parser parity directly.

### Verification
- `cargo fmt --check`, `cargo clippy --workspace --all-targets -D warnings`, `cargo test --workspace` (471 passed), `cargo doc --workspace --no-deps`.
- `cargo check -p mmd-anim-wasm --target wasm32-unknown-unknown`, `cargo build -p mmd-anim-ffi --release`.
- Package list audit clean for the 3 published crates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)