### PR TITLE
feat: add rig primitive API (IK/append C ABI, PMX rig spec)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ target/package/
 .codex/
 .claude/
 .agents/
+.ai/
 AGENTS.md
 CLAUDE.md
 
@@ -35,5 +36,4 @@ crates/mmd-anim-wasm/harness/pkg-web/
 
 # local dev artifacts
 artifacts/
-dist/
-examples/viewer/
+viewer/

--- a/crates/mmd-anim-ffi/include/mmd_runtime.h
+++ b/crates/mmd-anim-ffi/include/mmd_runtime.h
@@ -23,6 +23,9 @@ typedef struct mmd_runtime_model_t    mmd_runtime_model_t;
 typedef struct mmd_runtime_instance_t mmd_runtime_instance_t;
 typedef struct mmd_runtime_clip_t     mmd_runtime_clip_t;
 typedef struct mmd_runtime_pmx_material_split_t mmd_runtime_pmx_material_split_t;
+typedef struct mmd_runtime_pmx_rig_spec_t mmd_runtime_pmx_rig_spec_t;
+typedef struct mmd_runtime_ik_chain_t mmd_runtime_ik_chain_t;
+typedef struct mmd_runtime_append_solver_t mmd_runtime_append_solver_t;
 
 /* ------------------------------------------------------------------ */
 /*  Flag constants                                                    */
@@ -35,6 +38,9 @@ typedef struct mmd_runtime_pmx_material_split_t mmd_runtime_pmx_material_split_t
 
 /* IK link flags           (bitmask) */
 #define MMD_RUNTIME_IK_LINK_ANGLE_LIMIT (1u << 0)
+
+/* Rig primitive bone flags (bitmask) */
+#define MMD_RUNTIME_RIG_BONE_FIXED_AXIS (1u << 0)
 
 /* ------------------------------------------------------------------ */
 /*  Descriptor structs                                                */
@@ -91,6 +97,33 @@ typedef struct mmd_runtime_ffi_ik_link {
     float    angle_limit_min_xyz[3];
     float    angle_limit_max_xyz[3];
 } mmd_runtime_ffi_ik_link_t;
+
+typedef struct mmd_runtime_ffi_rig_ik_link {
+    uint32_t bone_slot;
+    bool     has_angle_limit;
+    float    angle_limit_min_xyz[3];
+    float    angle_limit_max_xyz[3];
+} mmd_runtime_ffi_rig_ik_link_t;
+
+typedef struct mmd_runtime_ffi_rig_bone {
+    int32_t  parent_slot;
+    float    rest_position_xyz[3];
+    uint32_t flags;
+    float    fixed_axis_xyz[3];
+} mmd_runtime_ffi_rig_bone_t;
+
+typedef struct mmd_runtime_ffi_ik_solve_stats {
+    uint32_t executed_iterations;
+    uint32_t link_steps;
+    float    final_distance;
+    uint32_t break_reason; /* 0=tolerance, 1=max_iterations, 2=rollback */
+} mmd_runtime_ffi_ik_solve_stats_t;
+
+typedef struct mmd_runtime_ffi_append_config {
+    float ratio;
+    bool  affect_rotation;
+    bool  affect_translation;
+} mmd_runtime_ffi_append_config_t;
 
 typedef struct mmd_runtime_ffi_bone_morph_offset {
     uint32_t morph_index;
@@ -206,6 +239,76 @@ mmd_runtime_ffi_byte_buffer_t mmd_runtime_parse_pmx_skinning_modes_json(
     const uint8_t* data,
     size_t         len);
 
+/* Rig primitive API.
+   Coordinates use the MMD convention: left-handed, Y-up, xyz vectors.
+   Quaternions are xyzw. Matrices are column-major f32[16].
+   Create functions return NULL on invalid input. Solve functions return false
+   on invalid input, NULL required pointers, non-finite values, or short output
+   buffers. Free functions accept NULL and otherwise release the owned opaque
+   handle created by the matching create function. */
+
+/* Creates an owned IK-chain primitive.
+   bones is a bone_count-sized rig-bone array; parent_slot < 0 means no parent.
+   target_bone_slot selects the effector bone in bones. links is a link_count-
+   sized array ordered the same way PMX IK links are solved. iteration_count
+   and limit_angle are the per-chain solve settings. bones and links are
+   borrowed only for the call. Returns NULL if required arrays are NULL,
+   indices are out of range, values are non-finite, or counts are invalid. */
+mmd_runtime_ik_chain_t* mmd_runtime_ik_chain_create(
+    const mmd_runtime_ffi_rig_bone_t*    bones,
+    size_t                               bone_count,
+    uint32_t                             target_bone_slot,
+    const mmd_runtime_ffi_rig_ik_link_t* links,
+    size_t                               link_count,
+    uint32_t                             iteration_count,
+    float                                limit_angle);
+
+void mmd_runtime_ik_chain_free(
+    mmd_runtime_ik_chain_t* chain);
+
+/* Solves an IK-chain primitive.
+   chain must be a live handle. parent_world_matrix may be NULL, which means
+   identity; when provided it points to one column-major f32[16] matrix.
+   local_position_offsets_xyz and local_rotations_xyzw are required arrays with
+   bone_count * 3 and bone_count * 4 f32 values. goal_position_xyz is a required
+   xyz vector in MMD coordinates. max_iterations_cap == 0 means no cap.
+   out_link_rotations_xyzw receives link_count xyzw quaternions and
+   out_link_rotation_f32_len must be at least link_count * 4. out_stats may be
+   NULL; when provided it receives solve diagnostics. Input and output arrays
+   are caller-owned and are not retained after the call. */
+bool mmd_runtime_ik_chain_solve(
+    mmd_runtime_ik_chain_t*              chain,
+    const float*                         parent_world_matrix,
+    const float*                         local_position_offsets_xyz,
+    const float*                         local_rotations_xyzw,
+    const float*                         goal_position_xyz,
+    float                                tolerance,
+    uint32_t                             max_iterations_cap,
+    float*                               out_link_rotations_xyzw,
+    size_t                               out_link_rotation_f32_len,
+    mmd_runtime_ffi_ik_solve_stats_t*    out_stats);
+
+/* Creates an owned append-transform primitive.
+   config is borrowed for the call and must not be NULL. ratio and channel flags
+   are copied into the handle. Returns NULL on invalid or non-finite input. */
+mmd_runtime_append_solver_t* mmd_runtime_append_solver_create(
+    const mmd_runtime_ffi_append_config_t* config);
+
+void mmd_runtime_append_solver_free(
+    mmd_runtime_append_solver_t* solver);
+
+/* Solves an append-transform primitive.
+   solver must be a live handle. source_position_offset_xyz and
+   source_rotation_xyzw are required caller-owned inputs. out_position_offset_xyz
+   and out_rotation_xyzw are required caller-owned outputs. The output rotation
+   is an xyzw quaternion. Returns false on NULL pointers or non-finite input. */
+bool mmd_runtime_append_solver_solve(
+    const mmd_runtime_append_solver_t* solver,
+    const float*                      source_position_offset_xyz,
+    const float*                      source_rotation_xyzw,
+    float*                            out_position_offset_xyz,
+    float*                            out_rotation_xyzw);
+
 /* PMX material split handle API.
    mmd_runtime_pmx_material_split_create parses PMX bytes once and returns an
    owned opaque handle. Free it with mmd_runtime_pmx_material_split_free.
@@ -288,6 +391,34 @@ mmd_runtime_ffi_byte_buffer_t mmd_runtime_pmx_material_split_sdef_rw1_buffer(
 mmd_runtime_ffi_byte_buffer_t mmd_runtime_pmx_material_split_qdef_enabled_buffer(
     const mmd_runtime_pmx_material_split_t* split,
     size_t                                  mesh_index);
+
+/* PMX rig-spec handle API.
+   PMX rig data is reported in MMD coordinates: left-handed, Y-up, xyz vectors.
+   Quaternions in any rig payload are xyzw. Matrices in any rig payload are
+   column-major f32[16].
+   mmd_runtime_pmx_rig_spec_create parses PMX bytes once and returns an owned
+   opaque handle. Free it with mmd_runtime_pmx_rig_spec_free. The manifest JSON
+   byte buffer is owned by Rust and must be freed with
+   mmd_runtime_byte_buffer_free. Invalid input or invalid handles return null
+   handles or empty buffers. */
+
+/* Creates an owned PMX rig-spec handle from data[0..len].
+   data is borrowed only for the call and must not be NULL when len > 0.
+   Returns NULL when the bytes are invalid, empty, or unsupported. */
+mmd_runtime_pmx_rig_spec_t* mmd_runtime_pmx_rig_spec_create(
+    const uint8_t* data,
+    size_t         len);
+
+/* Releases an owned PMX rig-spec handle. Passing NULL is allowed. */
+void mmd_runtime_pmx_rig_spec_free(
+    mmd_runtime_pmx_rig_spec_t* spec);
+
+/* Returns the rig-spec manifest JSON for spec.
+   spec must be a live handle. The returned byte buffer is Rust-owned and must
+   be freed with mmd_runtime_byte_buffer_free. Invalid or NULL spec returns an
+   empty buffer. */
+mmd_runtime_ffi_byte_buffer_t mmd_runtime_pmx_rig_spec_manifest_json(
+    const mmd_runtime_pmx_rig_spec_t* spec);
 
 mmd_runtime_model_t* mmd_runtime_model_create(
     const int32_t* parent_indices,

--- a/crates/mmd-anim-ffi/src/lib.rs
+++ b/crates/mmd-anim-ffi/src/lib.rs
@@ -5,11 +5,12 @@ use std::{ptr, slice, str, sync::Arc};
 
 use mmd_anim_runtime::ModelArena;
 use mmd_anim_runtime::{
-    AnimationClip, AppendTransformInit, BoneAnimationBinding, BoneIndex, BoneInit, BoneMorphOffset,
-    GroupMorphOffset, IkAngleLimit, IkLinkInit, IkSolveOptions, IkSolverInit,
-    MorphAnimationBinding, MorphIndex, MorphInit, MorphKeyframe, MorphOffsetSpan, MorphTrack,
-    MovableBoneKeyframe, MovableBoneTrack, PropertyAnimationBinding, PropertyKeyframe,
-    RuntimeInstance,
+    solve_append_transform, AnimationClip, AppendPrimitiveInput, AppendTransformInit,
+    BoneAnimationBinding, BoneIndex, BoneInit, BoneMorphOffset, GroupMorphOffset, IkAngleLimit,
+    IkChainDefinition, IkChainLinkDefinition, IkChainPoseInput, IkChainSolver, IkLinkInit,
+    IkSolveOptions, IkSolverInit, MorphAnimationBinding, MorphIndex, MorphInit, MorphKeyframe,
+    MorphOffsetSpan, MorphTrack, MovableBoneKeyframe, MovableBoneTrack, PropertyAnimationBinding,
+    PropertyKeyframe, RuntimeInstance,
 };
 
 pub const ABI_VERSION: u32 = 1;
@@ -56,6 +57,23 @@ pub struct MmdRuntimeClip {
 pub struct MmdRuntimePmxMaterialSplit {
     split: mmd_anim_format::PmxMaterialSplitResult,
     manifest_json: Vec<u8>,
+}
+
+pub struct MmdRuntimePmxRigSpec {
+    spec: mmd_anim_format::PmxRigSpec,
+    manifest_json: Vec<u8>,
+}
+
+pub struct MmdRuntimeIkChain {
+    solver: IkChainSolver,
+    bone_count: usize,
+    link_count: usize,
+}
+
+pub struct MmdRuntimeAppendSolver {
+    ratio: f32,
+    affect_rotation: bool,
+    affect_translation: bool,
 }
 
 #[repr(C)]
@@ -119,6 +137,37 @@ pub struct MmdRuntimeFfiIkLink {
 }
 
 #[repr(C)]
+pub struct MmdRuntimeFfiRigIkLink {
+    pub bone_slot: u32,
+    pub has_angle_limit: bool,
+    pub angle_limit_min_xyz: [f32; 3],
+    pub angle_limit_max_xyz: [f32; 3],
+}
+
+#[repr(C)]
+pub struct MmdRuntimeFfiRigBone {
+    pub parent_slot: i32,
+    pub rest_position_xyz: [f32; 3],
+    pub flags: u32,
+    pub fixed_axis_xyz: [f32; 3],
+}
+
+#[repr(C)]
+pub struct MmdRuntimeFfiIkSolveStats {
+    pub executed_iterations: u32,
+    pub link_steps: u32,
+    pub final_distance: f32,
+    pub break_reason: u32,
+}
+
+#[repr(C)]
+pub struct MmdRuntimeFfiAppendConfig {
+    pub ratio: f32,
+    pub affect_rotation: bool,
+    pub affect_translation: bool,
+}
+
+#[repr(C)]
 pub struct MmdRuntimeFfiBoneMorphOffset {
     pub morph_index: u32,
     pub target_bone_index: u32,
@@ -143,6 +192,7 @@ const APPEND_FLAG_ROTATION: u32 = 1;
 const APPEND_FLAG_TRANSLATION: u32 = 1 << 1;
 const APPEND_FLAG_LOCAL: u32 = 1 << 2;
 const IK_LINK_FLAG_ANGLE_LIMIT: u32 = 1;
+const RIG_BONE_FIXED_AXIS: u32 = 1;
 
 #[unsafe(no_mangle)]
 pub extern "C" fn mmd_runtime_abi_version() -> u32 {
@@ -185,6 +235,271 @@ pub unsafe extern "C" fn mmd_runtime_byte_buffer_free(buffer: MmdRuntimeFfiByteB
             buffer.len,
         )));
     }
+}
+
+/// Creates a stateful per-chain IK primitive solver.
+///
+/// # Safety
+///
+/// `bones` must point to `bone_count` readable entries and `links` must point
+/// to `link_count` readable entries when their counts are non-zero.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn mmd_runtime_ik_chain_create(
+    bones: *const MmdRuntimeFfiRigBone,
+    bone_count: usize,
+    target_bone_slot: u32,
+    links: *const MmdRuntimeFfiRigIkLink,
+    link_count: usize,
+    iteration_count: u32,
+    limit_angle: f32,
+) -> *mut MmdRuntimeIkChain {
+    let definition = unsafe {
+        build_ik_chain_definition(
+            bones,
+            bone_count,
+            target_bone_slot,
+            links,
+            link_count,
+            iteration_count,
+            limit_angle,
+        )
+    };
+    let Some(definition) = definition else {
+        return ptr::null_mut();
+    };
+    let solver = IkChainSolver::new(definition);
+    Box::into_raw(Box::new(MmdRuntimeIkChain {
+        solver,
+        bone_count,
+        link_count,
+    }))
+}
+
+/// Frees an IK primitive solver handle.
+///
+/// # Safety
+///
+/// `chain` must be null or a pointer returned by `mmd_runtime_ik_chain_create`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn mmd_runtime_ik_chain_free(chain: *mut MmdRuntimeIkChain) {
+    if chain.is_null() {
+        return;
+    }
+    unsafe {
+        drop(Box::from_raw(chain));
+    }
+}
+
+/// Solves one IK chain into caller-owned link-rotation output.
+///
+/// # Safety
+///
+/// Required input and output pointers must point to readable/writable arrays
+/// matching the documented C header lengths.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn mmd_runtime_ik_chain_solve(
+    chain: *mut MmdRuntimeIkChain,
+    parent_world_matrix: *const f32,
+    local_position_offsets_xyz: *const f32,
+    local_rotations_xyzw: *const f32,
+    goal_position_xyz: *const f32,
+    tolerance: f32,
+    max_iterations_cap: u32,
+    out_link_rotations_xyzw: *mut f32,
+    out_link_rotation_f32_len: usize,
+    out_stats: *mut MmdRuntimeFfiIkSolveStats,
+) -> bool {
+    if chain.is_null()
+        || local_rotations_xyzw.is_null()
+        || goal_position_xyz.is_null()
+        || out_link_rotations_xyzw.is_null()
+    {
+        return false;
+    }
+    let chain = unsafe { &mut *chain };
+    let required_output_len = match chain.link_count.checked_mul(4) {
+        Some(len) => len,
+        None => return false,
+    };
+    if out_link_rotation_f32_len < required_output_len {
+        return false;
+    }
+
+    let parent_world_matrix = if parent_world_matrix.is_null() {
+        None
+    } else {
+        let raw = unsafe { slice::from_raw_parts(parent_world_matrix, 16) };
+        if !all_finite(raw) {
+            return false;
+        }
+        let Ok(raw) = raw.try_into() else {
+            return false;
+        };
+        Some(glam::Mat4::from_cols_array(raw))
+    };
+
+    let position_offsets = if local_position_offsets_xyz.is_null() {
+        vec![glam::Vec3A::ZERO; chain.bone_count]
+    } else {
+        let Some(len) = chain.bone_count.checked_mul(3) else {
+            return false;
+        };
+        let raw = unsafe { slice::from_raw_parts(local_position_offsets_xyz, len) };
+        if !all_finite(raw) {
+            return false;
+        }
+        raw.chunks_exact(3)
+            .map(|v| glam::Vec3A::new(v[0], v[1], v[2]))
+            .collect()
+    };
+
+    let Some(rotation_len) = chain.bone_count.checked_mul(4) else {
+        return false;
+    };
+    let raw_rotations = unsafe { slice::from_raw_parts(local_rotations_xyzw, rotation_len) };
+    if !all_finite(raw_rotations) {
+        return false;
+    }
+    let mut rotations = Vec::with_capacity(chain.bone_count);
+    for q in raw_rotations.chunks_exact(4) {
+        let rotation = glam::Quat::from_xyzw(q[0], q[1], q[2], q[3]);
+        if rotation.length_squared() <= f32::EPSILON {
+            return false;
+        }
+        rotations.push(rotation.normalize());
+    }
+
+    let goal = unsafe { slice::from_raw_parts(goal_position_xyz, 3) };
+    if !all_finite(goal) || !tolerance.is_finite() {
+        return false;
+    }
+    let max_iterations_cap = if max_iterations_cap == 0 {
+        None
+    } else {
+        Some(max_iterations_cap)
+    };
+
+    let output = chain.solver.solve(IkChainPoseInput {
+        parent_world_matrix,
+        local_position_offsets: &position_offsets,
+        local_rotations: &rotations,
+        goal_position: glam::Vec3A::new(goal[0], goal[1], goal[2]),
+        tolerance,
+        max_iterations_cap,
+    });
+    if output.solved_link_rotations.len() != chain.link_count {
+        return false;
+    }
+
+    let out = unsafe { slice::from_raw_parts_mut(out_link_rotations_xyzw, required_output_len) };
+    for (rotation, dst) in output
+        .solved_link_rotations
+        .iter()
+        .zip(out.chunks_exact_mut(4))
+    {
+        dst.copy_from_slice(&rotation.to_array());
+    }
+    if !out_stats.is_null() {
+        unsafe {
+            *out_stats = MmdRuntimeFfiIkSolveStats {
+                executed_iterations: output.executed_iterations,
+                link_steps: output.link_steps,
+                final_distance: output.final_distance,
+                break_reason: if output.final_distance <= tolerance.max(0.0) {
+                    0
+                } else {
+                    1
+                },
+            };
+        }
+    }
+    true
+}
+
+/// Creates a per-bone append/grant primitive solver.
+///
+/// # Safety
+///
+/// `config` must point to a readable config struct.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn mmd_runtime_append_solver_create(
+    config: *const MmdRuntimeFfiAppendConfig,
+) -> *mut MmdRuntimeAppendSolver {
+    if config.is_null() {
+        return ptr::null_mut();
+    }
+    let config = unsafe { &*config };
+    if !config.ratio.is_finite() {
+        return ptr::null_mut();
+    }
+    Box::into_raw(Box::new(MmdRuntimeAppendSolver {
+        ratio: config.ratio,
+        affect_rotation: config.affect_rotation,
+        affect_translation: config.affect_translation,
+    }))
+}
+
+/// Frees an append primitive solver handle.
+///
+/// # Safety
+///
+/// `solver` must be null or a pointer returned by
+/// `mmd_runtime_append_solver_create`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn mmd_runtime_append_solver_free(solver: *mut MmdRuntimeAppendSolver) {
+    if solver.is_null() {
+        return;
+    }
+    unsafe {
+        drop(Box::from_raw(solver));
+    }
+}
+
+/// Solves one append/grant primitive into caller-owned output arrays.
+///
+/// # Safety
+///
+/// Pointers must reference readable/writable arrays matching the documented
+/// C header lengths.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn mmd_runtime_append_solver_solve(
+    solver: *const MmdRuntimeAppendSolver,
+    source_position_offset_xyz: *const f32,
+    source_rotation_xyzw: *const f32,
+    out_position_offset_xyz: *mut f32,
+    out_rotation_xyzw: *mut f32,
+) -> bool {
+    if solver.is_null()
+        || source_position_offset_xyz.is_null()
+        || source_rotation_xyzw.is_null()
+        || out_position_offset_xyz.is_null()
+        || out_rotation_xyzw.is_null()
+    {
+        return false;
+    }
+    let solver = unsafe { &*solver };
+    let position = unsafe { slice::from_raw_parts(source_position_offset_xyz, 3) };
+    let rotation = unsafe { slice::from_raw_parts(source_rotation_xyzw, 4) };
+    if !all_finite(position) || !all_finite(rotation) {
+        return false;
+    }
+    let source_rotation = glam::Quat::from_xyzw(rotation[0], rotation[1], rotation[2], rotation[3]);
+    if source_rotation.length_squared() <= f32::EPSILON {
+        return false;
+    }
+
+    let output = solve_append_transform(AppendPrimitiveInput {
+        source_position_offset: glam::Vec3A::new(position[0], position[1], position[2]),
+        source_rotation: source_rotation.normalize(),
+        ratio: solver.ratio,
+        affect_rotation: solver.affect_rotation,
+        affect_translation: solver.affect_translation,
+    });
+    let out_position = unsafe { slice::from_raw_parts_mut(out_position_offset_xyz, 3) };
+    out_position.copy_from_slice(&output.position_offset.to_array());
+    let out_rotation = unsafe { slice::from_raw_parts_mut(out_rotation_xyzw, 4) };
+    out_rotation.copy_from_slice(&output.rotation.to_array());
+    true
 }
 
 /// Parses VMD bytes and returns the serialized `VmdParsedAnimation` JSON.
@@ -891,6 +1206,33 @@ pub unsafe extern "C" fn mmd_runtime_pmx_material_split_create(
     }))
 }
 
+/// Parses PMX bytes once and creates an opaque rig-spec handle.
+///
+/// # Safety
+/// `data` must point to `len` readable bytes when `len` is non-zero.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn mmd_runtime_pmx_rig_spec_create(
+    data: *const u8,
+    len: usize,
+) -> *mut MmdRuntimePmxRigSpec {
+    if data.is_null() || len == 0 {
+        return ptr::null_mut();
+    }
+    let bytes = unsafe { slice::from_raw_parts(data, len) };
+    let spec = match mmd_anim_format::parse_pmx_rig_spec(bytes) {
+        Ok(spec) => spec,
+        Err(_) => return ptr::null_mut(),
+    };
+    let manifest_json = match serde_json::to_vec(&spec) {
+        Ok(json) => json,
+        Err(_) => return ptr::null_mut(),
+    };
+    Box::into_raw(Box::new(MmdRuntimePmxRigSpec {
+        spec,
+        manifest_json,
+    }))
+}
+
 /// Frees a PMX material-split handle.
 ///
 /// # Safety
@@ -905,6 +1247,21 @@ pub unsafe extern "C" fn mmd_runtime_pmx_material_split_free(
     }
     unsafe {
         drop(Box::from_raw(split));
+    }
+}
+
+/// Frees a PMX rig-spec handle.
+///
+/// # Safety
+/// `spec` must be null or a handle returned by
+/// `mmd_runtime_pmx_rig_spec_create` that has not already been freed.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn mmd_runtime_pmx_rig_spec_free(spec: *mut MmdRuntimePmxRigSpec) {
+    if spec.is_null() {
+        return;
+    }
+    unsafe {
+        drop(Box::from_raw(spec));
     }
 }
 
@@ -939,6 +1296,24 @@ pub unsafe extern "C" fn mmd_runtime_pmx_material_split_manifest_json(
         return empty_byte_buffer();
     };
     byte_buffer_from_vec(split.manifest_json.clone())
+}
+
+/// Returns the serialized rig-spec manifest JSON.
+///
+/// # Safety
+/// `spec` must be null or a valid handle returned by
+/// `mmd_runtime_pmx_rig_spec_create`. Passing any other pointer is undefined
+/// behavior. The returned buffer is owned by the caller and must be freed with
+/// `mmd_runtime_byte_buffer_free`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn mmd_runtime_pmx_rig_spec_manifest_json(
+    spec: *const MmdRuntimePmxRigSpec,
+) -> MmdRuntimeFfiByteBuffer {
+    let Some(spec) = (unsafe { spec.as_ref() }) else {
+        return empty_byte_buffer();
+    };
+    debug_assert_eq!(spec.spec.bone_count, spec.spec.bones.len());
+    byte_buffer_from_vec(spec.manifest_json.clone())
 }
 
 /// Returns split mesh vertex positions as a native-endian byte buffer.
@@ -2543,6 +2918,109 @@ unsafe fn checked_slice<'a, T>(ptr: *const T, len: usize) -> Option<&'a [T]> {
     Some(unsafe { slice::from_raw_parts(ptr, len) })
 }
 
+fn all_finite(values: &[f32]) -> bool {
+    values.iter().all(|value| value.is_finite())
+}
+
+unsafe fn build_ik_chain_definition(
+    bones: *const MmdRuntimeFfiRigBone,
+    bone_count: usize,
+    target_bone_slot: u32,
+    links: *const MmdRuntimeFfiRigIkLink,
+    link_count: usize,
+    iteration_count: u32,
+    limit_angle: f32,
+) -> Option<IkChainDefinition> {
+    if bone_count == 0
+        || link_count == 0
+        || target_bone_slot as usize >= bone_count
+        || !limit_angle.is_finite()
+    {
+        return None;
+    }
+    let bones = unsafe { checked_slice(bones, bone_count) }?;
+    let links = unsafe { checked_slice(links, link_count) }?;
+    let mut parent_slots = Vec::with_capacity(bone_count);
+    let mut rest_positions = Vec::with_capacity(bone_count);
+    let mut fixed_axes = Vec::with_capacity(bone_count);
+    for (slot, bone) in bones.iter().enumerate() {
+        if !all_finite(&bone.rest_position_xyz) {
+            return None;
+        }
+        let parent = match bone.parent_slot {
+            -1 => None,
+            parent if parent >= 0 && (parent as usize) < slot => Some(parent as usize),
+            _ => return None,
+        };
+        let fixed_axis = if bone.flags & RIG_BONE_FIXED_AXIS != 0 {
+            if !all_finite(&bone.fixed_axis_xyz) {
+                return None;
+            }
+            let axis = glam::Vec3A::new(
+                bone.fixed_axis_xyz[0],
+                bone.fixed_axis_xyz[1],
+                bone.fixed_axis_xyz[2],
+            );
+            if axis.length_squared() <= f32::EPSILON {
+                return None;
+            }
+            Some(axis.normalize())
+        } else {
+            None
+        };
+        parent_slots.push(parent);
+        rest_positions.push(glam::Vec3A::new(
+            bone.rest_position_xyz[0],
+            bone.rest_position_xyz[1],
+            bone.rest_position_xyz[2],
+        ));
+        fixed_axes.push(fixed_axis);
+    }
+
+    let links = links
+        .iter()
+        .map(|link| {
+            if link.bone_slot as usize >= bone_count {
+                return None;
+            }
+            let angle_limit = if link.has_angle_limit {
+                if !all_finite(&link.angle_limit_min_xyz) || !all_finite(&link.angle_limit_max_xyz)
+                {
+                    return None;
+                }
+                Some(IkAngleLimit::new(
+                    glam::Vec3A::new(
+                        link.angle_limit_min_xyz[0],
+                        link.angle_limit_min_xyz[1],
+                        link.angle_limit_min_xyz[2],
+                    ),
+                    glam::Vec3A::new(
+                        link.angle_limit_max_xyz[0],
+                        link.angle_limit_max_xyz[1],
+                        link.angle_limit_max_xyz[2],
+                    ),
+                ))
+            } else {
+                None
+            };
+            Some(IkChainLinkDefinition {
+                bone_slot: link.bone_slot as usize,
+                angle_limit,
+            })
+        })
+        .collect::<Option<Vec<_>>>()?;
+
+    Some(IkChainDefinition {
+        parent_slots,
+        rest_positions,
+        fixed_axes,
+        target_slot: target_bone_slot as usize,
+        links,
+        iteration_count,
+        limit_angle,
+    })
+}
+
 fn checked_range<T>(slice: &[T], offset: usize, count: usize) -> Option<&[T]> {
     let end = offset.checked_add(count)?;
     slice.get(offset..end)
@@ -2776,6 +3254,258 @@ fn build_morph_init_from_ffi(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn assert_near(actual: f32, expected: f32, tolerance: f32) {
+        assert!(
+            (actual - expected).abs() <= tolerance,
+            "actual={actual} expected={expected} tolerance={tolerance}"
+        );
+    }
+
+    fn assert_slice_near(actual: &[f32], expected: &[f32], tolerance: f32) {
+        assert_eq!(actual.len(), expected.len());
+        for (index, (actual, expected)) in actual.iter().zip(expected).enumerate() {
+            assert!(
+                (*actual - *expected).abs() <= tolerance,
+                "index={index} actual={actual} expected={expected} tolerance={tolerance}"
+            );
+        }
+    }
+
+    fn simple_ik_chain() -> *mut MmdRuntimeIkChain {
+        let bones = [
+            MmdRuntimeFfiRigBone {
+                parent_slot: -1,
+                rest_position_xyz: [0.0, 0.0, 0.0],
+                flags: 0,
+                fixed_axis_xyz: [0.0, 0.0, 0.0],
+            },
+            MmdRuntimeFfiRigBone {
+                parent_slot: 0,
+                rest_position_xyz: [1.0, 0.0, 0.0],
+                flags: 0,
+                fixed_axis_xyz: [0.0, 0.0, 0.0],
+            },
+        ];
+        let links = [MmdRuntimeFfiRigIkLink {
+            bone_slot: 0,
+            has_angle_limit: false,
+            angle_limit_min_xyz: [0.0, 0.0, 0.0],
+            angle_limit_max_xyz: [0.0, 0.0, 0.0],
+        }];
+        unsafe {
+            mmd_runtime_ik_chain_create(
+                bones.as_ptr(),
+                bones.len(),
+                1,
+                links.as_ptr(),
+                links.len(),
+                4,
+                0.0,
+            )
+        }
+    }
+
+    #[test]
+    fn append_solver_lifecycle_and_expected_output_use_xyzw_quaternion() {
+        let config = MmdRuntimeFfiAppendConfig {
+            ratio: 0.5,
+            affect_rotation: true,
+            affect_translation: true,
+        };
+        let solver = unsafe { mmd_runtime_append_solver_create(&config) };
+        assert!(!solver.is_null());
+
+        let source_position = [2.0, 4.0, -6.0];
+        let source_rotation = glam::Quat::from_rotation_z(std::f32::consts::FRAC_PI_2).to_array();
+        let mut out_position = [0.0; 3];
+        let mut out_rotation = [0.0; 4];
+        assert!(unsafe {
+            mmd_runtime_append_solver_solve(
+                solver,
+                source_position.as_ptr(),
+                source_rotation.as_ptr(),
+                out_position.as_mut_ptr(),
+                out_rotation.as_mut_ptr(),
+            )
+        });
+
+        assert_slice_near(&out_position, &[1.0, 2.0, -3.0], 1.0e-5);
+        let solved = glam::Quat::from_xyzw(
+            out_rotation[0],
+            out_rotation[1],
+            out_rotation[2],
+            out_rotation[3],
+        );
+        let rotated_x = solved.mul_vec3(glam::Vec3::X);
+        assert_near(rotated_x.x, std::f32::consts::FRAC_1_SQRT_2, 1.0e-5);
+        assert_near(rotated_x.y, std::f32::consts::FRAC_1_SQRT_2, 1.0e-5);
+        assert_near(out_rotation[3], solved.w, 0.0);
+
+        unsafe { mmd_runtime_append_solver_free(solver) };
+    }
+
+    #[test]
+    fn append_solver_rejects_null_inputs() {
+        let config = MmdRuntimeFfiAppendConfig {
+            ratio: 1.0,
+            affect_rotation: true,
+            affect_translation: true,
+        };
+        assert!(unsafe { mmd_runtime_append_solver_create(ptr::null()) }.is_null());
+        let solver = unsafe { mmd_runtime_append_solver_create(&config) };
+        assert!(!solver.is_null());
+
+        let source_position = [0.0; 3];
+        let source_rotation = [0.0, 0.0, 0.0, 1.0];
+        let mut out_position = [0.0; 3];
+        let mut out_rotation = [0.0; 4];
+        assert!(!unsafe {
+            mmd_runtime_append_solver_solve(
+                ptr::null(),
+                source_position.as_ptr(),
+                source_rotation.as_ptr(),
+                out_position.as_mut_ptr(),
+                out_rotation.as_mut_ptr(),
+            )
+        });
+        assert!(!unsafe {
+            mmd_runtime_append_solver_solve(
+                solver,
+                ptr::null(),
+                source_rotation.as_ptr(),
+                out_position.as_mut_ptr(),
+                out_rotation.as_mut_ptr(),
+            )
+        });
+        assert!(!unsafe {
+            mmd_runtime_append_solver_solve(
+                solver,
+                source_position.as_ptr(),
+                ptr::null(),
+                out_position.as_mut_ptr(),
+                out_rotation.as_mut_ptr(),
+            )
+        });
+
+        unsafe { mmd_runtime_append_solver_free(solver) };
+    }
+
+    #[test]
+    fn ik_chain_lifecycle_solve_converges_and_uses_column_major_parent_matrix() {
+        let chain = simple_ik_chain();
+        assert!(!chain.is_null());
+
+        let parent_world =
+            glam::Mat4::from_translation(glam::Vec3::new(2.0, 0.0, 0.0)).to_cols_array();
+        let local_rotations = [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0];
+        let goal = [2.0, 1.0, 0.0];
+        let mut out_rotations = [0.0; 4];
+        let mut stats = MmdRuntimeFfiIkSolveStats {
+            executed_iterations: 0,
+            link_steps: 0,
+            final_distance: f32::MAX,
+            break_reason: u32::MAX,
+        };
+
+        assert!(unsafe {
+            mmd_runtime_ik_chain_solve(
+                chain,
+                parent_world.as_ptr(),
+                ptr::null(),
+                local_rotations.as_ptr(),
+                goal.as_ptr(),
+                1.0e-3,
+                0,
+                out_rotations.as_mut_ptr(),
+                out_rotations.len(),
+                &mut stats,
+            )
+        });
+        assert!(
+            stats.final_distance <= 1.0e-3,
+            "IK should converge to the goal, stats={:?}",
+            (
+                stats.executed_iterations,
+                stats.link_steps,
+                stats.final_distance,
+                stats.break_reason
+            )
+        );
+        assert_eq!(stats.break_reason, 0);
+
+        let solved = glam::Quat::from_xyzw(
+            out_rotations[0],
+            out_rotations[1],
+            out_rotations[2],
+            out_rotations[3],
+        );
+        let rotated_x = solved.mul_vec3(glam::Vec3::X);
+        assert_near(rotated_x.x, 0.0, 1.0e-3);
+        assert_near(rotated_x.y, 1.0, 1.0e-3);
+        assert_near(out_rotations[3], solved.w, 0.0);
+
+        unsafe { mmd_runtime_ik_chain_free(chain) };
+    }
+
+    #[test]
+    fn ik_chain_rejects_null_and_short_buffer_inputs() {
+        let chain = simple_ik_chain();
+        assert!(!chain.is_null());
+
+        let local_rotations = [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0];
+        let goal = [0.0, 1.0, 0.0];
+        let mut out_rotations = [0.0; 4];
+
+        assert!(
+            unsafe { mmd_runtime_ik_chain_create(ptr::null(), 2, 1, ptr::null(), 1, 1, 0.0) }
+                .is_null()
+        );
+        assert!(!unsafe {
+            mmd_runtime_ik_chain_solve(
+                ptr::null_mut(),
+                ptr::null(),
+                ptr::null(),
+                local_rotations.as_ptr(),
+                goal.as_ptr(),
+                1.0e-3,
+                0,
+                out_rotations.as_mut_ptr(),
+                out_rotations.len(),
+                ptr::null_mut(),
+            )
+        });
+        assert!(!unsafe {
+            mmd_runtime_ik_chain_solve(
+                chain,
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                goal.as_ptr(),
+                1.0e-3,
+                0,
+                out_rotations.as_mut_ptr(),
+                out_rotations.len(),
+                ptr::null_mut(),
+            )
+        });
+        assert!(!unsafe {
+            mmd_runtime_ik_chain_solve(
+                chain,
+                ptr::null(),
+                ptr::null(),
+                local_rotations.as_ptr(),
+                goal.as_ptr(),
+                1.0e-3,
+                0,
+                out_rotations.as_mut_ptr(),
+                out_rotations.len() - 1,
+                ptr::null_mut(),
+            )
+        });
+
+        unsafe { mmd_runtime_ik_chain_free(chain) };
+    }
 
     #[test]
     fn exports_pmx_from_parts_through_c_abi() {
@@ -4564,6 +5294,225 @@ mod tests {
         );
         serde_json::from_slice(&manifest_bytes)
             .unwrap_or_else(|err| panic!("{context}: manifest_json parse failed: {err}"))
+    }
+
+    fn rig_spec_manifest_json(
+        spec: *mut MmdRuntimePmxRigSpec,
+        context: &str,
+    ) -> serde_json::Value {
+        let manifest_bytes =
+            ffi_buffer_to_vec(unsafe { mmd_runtime_pmx_rig_spec_manifest_json(spec) });
+        assert!(
+            !manifest_bytes.is_empty(),
+            "{context}: manifest_json must not be empty"
+        );
+        serde_json::from_slice(&manifest_bytes)
+            .unwrap_or_else(|err| panic!("{context}: manifest_json parse failed: {err}"))
+    }
+
+    fn assert_json_array3(value: &serde_json::Value, context: &str) {
+        let array = value
+            .as_array()
+            .unwrap_or_else(|| panic!("{context}: must be an array"));
+        assert_eq!(array.len(), 3, "{context}: must have three elements");
+        assert!(
+            array.iter().all(|item| item.is_number()),
+            "{context}: elements must be numbers"
+        );
+    }
+
+    #[test]
+    fn rig_spec_manifest_json_has_expected_shape() {
+        let bytes: &[u8] =
+            include_bytes!("../../mmd-anim-format/fixtures/pmx/ik_multi_axis_limit.pmx");
+        let spec = unsafe { mmd_runtime_pmx_rig_spec_create(bytes.as_ptr(), bytes.len()) };
+        assert!(!spec.is_null(), "rig spec handle must not be null");
+
+        let manifest = rig_spec_manifest_json(spec, "fixture rig spec");
+        let bone_count = manifest
+            .get("boneCount")
+            .and_then(|v| v.as_u64())
+            .expect("fixture rig spec: boneCount must be a number");
+        let ik_chain_count = manifest
+            .get("ikChainCount")
+            .and_then(|v| v.as_u64())
+            .expect("fixture rig spec: ikChainCount must be a number");
+        let grant_count = manifest
+            .get("grantCount")
+            .and_then(|v| v.as_u64())
+            .expect("fixture rig spec: grantCount must be a number");
+
+        let bones = manifest
+            .get("bones")
+            .and_then(|v| v.as_array())
+            .expect("fixture rig spec: bones must be an array");
+        let ik_chains = manifest
+            .get("ikChains")
+            .and_then(|v| v.as_array())
+            .expect("fixture rig spec: ikChains must be an array");
+        let grants = manifest
+            .get("grants")
+            .and_then(|v| v.as_array())
+            .expect("fixture rig spec: grants must be an array");
+
+        assert_eq!(bones.len(), bone_count as usize, "boneCount mismatch");
+        assert_eq!(
+            ik_chains.len(),
+            ik_chain_count as usize,
+            "ikChainCount mismatch"
+        );
+        assert_eq!(grants.len(), grant_count as usize, "grantCount mismatch");
+        assert!(bone_count > 0, "fixture rig spec: boneCount must be positive");
+        assert!(
+            ik_chain_count > 0,
+            "fixture rig spec: ikChainCount must be positive"
+        );
+
+        for (bone_index, bone) in bones.iter().enumerate() {
+            let context = format!("fixture rig spec: bone {bone_index}");
+            assert!(bone.get("name").is_some_and(|v| v.is_string()), "{context}: name");
+            assert!(
+                bone.get("nameBytes").is_some_and(|v| v.is_string()),
+                "{context}: nameBytes"
+            );
+            assert!(
+                bone.get("parentIndex").is_some_and(|v| v.is_number()),
+                "{context}: parentIndex"
+            );
+            assert_json_array3(
+                bone.get("restPosition")
+                    .unwrap_or_else(|| panic!("{context}: restPosition missing")),
+                &format!("{context}: restPosition"),
+            );
+            assert!(
+                bone.get("deformLayer").is_some_and(|v| v.is_number()),
+                "{context}: deformLayer"
+            );
+            assert!(bone.get("fixedAxis").is_some(), "{context}: fixedAxis missing");
+            assert!(bone.get("localAxis").is_some(), "{context}: localAxis missing");
+            assert!(
+                bone.get("transformAfterPhysics")
+                    .is_some_and(|v| v.is_boolean()),
+                "{context}: transformAfterPhysics"
+            );
+            if let Some(local_axis) = bone.get("localAxis").filter(|v| !v.is_null()) {
+                assert_json_array3(
+                    local_axis
+                        .get("x")
+                        .unwrap_or_else(|| panic!("{context}: localAxis.x missing")),
+                    &format!("{context}: localAxis.x"),
+                );
+                assert_json_array3(
+                    local_axis
+                        .get("z")
+                        .unwrap_or_else(|| panic!("{context}: localAxis.z missing")),
+                    &format!("{context}: localAxis.z"),
+                );
+            }
+        }
+
+        for (chain_index, chain) in ik_chains.iter().enumerate() {
+            let context = format!("fixture rig spec: ik chain {chain_index}");
+            assert!(
+                chain
+                    .get("controllerBoneIndex")
+                    .is_some_and(|v| v.is_number()),
+                "{context}: controllerBoneIndex"
+            );
+            assert!(
+                chain.get("targetBoneIndex").is_some_and(|v| v.is_number()),
+                "{context}: targetBoneIndex"
+            );
+            assert!(
+                chain.get("iterationCount").is_some_and(|v| v.is_number()),
+                "{context}: iterationCount"
+            );
+            assert!(
+                chain.get("limitAngle").is_some_and(|v| v.is_number()),
+                "{context}: limitAngle"
+            );
+            let links = chain
+                .get("links")
+                .and_then(|v| v.as_array())
+                .unwrap_or_else(|| panic!("{context}: links must be an array"));
+            for (link_index, link) in links.iter().enumerate() {
+                let context = format!("{context}: link {link_index}");
+                assert!(
+                    link.get("boneIndex").is_some_and(|v| v.is_number()),
+                    "{context}: boneIndex"
+                );
+                assert!(
+                    link.get("hasAngleLimit").is_some_and(|v| v.is_boolean()),
+                    "{context}: hasAngleLimit"
+                );
+                assert_json_array3(
+                    link.get("angleLimitMin")
+                        .unwrap_or_else(|| panic!("{context}: angleLimitMin missing")),
+                    &format!("{context}: angleLimitMin"),
+                );
+                assert_json_array3(
+                    link.get("angleLimitMax")
+                        .unwrap_or_else(|| panic!("{context}: angleLimitMax missing")),
+                    &format!("{context}: angleLimitMax"),
+                );
+            }
+        }
+
+        for (grant_index, grant) in grants.iter().enumerate() {
+            let context = format!("fixture rig spec: grant {grant_index}");
+            assert!(
+                grant.get("targetBoneIndex").is_some_and(|v| v.is_number()),
+                "{context}: targetBoneIndex"
+            );
+            assert!(
+                grant.get("sourceBoneIndex").is_some_and(|v| v.is_number()),
+                "{context}: sourceBoneIndex"
+            );
+            assert!(
+                grant.get("ratio").is_some_and(|v| v.is_number()),
+                "{context}: ratio"
+            );
+            assert!(
+                grant.get("affectRotation").is_some_and(|v| v.is_boolean()),
+                "{context}: affectRotation"
+            );
+            assert!(
+                grant
+                    .get("affectTranslation")
+                    .is_some_and(|v| v.is_boolean()),
+                "{context}: affectTranslation"
+            );
+            assert!(
+                grant.get("local").is_some_and(|v| v.is_boolean()),
+                "{context}: local"
+            );
+        }
+
+        unsafe { mmd_runtime_pmx_rig_spec_free(spec) };
+    }
+
+    #[test]
+    fn rig_spec_rejects_null_and_invalid_input() {
+        let null_spec = unsafe { mmd_runtime_pmx_rig_spec_create(ptr::null(), 1) };
+        assert!(null_spec.is_null(), "null input must return null handle");
+
+        let byte = 0_u8;
+        let empty_spec = unsafe { mmd_runtime_pmx_rig_spec_create(&byte as *const u8, 0) };
+        assert!(empty_spec.is_null(), "empty input must return null handle");
+
+        let garbage = b"not a pmx";
+        let invalid_spec =
+            unsafe { mmd_runtime_pmx_rig_spec_create(garbage.as_ptr(), garbage.len()) };
+        assert!(
+            invalid_spec.is_null(),
+            "invalid input must return null handle"
+        );
+
+        assert_empty_ffi_buffer(
+            unsafe { mmd_runtime_pmx_rig_spec_manifest_json(ptr::null()) },
+            "null rig spec manifest",
+        );
+        unsafe { mmd_runtime_pmx_rig_spec_free(ptr::null_mut()) };
     }
 
     #[test]

--- a/crates/mmd-anim-format/src/lib.rs
+++ b/crates/mmd-anim-format/src/lib.rs
@@ -33,9 +33,10 @@ pub use pmx::{
     PmxPartsDisplayFrameItem, PmxPartsGroupMorphOffset, PmxPartsIndexSizes, PmxPartsInput,
     PmxPartsJointDescriptor, PmxPartsMaterialDescriptor, PmxPartsMaterialFlags,
     PmxPartsMorphDescriptor, PmxPartsRigidBodyDescriptor, PmxPartsVertexMorphOffset,
-    PmxRuntimeImport, build_pmx_model_from_parts, export_pmx_model, import_pmx_model,
-    import_pmx_runtime, parse_pmx_material_split, parse_pmx_model, split_pmx_model_by_material,
-    validate_pmx_export_model,
+    PmxRigSpec, PmxRigSpecBone, PmxRigSpecGrant, PmxRigSpecIkChain, PmxRigSpecIkLink,
+    PmxRigSpecLocalAxis, PmxRuntimeImport, build_pmx_model_from_parts, export_pmx_model,
+    import_pmx_model, import_pmx_runtime, parse_pmx_material_split, parse_pmx_model,
+    parse_pmx_rig_spec, split_pmx_model_by_material, validate_pmx_export_model,
 };
 pub use vmd::{
     VmdCameraState, VmdClipBuildOptions, VmdIkEntry, VmdImportResult, VmdParsedAnimation,

--- a/crates/mmd-anim-format/src/pmx/mod.rs
+++ b/crates/mmd-anim-format/src/pmx/mod.rs
@@ -1017,6 +1017,153 @@ pub struct PmxParsedIkLimit {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+pub struct PmxRigSpec {
+    pub bone_count: usize,
+    pub ik_chain_count: usize,
+    pub grant_count: usize,
+    pub bones: Vec<PmxRigSpecBone>,
+    pub ik_chains: Vec<PmxRigSpecIkChain>,
+    pub grants: Vec<PmxRigSpecGrant>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PmxRigSpecBone {
+    pub name: String,
+    pub name_bytes: String,
+    pub parent_index: i32,
+    pub rest_position: [f32; 3],
+    pub deform_layer: i32,
+    pub fixed_axis: Option<[f32; 3]>,
+    pub local_axis: Option<PmxRigSpecLocalAxis>,
+    pub transform_after_physics: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PmxRigSpecLocalAxis {
+    pub x: [f32; 3],
+    pub z: [f32; 3],
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PmxRigSpecIkChain {
+    pub controller_bone_index: i32,
+    pub target_bone_index: i32,
+    pub iteration_count: u32,
+    pub limit_angle: f32,
+    pub links: Vec<PmxRigSpecIkLink>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PmxRigSpecIkLink {
+    pub bone_index: i32,
+    pub has_angle_limit: bool,
+    pub angle_limit_min: [f32; 3],
+    pub angle_limit_max: [f32; 3],
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PmxRigSpecGrant {
+    pub target_bone_index: i32,
+    pub source_bone_index: i32,
+    pub ratio: f32,
+    pub affect_rotation: bool,
+    pub affect_translation: bool,
+    pub local: bool,
+}
+
+pub fn parse_pmx_rig_spec(data: &[u8]) -> Result<PmxRigSpec, ImportError> {
+    let model = parse_pmx_model(data)?;
+    Ok(pmx_model_to_rig_spec(&model))
+}
+
+pub fn pmx_model_to_rig_spec(model: &PmxParsedModel) -> PmxRigSpec {
+    let mut bones = Vec::with_capacity(model.skeleton.bones.len());
+    let mut ik_chains = Vec::new();
+    let mut grants = Vec::new();
+
+    for (index, bone) in model.skeleton.bones.iter().enumerate() {
+        bones.push(PmxRigSpecBone {
+            name: bone.name.clone(),
+            name_bytes: shift_jis_hex(&bone.name),
+            parent_index: bone.parent_index,
+            rest_position: bone.position,
+            deform_layer: bone.layer,
+            fixed_axis: bone.fixed_axis,
+            local_axis: bone.local_axis.as_ref().map(|axis| PmxRigSpecLocalAxis {
+                x: axis.x,
+                z: axis.z,
+            }),
+            transform_after_physics: bone.flags.transform_after_physics,
+        });
+
+        if let Some(ik) = &bone.ik {
+            ik_chains.push(PmxRigSpecIkChain {
+                controller_bone_index: index as i32,
+                target_bone_index: ik.target_index,
+                iteration_count: ik.loop_count.max(0) as u32,
+                limit_angle: ik.limit_angle,
+                links: ik
+                    .links
+                    .iter()
+                    .map(|link| {
+                        let (angle_limit_min, angle_limit_max) =
+                            link.limits.as_ref().map_or(([0.0; 3], [0.0; 3]), |limit| {
+                                (limit.lower, limit.upper)
+                            });
+                        PmxRigSpecIkLink {
+                            bone_index: link.bone_index,
+                            has_angle_limit: link.limits.is_some(),
+                            angle_limit_min,
+                            angle_limit_max,
+                        }
+                    })
+                    .collect(),
+            });
+        }
+
+        if let Some(append) = &bone.append_transform {
+            grants.push(PmxRigSpecGrant {
+                target_bone_index: index as i32,
+                source_bone_index: append.parent_index,
+                ratio: append.weight,
+                affect_rotation: bone.flags.append_rotate,
+                affect_translation: bone.flags.append_translate,
+                local: bone.flags.append_local,
+            });
+        }
+    }
+
+    PmxRigSpec {
+        bone_count: bones.len(),
+        ik_chain_count: ik_chains.len(),
+        grant_count: grants.len(),
+        bones,
+        ik_chains,
+        grants,
+    }
+}
+
+fn shift_jis_hex(text: &str) -> String {
+    let (encoded, _, _) = encoding_rs::SHIFT_JIS.encode(text);
+    bytes_to_hex(&encoded)
+}
+
+fn bytes_to_hex(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for &byte in bytes {
+        out.push(HEX[(byte >> 4) as usize] as char);
+        out.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    out
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct PmxParsedMorph {
     pub name: String,
     pub english_name: String,

--- a/crates/mmd-anim-runtime/src/append_primitive.rs
+++ b/crates/mmd-anim-runtime/src/append_primitive.rs
@@ -1,0 +1,160 @@
+use glam::{Quat, Vec3A};
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct AppendPrimitiveInput {
+    pub source_position_offset: Vec3A,
+    pub source_rotation: Quat,
+    pub ratio: f32,
+    pub affect_rotation: bool,
+    pub affect_translation: bool,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct AppendPrimitiveOutput {
+    pub position_offset: Vec3A,
+    pub rotation: Quat,
+}
+
+impl Default for AppendPrimitiveOutput {
+    fn default() -> Self {
+        Self {
+            position_offset: Vec3A::ZERO,
+            rotation: Quat::IDENTITY,
+        }
+    }
+}
+
+pub fn solve_append_transform(input: AppendPrimitiveInput) -> AppendPrimitiveOutput {
+    let rotation = if input.affect_rotation {
+        Quat::IDENTITY
+            .slerp(input.source_rotation, input.ratio)
+            .normalize()
+    } else {
+        Quat::IDENTITY
+    };
+    let position_offset = if input.affect_translation {
+        input.source_position_offset * input.ratio
+    } else {
+        Vec3A::ZERO
+    };
+
+    AppendPrimitiveOutput {
+        position_offset,
+        rotation,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn assert_vec3a_near(actual: Vec3A, expected: Vec3A) {
+        let delta = (actual - expected).abs();
+        assert!(
+            delta.x < 1.0e-5 && delta.y < 1.0e-5 && delta.z < 1.0e-5,
+            "actual={actual:?} expected={expected:?} delta={delta:?}"
+        );
+    }
+
+    #[test]
+    fn solves_rotation_translation_and_ratio() {
+        let output = solve_append_transform(AppendPrimitiveInput {
+            source_position_offset: Vec3A::new(2.0, 4.0, -6.0),
+            source_rotation: Quat::from_rotation_z(std::f32::consts::FRAC_PI_2),
+            ratio: 0.5,
+            affect_rotation: true,
+            affect_translation: true,
+        });
+
+        assert_vec3a_near(output.position_offset, Vec3A::new(1.0, 2.0, -3.0));
+        assert_vec3a_near(
+            output.rotation.mul_vec3a(Vec3A::X),
+            Vec3A::new(
+                std::f32::consts::FRAC_1_SQRT_2,
+                std::f32::consts::FRAC_1_SQRT_2,
+                0.0,
+            ),
+        );
+    }
+
+    #[test]
+    fn disabled_channels_return_identity_offsets() {
+        let output = solve_append_transform(AppendPrimitiveInput {
+            source_position_offset: Vec3A::new(2.0, 0.0, 0.0),
+            source_rotation: Quat::from_rotation_y(1.0),
+            ratio: 1.0,
+            affect_rotation: false,
+            affect_translation: false,
+        });
+
+        assert_vec3a_near(output.position_offset, Vec3A::ZERO);
+        assert_eq!(output.rotation, Quat::IDENTITY);
+    }
+
+    #[test]
+    fn dependency_order_characterization_keeps_known_append_delta_bounded() {
+        let source_local = Quat::from_rotation_z(0.8);
+        let upstream = solve_append_transform(AppendPrimitiveInput {
+            source_position_offset: Vec3A::new(2.0, 0.0, 0.0),
+            source_rotation: source_local,
+            ratio: 0.5,
+            affect_rotation: true,
+            affect_translation: true,
+        });
+
+        let correct_order = solve_append_transform(AppendPrimitiveInput {
+            source_position_offset: upstream.position_offset,
+            source_rotation: upstream.rotation,
+            ratio: 0.5,
+            affect_rotation: true,
+            affect_translation: true,
+        });
+        let dependency_order = solve_append_transform(AppendPrimitiveInput {
+            source_position_offset: Vec3A::new(2.0, 0.0, 0.0),
+            source_rotation: source_local,
+            ratio: 0.5,
+            affect_rotation: true,
+            affect_translation: true,
+        });
+
+        let position_delta =
+            (correct_order.position_offset - dependency_order.position_offset).length();
+        let angular_delta = correct_order
+            .rotation
+            .angle_between(dependency_order.rotation);
+
+        assert!(
+            position_delta > 0.0 && angular_delta > 0.0,
+            "fixture must characterize a non-zero strict-order vs dependency-order delta"
+        );
+        assert!(
+            position_delta <= 0.5 && angular_delta <= 0.21,
+            "characterization budget widened unexpectedly: position_delta={position_delta} angular_delta={angular_delta}"
+        );
+    }
+
+    #[test]
+    fn append_primitive_is_bit_deterministic_in_current_process_profile() {
+        // The workspace currently enables glam fast-math; this test claims bit
+        // identity only for repeated solves in the same process/build profile.
+        let input = AppendPrimitiveInput {
+            source_position_offset: Vec3A::new(0.25, -0.5, 1.25),
+            source_rotation: Quat::from_rotation_y(0.7),
+            ratio: 0.375,
+            affect_rotation: true,
+            affect_translation: true,
+        };
+        let expected = solve_append_transform(input);
+        for _ in 0..32 {
+            let actual = solve_append_transform(input);
+            assert_eq!(
+                actual.position_offset.to_array().map(f32::to_bits),
+                expected.position_offset.to_array().map(f32::to_bits)
+            );
+            assert_eq!(
+                actual.rotation.to_array().map(f32::to_bits),
+                expected.rotation.to_array().map(f32::to_bits)
+            );
+        }
+    }
+}

--- a/crates/mmd-anim-runtime/src/ik_primitive.rs
+++ b/crates/mmd-anim-runtime/src/ik_primitive.rs
@@ -1,0 +1,1092 @@
+use glam::{Mat4, Quat, Vec3A};
+
+use crate::IkAngleLimit;
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct IkChainLinkDefinition {
+    pub bone_slot: usize,
+    pub angle_limit: Option<IkAngleLimit>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct IkChainDefinition {
+    pub parent_slots: Vec<Option<usize>>,
+    pub rest_positions: Vec<Vec3A>,
+    pub fixed_axes: Vec<Option<Vec3A>>,
+    pub target_slot: usize,
+    pub links: Vec<IkChainLinkDefinition>,
+    pub iteration_count: u32,
+    pub limit_angle: f32,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct IkChainPoseInput<'a> {
+    pub parent_world_matrix: Option<Mat4>,
+    pub local_position_offsets: &'a [Vec3A],
+    pub local_rotations: &'a [Quat],
+    pub goal_position: Vec3A,
+    pub tolerance: f32,
+    pub max_iterations_cap: Option<u32>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct IkChainSolveOutput {
+    pub solved_link_rotations: Vec<Quat>,
+    pub final_distance: f32,
+    pub executed_iterations: u32,
+    pub link_steps: u32,
+}
+
+#[derive(Debug)]
+pub struct IkChainSolver {
+    definition: IkChainDefinition,
+    world_matrices: Vec<Mat4>,
+    local_rotations: Vec<Quat>,
+    base_rotations: Vec<Quat>,
+    ik_rotations: Vec<Quat>,
+    best_ik_rotations: Vec<Quat>,
+    chain_states: Vec<ChainLinkState>,
+}
+
+impl IkChainSolver {
+    pub fn new(definition: IkChainDefinition) -> Self {
+        let bone_count = definition.rest_positions.len();
+        let link_count = definition.links.len();
+        Self {
+            definition,
+            world_matrices: vec![Mat4::IDENTITY; bone_count],
+            local_rotations: vec![Quat::IDENTITY; bone_count],
+            base_rotations: Vec::with_capacity(link_count),
+            ik_rotations: Vec::with_capacity(link_count),
+            best_ik_rotations: Vec::with_capacity(link_count),
+            chain_states: Vec::with_capacity(link_count),
+        }
+    }
+
+    pub fn solve(&mut self, input: IkChainPoseInput<'_>) -> IkChainSolveOutput {
+        let tolerance = input.tolerance.max(0.0);
+        let iteration_count = input
+            .max_iterations_cap
+            .map(|cap| self.definition.iteration_count.min(cap))
+            .unwrap_or(self.definition.iteration_count)
+            .max(1) as usize;
+        let limit_angle = self.definition.limit_angle.max(0.0);
+        let link_count = self.definition.links.len();
+
+        self.local_rotations.copy_from_slice(input.local_rotations);
+        self.update_world_matrices(input);
+
+        self.base_rotations.clear();
+        self.base_rotations.extend(
+            self.definition
+                .links
+                .iter()
+                .map(|link| self.local_rotations[link.bone_slot]),
+        );
+        self.ik_rotations.clear();
+        self.ik_rotations.resize(link_count, Quat::IDENTITY);
+        self.best_ik_rotations.clear();
+        self.best_ik_rotations.resize(link_count, Quat::IDENTITY);
+        self.chain_states.clear();
+        self.chain_states
+            .resize_with(link_count, ChainLinkState::default);
+
+        self.apply_link_rotations();
+        self.update_world_matrices(input);
+
+        let mut final_distance = f32::MAX;
+        let mut best_distance = f32::MAX;
+        let mut executed_iterations = 0u32;
+        let mut link_steps = 0u32;
+
+        for iteration in 0..iteration_count {
+            let eff_pos = translation(self.world_matrices[self.definition.target_slot]);
+            final_distance = (eff_pos - input.goal_position).length();
+            if final_distance <= tolerance {
+                break;
+            }
+            executed_iterations += 1;
+
+            for link_index in 0..link_count {
+                let link = &self.definition.links[link_index];
+                let link_slot = link.bone_slot;
+
+                if link_slot == self.definition.target_slot {
+                    continue;
+                }
+
+                let link_world = self.world_matrices[link_slot];
+                let link_pos = translation(link_world);
+                let eff_pos = translation(self.world_matrices[self.definition.target_slot]);
+                let link_world_rot = rotation(link_world);
+                let local_effector = link_world_rot.inverse().mul_vec3a(eff_pos - link_pos);
+                let local_target = link_world_rot
+                    .inverse()
+                    .mul_vec3a(input.goal_position - link_pos);
+
+                if local_effector.length_squared() <= f32::EPSILON
+                    || local_target.length_squared() <= f32::EPSILON
+                {
+                    continue;
+                }
+
+                solve_link_step(LinkStepInput {
+                    local_effector: &local_effector,
+                    local_target: &local_target,
+                    link_index,
+                    base_rotations: &self.base_rotations,
+                    ik_rotations: &mut self.ik_rotations,
+                    chain_states: &mut self.chain_states,
+                    angle_limit: link.angle_limit,
+                    iteration,
+                    limit_angle,
+                });
+
+                self.apply_link_rotations();
+                self.update_world_matrices(input);
+                link_steps += 1;
+            }
+
+            let current_distance = {
+                let eff = translation(self.world_matrices[self.definition.target_slot]);
+                (eff - input.goal_position).length()
+            };
+            final_distance = current_distance;
+            if current_distance < best_distance {
+                best_distance = current_distance;
+                self.best_ik_rotations.copy_from_slice(&self.ik_rotations);
+                if current_distance <= tolerance {
+                    break;
+                }
+            } else {
+                self.ik_rotations.copy_from_slice(&self.best_ik_rotations);
+                self.apply_link_rotations();
+                self.update_world_matrices(input);
+                break;
+            }
+        }
+
+        self.ik_rotations.copy_from_slice(&self.best_ik_rotations);
+        self.apply_link_rotations();
+        self.update_world_matrices(input);
+
+        let solved_link_rotations = self
+            .definition
+            .links
+            .iter()
+            .map(|link| self.local_rotations[link.bone_slot])
+            .collect();
+
+        IkChainSolveOutput {
+            solved_link_rotations,
+            final_distance,
+            executed_iterations,
+            link_steps,
+        }
+    }
+
+    pub(crate) fn update_world_matrices(&mut self, input: IkChainPoseInput<'_>) {
+        update_mini_chain_world_matrices(
+            &self.definition,
+            input.parent_world_matrix.unwrap_or(Mat4::IDENTITY),
+            input.local_position_offsets,
+            &self.local_rotations,
+            &mut self.world_matrices,
+        );
+    }
+
+    fn apply_link_rotations(&mut self) {
+        for (i, link) in self.definition.links.iter().enumerate() {
+            let effective = (self.ik_rotations[i] * self.base_rotations[i]).normalize();
+            self.local_rotations[link.bone_slot] = constrain_rotation_to_axis_if_needed(
+                effective,
+                self.definition.fixed_axes[link.bone_slot],
+            );
+        }
+    }
+}
+
+pub(crate) fn update_mini_chain_world_matrices(
+    definition: &IkChainDefinition,
+    parent_world_matrix: Mat4,
+    local_position_offsets: &[Vec3A],
+    local_rotations: &[Quat],
+    world_matrices: &mut [Mat4],
+) {
+    for slot in 0..definition.rest_positions.len() {
+        let local_position = definition.rest_positions[slot] + local_position_offsets[slot];
+        let local_rotation = constrain_rotation_to_axis_if_needed(
+            local_rotations[slot],
+            definition.fixed_axes[slot],
+        );
+        let local_matrix = Mat4::from_scale_rotation_translation(
+            Vec3A::ONE.into(),
+            local_rotation,
+            local_position.into(),
+        );
+        world_matrices[slot] = match definition.parent_slots[slot] {
+            Some(parent) => world_matrices[parent] * local_matrix,
+            None => parent_world_matrix * local_matrix,
+        };
+    }
+}
+
+pub(crate) fn solve_link_step(input: LinkStepInput<'_>) {
+    let single_axis = get_single_axis_limit(input.angle_limit);
+    if let (Some(angle_limit), Some(axis_index)) = (input.angle_limit, single_axis) {
+        solve_plane_link_step(PlaneLinkStepInput {
+            local_effector: input.local_effector,
+            local_target: input.local_target,
+            link_index: input.link_index,
+            base_rotations: input.base_rotations,
+            ik_rotations: input.ik_rotations,
+            chain_states: input.chain_states,
+            axis_index,
+            limits: angle_limit,
+            iteration: input.iteration,
+            limit_angle: input.limit_angle,
+        });
+    } else if let Some(angle_limit) = input.angle_limit {
+        solve_limited_axes_link_step(LimitedAxesLinkStepInput {
+            local_effector: input.local_effector,
+            local_target: input.local_target,
+            link_index: input.link_index,
+            base_rotations: input.base_rotations,
+            ik_rotations: input.ik_rotations,
+            chain_states: input.chain_states,
+            limits: angle_limit,
+            limit_angle: input.limit_angle,
+        });
+    } else {
+        solve_unconstrained_link_step(UnconstrainedLinkStepInput {
+            local_effector: input.local_effector,
+            local_target: input.local_target,
+            link_index: input.link_index,
+            base_rotations: input.base_rotations,
+            ik_rotations: input.ik_rotations,
+            limit_angle: input.limit_angle,
+        });
+    }
+}
+
+pub(crate) struct LinkStepInput<'a> {
+    pub local_effector: &'a Vec3A,
+    pub local_target: &'a Vec3A,
+    pub link_index: usize,
+    pub base_rotations: &'a [Quat],
+    pub ik_rotations: &'a mut [Quat],
+    pub chain_states: &'a mut [ChainLinkState],
+    pub angle_limit: Option<IkAngleLimit>,
+    pub iteration: usize,
+    pub limit_angle: f32,
+}
+
+struct UnconstrainedLinkStepInput<'a> {
+    local_effector: &'a Vec3A,
+    local_target: &'a Vec3A,
+    link_index: usize,
+    base_rotations: &'a [Quat],
+    ik_rotations: &'a mut [Quat],
+    limit_angle: f32,
+}
+
+fn solve_unconstrained_link_step(input: UnconstrainedLinkStepInput<'_>) {
+    let local_eff_n = input.local_effector.normalize();
+    let local_tgt_n = input.local_target.normalize();
+    let dot = local_eff_n.dot(local_tgt_n).clamp(-1.0, 1.0);
+    let mut angle = dot.acos();
+
+    let tiny_angle = 1e-3 * std::f32::consts::PI / 180.0;
+    if angle < tiny_angle {
+        return;
+    }
+
+    if input.limit_angle > 0.0 {
+        angle = angle.min(input.limit_angle);
+    }
+
+    let axis = local_eff_n.cross(local_tgt_n);
+    let axis_vec = if axis.length() < 1e-5 {
+        if dot > -1.0 + 1e-5 {
+            return;
+        }
+        let basis = if local_eff_n.x.abs() < 0.9 {
+            Vec3A::new(1.0, 0.0, 0.0)
+        } else {
+            Vec3A::new(0.0, 1.0, 0.0)
+        };
+        local_eff_n.cross(basis).normalize()
+    } else {
+        axis.normalize()
+    };
+
+    let delta = Quat::from_axis_angle(axis_vec.into(), angle);
+    let base = input.base_rotations[input.link_index];
+    let ik = input.ik_rotations[input.link_index];
+    let chain_rotation = (ik * base * delta).normalize();
+
+    input.ik_rotations[input.link_index] = (chain_rotation * base.inverse()).normalize();
+}
+
+pub(crate) fn translation(matrix: Mat4) -> Vec3A {
+    Vec3A::from_vec4(matrix.w_axis)
+}
+
+pub(crate) fn rotation(matrix: Mat4) -> Quat {
+    matrix.to_scale_rotation_translation().1
+}
+
+pub(crate) fn constrain_rotation_to_axis(rotation: Quat, axis: Vec3A) -> Quat {
+    let axis = axis.normalize();
+    let vector = Vec3A::new(rotation.x, rotation.y, rotation.z);
+    let projected = axis * vector.dot(axis);
+    let twist = Quat::from_xyzw(projected.x, projected.y, projected.z, rotation.w);
+    if twist.length_squared() <= f32::EPSILON {
+        Quat::IDENTITY
+    } else {
+        twist.normalize()
+    }
+}
+
+fn constrain_rotation_to_axis_if_needed(rotation: Quat, axis: Option<Vec3A>) -> Quat {
+    axis.map_or(rotation, |axis| constrain_rotation_to_axis(rotation, axis))
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub(crate) struct ChainLinkState {
+    pub previous_euler: [f32; 3],
+    pub plane_mode_angle: f32,
+}
+
+pub(crate) fn get_single_axis_limit(limit: Option<IkAngleLimit>) -> Option<usize> {
+    let limit = limit?;
+    let has = [
+        limit.min.x != 0.0 || limit.max.x != 0.0,
+        limit.min.y != 0.0 || limit.max.y != 0.0,
+        limit.min.z != 0.0 || limit.max.z != 0.0,
+    ];
+    if has[0]
+        && limit.min.y == 0.0
+        && limit.max.y == 0.0
+        && limit.min.z == 0.0
+        && limit.max.z == 0.0
+    {
+        return Some(0);
+    }
+    if has[1]
+        && limit.min.x == 0.0
+        && limit.max.x == 0.0
+        && limit.min.z == 0.0
+        && limit.max.z == 0.0
+    {
+        return Some(1);
+    }
+    if has[2]
+        && limit.min.x == 0.0
+        && limit.max.x == 0.0
+        && limit.min.y == 0.0
+        && limit.max.y == 0.0
+    {
+        return Some(2);
+    }
+    None
+}
+
+pub(crate) fn quat_to_rotation_mat3(rotation: Quat) -> [f32; 9] {
+    let [x, y, z, w] = rotation.normalize().to_array();
+    let x2 = x + x;
+    let y2 = y + y;
+    let z2 = z + z;
+    let xx = x * x2;
+    let xy = x * y2;
+    let xz = x * z2;
+    let yy = y * y2;
+    let yz = y * z2;
+    let zz = z * z2;
+    let wx = w * x2;
+    let wy = w * y2;
+    let wz = w * z2;
+    [
+        1.0 - (yy + zz),
+        xy + wz,
+        xz - wy,
+        xy - wz,
+        1.0 - (xx + zz),
+        yz + wx,
+        xz + wy,
+        yz - wx,
+        1.0 - (xx + yy),
+    ]
+}
+
+pub(crate) fn decompose_euler_xyz(mat: &[f32; 9], before: &[f32; 3]) -> [f32; 3] {
+    let sy = -mat[2];
+    let mut result: [f32; 3];
+    if 1.0 - sy.abs() < 1e-6 {
+        let y = sy.asin();
+        let sx = before[0].sin();
+        let sz = before[2].sin();
+        if sx.abs() < sz.abs() {
+            let cx = before[0].cos();
+            result = if cx > 0.0 {
+                [0.0, y, (-mat[3]).asin()]
+            } else {
+                [std::f32::consts::PI, y, mat[3].asin()]
+            };
+        } else {
+            let cz = before[2].cos();
+            result = if cz > 0.0 {
+                [(-mat[7]).asin(), y, 0.0]
+            } else {
+                [mat[7].asin(), y, std::f32::consts::PI]
+            };
+        }
+    } else {
+        result = [mat[5].atan2(mat[8]), (-mat[2]).asin(), mat[1].atan2(mat[0])];
+    }
+
+    let pi = std::f32::consts::PI;
+    let candidates: [[f32; 3]; 8] = [
+        [result[0] + pi, pi - result[1], result[2] + pi],
+        [result[0] + pi, pi - result[1], result[2] - pi],
+        [result[0] + pi, -pi - result[1], result[2] + pi],
+        [result[0] + pi, -pi - result[1], result[2] - pi],
+        [result[0] - pi, pi - result[1], result[2] + pi],
+        [result[0] - pi, pi - result[1], result[2] - pi],
+        [result[0] - pi, -pi - result[1], result[2] + pi],
+        [result[0] - pi, -pi - result[1], result[2] - pi],
+    ];
+    let mut min_error = diff_angle(result[0], before[0]).abs()
+        + diff_angle(result[1], before[1]).abs()
+        + diff_angle(result[2], before[2]).abs();
+    for candidate in &candidates {
+        let error = diff_angle(candidate[0], before[0]).abs()
+            + diff_angle(candidate[1], before[1]).abs()
+            + diff_angle(candidate[2], before[2]).abs();
+        if error < min_error {
+            min_error = error;
+            result = *candidate;
+        }
+    }
+    result
+}
+
+fn diff_angle(a: f32, b: f32) -> f32 {
+    let diff = normalize_angle(a) - normalize_angle(b);
+    if diff > std::f32::consts::PI {
+        diff - std::f32::consts::TAU
+    } else if diff < -std::f32::consts::PI {
+        diff + std::f32::consts::TAU
+    } else {
+        diff
+    }
+}
+
+fn normalize_angle(angle: f32) -> f32 {
+    let mut result = angle;
+    while result >= std::f32::consts::TAU {
+        result -= std::f32::consts::TAU;
+    }
+    while result < 0.0 {
+        result += std::f32::consts::TAU;
+    }
+    result
+}
+
+pub(crate) fn euler_xyz_to_quat(euler: &[f32; 3]) -> Quat {
+    let [x, y, z] = *euler;
+    let c1 = (x / 2.0).cos();
+    let c2 = (y / 2.0).cos();
+    let c3 = (z / 2.0).cos();
+    let s1 = (x / 2.0).sin();
+    let s2 = (y / 2.0).sin();
+    let s3 = (z / 2.0).sin();
+    Quat::from_xyzw(
+        s1 * c2 * c3 + c1 * s2 * s3,
+        c1 * s2 * c3 - s1 * c2 * s3,
+        c1 * c2 * s3 + s1 * s2 * c3,
+        c1 * c2 * c3 - s1 * s2 * s3,
+    )
+}
+
+pub(crate) struct LimitedAxesLinkStepInput<'a> {
+    pub local_effector: &'a Vec3A,
+    pub local_target: &'a Vec3A,
+    pub link_index: usize,
+    pub base_rotations: &'a [Quat],
+    pub ik_rotations: &'a mut [Quat],
+    pub chain_states: &'a mut [ChainLinkState],
+    pub limits: IkAngleLimit,
+    pub limit_angle: f32,
+}
+
+pub(crate) fn solve_limited_axes_link_step(input: LimitedAxesLinkStepInput<'_>) {
+    let state = &mut input.chain_states[input.link_index];
+    let base = input.base_rotations[input.link_index];
+    let current = (input.ik_rotations[input.link_index] * base).normalize();
+    let current_mat = quat_to_rotation_mat3(current);
+    let mut total_euler = decompose_euler_xyz(&current_mat, &state.previous_euler);
+    let mut working_effector = *input.local_effector;
+    let target = input.local_target.normalize();
+
+    // PMX local_axis is intentionally not used as an angle-limit basis in v1.
+    // It remains rig metadata / host control orientation only to preserve the
+    // existing whole-runtime IK behavior.
+    for axis_index in [2usize, 1, 0] {
+        let (lower, upper) = limit_axis_bounds(input.limits, axis_index);
+        if lower == 0.0 && upper == 0.0 {
+            let next = total_euler[axis_index].clamp(lower, upper);
+            let applied = next - total_euler[axis_index];
+            total_euler[axis_index] = next;
+            if applied.abs() > 0.0 {
+                working_effector = Quat::from_axis_angle(axis_vec(axis_index).into(), applied)
+                    .mul_vec3a(working_effector);
+            }
+            continue;
+        }
+
+        let axis = axis_vec(axis_index);
+        let signed_angle = signed_projected_angle(working_effector, target, axis);
+        if signed_angle.abs() <= 1.0e-6 {
+            continue;
+        }
+        let step = if input.limit_angle > 0.0 {
+            signed_angle.clamp(-input.limit_angle, input.limit_angle)
+        } else {
+            signed_angle
+        };
+        let next = (total_euler[axis_index] + step).clamp(lower, upper);
+        let applied = next - total_euler[axis_index];
+        total_euler[axis_index] = next;
+        if applied.abs() > 0.0 {
+            working_effector =
+                Quat::from_axis_angle(axis.into(), applied).mul_vec3a(working_effector);
+        }
+    }
+
+    state.previous_euler = total_euler;
+    let chain_rotation = euler_xyz_to_quat(&total_euler).normalize();
+    input.ik_rotations[input.link_index] = (chain_rotation * base.inverse()).normalize();
+}
+
+pub(crate) fn limit_axis_bounds(limits: IkAngleLimit, axis_index: usize) -> (f32, f32) {
+    match axis_index {
+        0 => (limits.min.x, limits.max.x),
+        1 => (limits.min.y, limits.max.y),
+        _ => (limits.min.z, limits.max.z),
+    }
+}
+
+pub(crate) fn axis_vec(axis_index: usize) -> Vec3A {
+    match axis_index {
+        0 => Vec3A::new(1.0, 0.0, 0.0),
+        1 => Vec3A::new(0.0, 1.0, 0.0),
+        _ => Vec3A::new(0.0, 0.0, 1.0),
+    }
+}
+
+pub(crate) fn signed_projected_angle(from: Vec3A, to: Vec3A, axis: Vec3A) -> f32 {
+    let projected_from = from - axis * from.dot(axis);
+    let projected_to = to - axis * to.dot(axis);
+    if projected_from.length_squared() <= f32::EPSILON
+        || projected_to.length_squared() <= f32::EPSILON
+    {
+        return 0.0;
+    }
+    let from_n = projected_from.normalize();
+    let to_n = projected_to.normalize();
+    let dot = from_n.dot(to_n).clamp(-1.0, 1.0);
+    let angle = dot.acos();
+    let sign = axis.dot(from_n.cross(to_n)).signum();
+    angle * if sign == 0.0 { 1.0 } else { sign }
+}
+
+pub(crate) struct PlaneLinkStepInput<'a> {
+    pub local_effector: &'a Vec3A,
+    pub local_target: &'a Vec3A,
+    pub link_index: usize,
+    pub base_rotations: &'a [Quat],
+    pub ik_rotations: &'a mut [Quat],
+    pub chain_states: &'a mut [ChainLinkState],
+    pub axis_index: usize,
+    pub limits: IkAngleLimit,
+    pub iteration: usize,
+    pub limit_angle: f32,
+}
+
+pub(crate) fn solve_plane_link_step(input: PlaneLinkStepInput<'_>) {
+    let rotate_axis = match input.axis_index {
+        0 => Vec3A::new(1.0, 0.0, 0.0),
+        1 => Vec3A::new(0.0, 1.0, 0.0),
+        _ => Vec3A::new(0.0, 0.0, 1.0),
+    };
+    let local_eff_n = input.local_effector.normalize();
+    let local_tgt_n = input.local_target.normalize();
+
+    let dot = local_eff_n.dot(local_tgt_n).clamp(-1.0, 1.0);
+    let raw_angle = dot.acos();
+    let capped_angle = if input.limit_angle > 0.0 {
+        raw_angle.min(input.limit_angle)
+    } else {
+        raw_angle
+    };
+
+    let target_vec1 =
+        Quat::from_axis_angle(rotate_axis.into(), capped_angle).mul_vec3a(local_eff_n);
+    let target_vec2 =
+        Quat::from_axis_angle(rotate_axis.into(), -capped_angle).mul_vec3a(local_eff_n);
+    let signed_angle = if target_vec1.dot(local_tgt_n) > target_vec2.dot(local_tgt_n) {
+        capped_angle
+    } else {
+        -capped_angle
+    };
+
+    let state = &mut input.chain_states[input.link_index];
+    let mut next_angle = state.plane_mode_angle + signed_angle;
+    let (lower, upper) = match input.axis_index {
+        0 => (input.limits.min.x, input.limits.max.x),
+        1 => (input.limits.min.y, input.limits.max.y),
+        _ => (input.limits.min.z, input.limits.max.z),
+    };
+    let base = input.base_rotations[input.link_index];
+
+    if input.iteration == 0 && (next_angle < lower || next_angle > upper) {
+        if -next_angle > lower && -next_angle < upper {
+            next_angle = -next_angle;
+        } else {
+            let half = (lower + upper) * 0.5;
+            if (half - next_angle).abs() > (half + next_angle).abs() {
+                next_angle = -next_angle;
+            }
+        }
+    }
+
+    state.plane_mode_angle = next_angle.clamp(lower, upper);
+    let chain_rotation = Quat::from_axis_angle(rotate_axis.into(), state.plane_mode_angle);
+    input.ik_rotations[input.link_index] = (chain_rotation * base.inverse()).normalize();
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::*;
+    use crate::{BoneIndex, BoneInit, IkLinkInit, IkSolverInit, ModelArena, RuntimeInstance};
+
+    fn assert_vec3a_near(actual: Vec3A, expected: Vec3A) {
+        let delta = (actual - expected).abs();
+        assert!(
+            delta.x < 1.0e-5 && delta.y < 1.0e-5 && delta.z < 1.0e-5,
+            "actual={actual:?} expected={expected:?} delta={delta:?}"
+        );
+    }
+
+    fn assert_quat_near(actual: Quat, expected: Quat) {
+        let actual = actual.to_array();
+        let expected = expected.to_array();
+        let delta = [
+            (actual[0] - expected[0]).abs(),
+            (actual[1] - expected[1]).abs(),
+            (actual[2] - expected[2]).abs(),
+            (actual[3] - expected[3]).abs(),
+        ];
+        assert!(
+            delta[0] < 1.0e-5 && delta[1] < 1.0e-5 && delta[2] < 1.0e-5 && delta[3] < 1.0e-5,
+            "actual={actual:?} expected={expected:?} delta={delta:?}"
+        );
+    }
+
+    fn one_link_definition(angle_limit: Option<IkAngleLimit>) -> IkChainDefinition {
+        IkChainDefinition {
+            parent_slots: vec![None, Some(0)],
+            rest_positions: vec![Vec3A::ZERO, Vec3A::X],
+            fixed_axes: vec![None, None],
+            target_slot: 1,
+            links: vec![IkChainLinkDefinition {
+                bone_slot: 0,
+                angle_limit,
+            }],
+            iteration_count: 1,
+            limit_angle: 0.0,
+        }
+    }
+
+    #[test]
+    fn mini_chain_world_update_uses_identity_when_parent_world_is_unspecified() {
+        let definition = one_link_definition(None);
+        let mut world = vec![Mat4::IDENTITY; 2];
+        update_mini_chain_world_matrices(
+            &definition,
+            Mat4::IDENTITY,
+            &[Vec3A::ZERO, Vec3A::new(0.0, 2.0, 0.0)],
+            &[
+                Quat::from_rotation_z(std::f32::consts::FRAC_PI_2),
+                Quat::IDENTITY,
+            ],
+            &mut world,
+        );
+
+        assert_vec3a_near(translation(world[1]), Vec3A::new(-2.0, 1.0, 0.0));
+    }
+
+    #[test]
+    fn primitive_matches_full_runtime_for_unconstrained_chain() {
+        let model = Arc::new(
+            ModelArena::new_with_ik(
+                vec![
+                    BoneInit::new(None, Vec3A::ZERO),
+                    BoneInit::new(Some(BoneIndex(0)), Vec3A::X),
+                    BoneInit::new(None, Vec3A::Y),
+                ],
+                vec![IkSolverInit {
+                    ik_bone: BoneIndex(2),
+                    target_bone: BoneIndex(1),
+                    links: vec![IkLinkInit::new(BoneIndex(0))],
+                    iteration_count: 1,
+                    limit_angle: 0.0,
+                }],
+            )
+            .unwrap(),
+        );
+        let mut runtime = RuntimeInstance::new(model);
+        runtime.evaluate_current_pose();
+
+        let mut solver = IkChainSolver::new(one_link_definition(None));
+        let local_position_offsets = [Vec3A::ZERO; 2];
+        let local_rotations = [Quat::IDENTITY; 2];
+        let output = solver.solve(IkChainPoseInput {
+            parent_world_matrix: None,
+            local_position_offsets: &local_position_offsets,
+            local_rotations: &local_rotations,
+            goal_position: Vec3A::Y,
+            tolerance: 1.0e-2,
+            max_iterations_cap: None,
+        });
+
+        assert_quat_near(
+            output.solved_link_rotations[0],
+            runtime.pose().local_rotation(BoneIndex(0)),
+        );
+    }
+
+    #[test]
+    fn primitive_matches_full_runtime_for_two_link_unconstrained_chain() {
+        let model = Arc::new(
+            ModelArena::new_with_ik(
+                vec![
+                    BoneInit::new(None, Vec3A::ZERO),
+                    BoneInit::new(Some(BoneIndex(0)), Vec3A::X),
+                    BoneInit::new(Some(BoneIndex(1)), Vec3A::X),
+                    BoneInit::new(None, Vec3A::new(1.0, 1.0, 0.0)),
+                ],
+                vec![IkSolverInit {
+                    ik_bone: BoneIndex(3),
+                    target_bone: BoneIndex(2),
+                    links: vec![IkLinkInit::new(BoneIndex(1)), IkLinkInit::new(BoneIndex(0))],
+                    iteration_count: 4,
+                    limit_angle: 0.0,
+                }],
+            )
+            .unwrap(),
+        );
+        let mut runtime = RuntimeInstance::new(model);
+        runtime.evaluate_current_pose();
+
+        let definition = IkChainDefinition {
+            parent_slots: vec![None, Some(0), Some(1)],
+            rest_positions: vec![Vec3A::ZERO, Vec3A::X, Vec3A::X],
+            fixed_axes: vec![None, None, None],
+            target_slot: 2,
+            links: vec![
+                IkChainLinkDefinition {
+                    bone_slot: 1,
+                    angle_limit: None,
+                },
+                IkChainLinkDefinition {
+                    bone_slot: 0,
+                    angle_limit: None,
+                },
+            ],
+            iteration_count: 4,
+            limit_angle: 0.0,
+        };
+        let mut solver = IkChainSolver::new(definition);
+        let local_position_offsets = [Vec3A::ZERO; 3];
+        let local_rotations = [Quat::IDENTITY; 3];
+        let output = solver.solve(IkChainPoseInput {
+            parent_world_matrix: None,
+            local_position_offsets: &local_position_offsets,
+            local_rotations: &local_rotations,
+            goal_position: Vec3A::new(1.0, 1.0, 0.0),
+            tolerance: 1.0e-2,
+            max_iterations_cap: None,
+        });
+
+        assert_quat_near(
+            output.solved_link_rotations[0],
+            runtime.pose().local_rotation(BoneIndex(1)),
+        );
+        assert_quat_near(
+            output.solved_link_rotations[1],
+            runtime.pose().local_rotation(BoneIndex(0)),
+        );
+    }
+
+    #[test]
+    fn deform_order_characterization_keeps_known_ik_delta_bounded() {
+        fn solve_one_pass(
+            definition: &IkChainDefinition,
+            goal_position: Vec3A,
+            strict: bool,
+        ) -> Vec<Quat> {
+            let local_position_offsets = vec![Vec3A::ZERO; definition.rest_positions.len()];
+            let mut local_rotations = vec![Quat::IDENTITY; definition.rest_positions.len()];
+            let base_rotations = vec![Quat::IDENTITY; definition.links.len()];
+            let mut ik_rotations = vec![Quat::IDENTITY; definition.links.len()];
+            let mut chain_states = vec![ChainLinkState::default(); definition.links.len()];
+            let mut world_matrices = vec![Mat4::IDENTITY; definition.rest_positions.len()];
+
+            update_mini_chain_world_matrices(
+                definition,
+                Mat4::IDENTITY,
+                &local_position_offsets,
+                &local_rotations,
+                &mut world_matrices,
+            );
+
+            for link_index in 0..definition.links.len() {
+                let link = &definition.links[link_index];
+                let link_slot = link.bone_slot;
+                let link_world = world_matrices[link_slot];
+                let link_pos = translation(link_world);
+                let eff_pos = translation(world_matrices[definition.target_slot]);
+                let link_world_rot = rotation(link_world);
+                let local_effector = link_world_rot.inverse().mul_vec3a(eff_pos - link_pos);
+                let local_target = link_world_rot.inverse().mul_vec3a(goal_position - link_pos);
+
+                solve_link_step(LinkStepInput {
+                    local_effector: &local_effector,
+                    local_target: &local_target,
+                    link_index,
+                    base_rotations: &base_rotations,
+                    ik_rotations: &mut ik_rotations,
+                    chain_states: &mut chain_states,
+                    angle_limit: link.angle_limit,
+                    iteration: 0,
+                    limit_angle: definition.limit_angle,
+                });
+
+                if strict {
+                    local_rotations[link_slot] = ik_rotations[link_index].normalize();
+                    update_mini_chain_world_matrices(
+                        definition,
+                        Mat4::IDENTITY,
+                        &local_position_offsets,
+                        &local_rotations,
+                        &mut world_matrices,
+                    );
+                }
+            }
+
+            if !strict {
+                for (link_index, link) in definition.links.iter().enumerate() {
+                    local_rotations[link.bone_slot] = ik_rotations[link_index].normalize();
+                }
+                update_mini_chain_world_matrices(
+                    definition,
+                    Mat4::IDENTITY,
+                    &local_position_offsets,
+                    &local_rotations,
+                    &mut world_matrices,
+                );
+            }
+
+            definition
+                .links
+                .iter()
+                .map(|link| local_rotations[link.bone_slot])
+                .collect()
+        }
+
+        let definition = IkChainDefinition {
+            parent_slots: vec![None, Some(0), Some(1)],
+            rest_positions: vec![Vec3A::ZERO, Vec3A::X, Vec3A::X],
+            fixed_axes: vec![None, None, None],
+            target_slot: 2,
+            links: vec![
+                IkChainLinkDefinition {
+                    bone_slot: 1,
+                    angle_limit: None,
+                },
+                IkChainLinkDefinition {
+                    bone_slot: 0,
+                    angle_limit: None,
+                },
+            ],
+            iteration_count: 1,
+            limit_angle: 0.0,
+        };
+        let goal_position = Vec3A::new(1.0, 1.0, 0.0);
+
+        let correct_order = solve_one_pass(&definition, goal_position, true);
+        let dependency_order = solve_one_pass(&definition, goal_position, false);
+        let max_angular_delta = correct_order
+            .iter()
+            .zip(&dependency_order)
+            .map(|(correct, dependency)| correct.angle_between(*dependency))
+            .fold(0.0f32, f32::max);
+
+        assert!(
+            max_angular_delta > 0.0,
+            "fixture must characterize a non-zero strict-order vs dependency-order IK delta"
+        );
+        assert!(
+            max_angular_delta <= 0.79,
+            "characterization budget widened unexpectedly: max_angular_delta={max_angular_delta}"
+        );
+    }
+
+    #[test]
+    fn primitive_matches_full_runtime_for_knee_plane_limit() {
+        let limit = IkAngleLimit::new(
+            Vec3A::new(0.0, 0.0, 0.0),
+            Vec3A::new(0.0, 0.0, std::f32::consts::FRAC_PI_4),
+        );
+        let model = Arc::new(
+            ModelArena::new_with_ik(
+                vec![
+                    BoneInit::new(None, Vec3A::ZERO),
+                    BoneInit::new(Some(BoneIndex(0)), Vec3A::X),
+                    BoneInit::new(None, Vec3A::Y),
+                ],
+                vec![IkSolverInit {
+                    ik_bone: BoneIndex(2),
+                    target_bone: BoneIndex(1),
+                    links: vec![IkLinkInit::new(BoneIndex(0)).with_angle_limit(limit)],
+                    iteration_count: 1,
+                    limit_angle: 0.0,
+                }],
+            )
+            .unwrap(),
+        );
+        let mut runtime = RuntimeInstance::new(model);
+        runtime.evaluate_current_pose();
+
+        let mut solver = IkChainSolver::new(one_link_definition(Some(limit)));
+        let local_position_offsets = [Vec3A::ZERO; 2];
+        let local_rotations = [Quat::IDENTITY; 2];
+        let output = solver.solve(IkChainPoseInput {
+            parent_world_matrix: None,
+            local_position_offsets: &local_position_offsets,
+            local_rotations: &local_rotations,
+            goal_position: Vec3A::Y,
+            tolerance: 1.0e-2,
+            max_iterations_cap: None,
+        });
+
+        assert_quat_near(
+            output.solved_link_rotations[0],
+            runtime.pose().local_rotation(BoneIndex(0)),
+        );
+    }
+
+    #[test]
+    fn primitive_matches_full_runtime_for_limited_axes_chain() {
+        let limit = IkAngleLimit::new(Vec3A::new(0.0, -0.6, -0.6), Vec3A::new(0.0, 0.6, 0.6));
+        let goal = Vec3A::new(0.25, 0.55, 0.80).normalize();
+        let model = Arc::new(
+            ModelArena::new_with_ik(
+                vec![
+                    BoneInit::new(None, Vec3A::ZERO),
+                    BoneInit::new(Some(BoneIndex(0)), Vec3A::X),
+                    BoneInit::new(None, goal),
+                ],
+                vec![IkSolverInit {
+                    ik_bone: BoneIndex(2),
+                    target_bone: BoneIndex(1),
+                    links: vec![IkLinkInit::new(BoneIndex(0)).with_angle_limit(limit)],
+                    iteration_count: 1,
+                    limit_angle: 0.0,
+                }],
+            )
+            .unwrap(),
+        );
+        let mut runtime = RuntimeInstance::new(model);
+        runtime.evaluate_current_pose();
+
+        let mut solver = IkChainSolver::new(one_link_definition(Some(limit)));
+        let local_position_offsets = [Vec3A::ZERO; 2];
+        let local_rotations = [Quat::IDENTITY; 2];
+        let output = solver.solve(IkChainPoseInput {
+            parent_world_matrix: None,
+            local_position_offsets: &local_position_offsets,
+            local_rotations: &local_rotations,
+            goal_position: goal,
+            tolerance: 1.0e-2,
+            max_iterations_cap: None,
+        });
+
+        assert_quat_near(
+            output.solved_link_rotations[0],
+            runtime.pose().local_rotation(BoneIndex(0)),
+        );
+    }
+
+    #[test]
+    fn primitive_is_bit_deterministic_in_current_process_profile() {
+        // The workspace currently enables glam fast-math; this test asserts
+        // bit identity only across repeated solves in this same build profile.
+        let definition = IkChainDefinition {
+            parent_slots: vec![None, Some(0), Some(1)],
+            rest_positions: vec![Vec3A::ZERO, Vec3A::X, Vec3A::X],
+            fixed_axes: vec![None, None, None],
+            target_slot: 2,
+            links: vec![
+                IkChainLinkDefinition {
+                    bone_slot: 1,
+                    angle_limit: None,
+                },
+                IkChainLinkDefinition {
+                    bone_slot: 0,
+                    angle_limit: None,
+                },
+            ],
+            iteration_count: 4,
+            limit_angle: 0.0,
+        };
+        let local_position_offsets = [Vec3A::ZERO; 3];
+        let local_rotations = [Quat::IDENTITY; 3];
+        let input = IkChainPoseInput {
+            parent_world_matrix: None,
+            local_position_offsets: &local_position_offsets,
+            local_rotations: &local_rotations,
+            goal_position: Vec3A::new(1.0, 1.0, 0.0),
+            tolerance: 1.0e-2,
+            max_iterations_cap: None,
+        };
+        let mut baseline_solver = IkChainSolver::new(definition.clone());
+        let expected = baseline_solver.solve(input);
+
+        for _ in 0..32 {
+            let mut solver = IkChainSolver::new(definition.clone());
+            let actual = solver.solve(input);
+            assert_eq!(
+                actual.final_distance.to_bits(),
+                expected.final_distance.to_bits()
+            );
+            assert_eq!(actual.executed_iterations, expected.executed_iterations);
+            assert_eq!(actual.link_steps, expected.link_steps);
+            let actual_bits: Vec<_> = actual
+                .solved_link_rotations
+                .iter()
+                .map(|q| q.to_array().map(f32::to_bits))
+                .collect();
+            let expected_bits: Vec<_> = expected
+                .solved_link_rotations
+                .iter()
+                .map(|q| q.to_array().map(f32::to_bits))
+                .collect();
+            assert_eq!(actual_bits, expected_bits);
+        }
+    }
+}

--- a/crates/mmd-anim-runtime/src/lib.rs
+++ b/crates/mmd-anim-runtime/src/lib.rs
@@ -5,6 +5,8 @@
 //! crate and read contiguous output buffers back.
 
 mod animation;
+pub mod append_primitive;
+pub mod ik_primitive;
 mod model;
 mod pose;
 mod runtime;
@@ -13,6 +15,10 @@ pub use animation::{
     AnimationClip, BoneAnimationBinding, InterpolationScalar, InterpolationVector3,
     MorphAnimationBinding, MorphKeyframe, MorphTrack, MovableBoneKeyframe, MovableBoneTrack,
     PropertyAnimationBinding, PropertyKeyframe,
+};
+pub use append_primitive::{AppendPrimitiveInput, AppendPrimitiveOutput, solve_append_transform};
+pub use ik_primitive::{
+    IkChainDefinition, IkChainLinkDefinition, IkChainPoseInput, IkChainSolveOutput, IkChainSolver,
 };
 pub use model::{
     AppendTransform, AppendTransformInit, BoneIndex, BoneInit, BoneMorphOffset, GroupMorphOffset,

--- a/crates/mmd-anim-runtime/src/runtime.rs
+++ b/crates/mmd-anim-runtime/src/runtime.rs
@@ -1,8 +1,22 @@
 use std::sync::Arc;
 
-use glam::{Mat4, Quat, Vec3A};
+use glam::{Mat4, Quat};
 
 use crate::{AnimationClip, ModelArena, MorphIndex, PoseArena};
+use crate::{
+    append_primitive::{AppendPrimitiveInput, solve_append_transform},
+    ik_primitive::{
+        ChainLinkState, LinkStepInput, constrain_rotation_to_axis, rotation, solve_link_step,
+        translation,
+    },
+};
+
+#[cfg(test)]
+use crate::ik_primitive::{
+    LimitedAxesLinkStepInput, PlaneLinkStepInput, axis_vec, decompose_euler_xyz, euler_xyz_to_quat,
+    limit_axis_bounds, quat_to_rotation_mat3, signed_projected_angle, solve_limited_axes_link_step,
+    solve_plane_link_step,
+};
 
 #[derive(Debug)]
 struct IkScratch {
@@ -178,39 +192,36 @@ impl RuntimeInstance {
 
             if let Some(append_index) = self.model.append_transform_index(*bone) {
                 let append = self.model.append_transform(append_index);
+                let use_source_append = !append.local
+                    && self
+                        .model
+                        .append_transform_index(append.source_bone)
+                        .is_some();
+                let source_rotation = if use_source_append {
+                    self.pose.append_rotation(append.source_bone)
+                } else {
+                    self.pose.local_rotation(append.source_bone)
+                };
+                let source_position_offset = if use_source_append {
+                    self.pose.append_position_offset(append.source_bone)
+                } else {
+                    self.pose.local_position_offset(append.source_bone)
+                };
+                let append_output = solve_append_transform(AppendPrimitiveInput {
+                    source_position_offset,
+                    source_rotation,
+                    ratio: append.ratio,
+                    affect_rotation: append.affect_rotation,
+                    affect_translation: append.affect_translation,
+                });
+                self.pose.set_append_rotation(*bone, append_output.rotation);
+                self.pose
+                    .set_append_position_offset(*bone, append_output.position_offset);
                 if append.affect_rotation {
-                    let source_rotation = if !append.local
-                        && self
-                            .model
-                            .append_transform_index(append.source_bone)
-                            .is_some()
-                    {
-                        self.pose.append_rotation(append.source_bone)
-                    } else {
-                        self.pose.local_rotation(append.source_bone)
-                    };
-                    let append_rotation = Quat::IDENTITY
-                        .slerp(source_rotation, append.ratio)
-                        .normalize();
-                    self.pose.set_append_rotation(*bone, append_rotation);
-                    local_rotation = (local_rotation * append_rotation).normalize();
+                    local_rotation = (local_rotation * append_output.rotation).normalize();
                 }
-
                 if append.affect_translation {
-                    let source_position_offset = if !append.local
-                        && self
-                            .model
-                            .append_transform_index(append.source_bone)
-                            .is_some()
-                    {
-                        self.pose.append_position_offset(append.source_bone)
-                    } else {
-                        self.pose.local_position_offset(append.source_bone)
-                    };
-                    let append_position_offset = source_position_offset * append.ratio;
-                    self.pose
-                        .set_append_position_offset(*bone, append_position_offset);
-                    local_position += append_position_offset;
+                    local_position += append_output.position_offset;
                 }
             }
 
@@ -349,69 +360,17 @@ impl RuntimeInstance {
                         continue;
                     }
 
-                    let single_axis = get_single_axis_limit(link.angle_limit);
-
-                    if let (Some(angle_limit), Some(axis_index)) = (link.angle_limit, single_axis) {
-                        solve_plane_link_step(PlaneLinkStepInput {
-                            local_effector: &local_effector,
-                            local_target: &local_target,
-                            link_index,
-                            base_rotations: &base_rotations,
-                            ik_rotations: &mut ik_rotations,
-                            chain_states: &mut chain_states,
-                            axis_index,
-                            limits: angle_limit,
-                            iteration: _iteration,
-                            limit_angle,
-                        });
-                    } else if let Some(angle_limit) = link.angle_limit {
-                        solve_limited_axes_link_step(LimitedAxesLinkStepInput {
-                            local_effector: &local_effector,
-                            local_target: &local_target,
-                            link_index,
-                            base_rotations: &base_rotations,
-                            ik_rotations: &mut ik_rotations,
-                            chain_states: &mut chain_states,
-                            limits: angle_limit,
-                            limit_angle,
-                        });
-                    } else {
-                        let local_eff_n = local_effector.normalize();
-                        let local_tgt_n = local_target.normalize();
-                        let dot = local_eff_n.dot(local_tgt_n).clamp(-1.0, 1.0);
-                        let mut angle = dot.acos();
-
-                        let tiny_angle = 1e-3 * std::f32::consts::PI / 180.0;
-                        if angle < tiny_angle {
-                            continue;
-                        }
-
-                        if limit_angle > 0.0 {
-                            angle = angle.min(limit_angle);
-                        }
-
-                        let axis = local_eff_n.cross(local_tgt_n);
-                        let axis_vec = if axis.length() < 1e-5 {
-                            if dot > -1.0 + 1e-5 {
-                                continue;
-                            }
-                            let basis = if local_eff_n.x.abs() < 0.9 {
-                                Vec3A::new(1.0, 0.0, 0.0)
-                            } else {
-                                Vec3A::new(0.0, 1.0, 0.0)
-                            };
-                            local_eff_n.cross(basis).normalize()
-                        } else {
-                            axis.normalize()
-                        };
-
-                        let delta = Quat::from_axis_angle(axis_vec.into(), angle);
-                        let base = base_rotations[link_index];
-                        let ik = ik_rotations[link_index];
-                        let chain_rotation = (ik * base * delta).normalize();
-
-                        ik_rotations[link_index] = (chain_rotation * base.inverse()).normalize();
-                    }
+                    solve_link_step(LinkStepInput {
+                        local_effector: &local_effector,
+                        local_target: &local_target,
+                        link_index,
+                        base_rotations: &base_rotations,
+                        ik_rotations: &mut ik_rotations,
+                        chain_states: &mut chain_states,
+                        angle_limit: link.angle_limit,
+                        iteration: _iteration,
+                        limit_angle,
+                    });
 
                     self.apply_ik_link_rotations(&links, &base_rotations, &ik_rotations);
                     self.update_world_matrices_from_bone(link_bone);
@@ -642,337 +601,6 @@ fn expand_group_morph_weight(
             expand_group_morph_weight(child, contribution, spans, offsets, expanded_weights);
         }
     }
-}
-
-fn translation(matrix: Mat4) -> Vec3A {
-    Vec3A::from_vec4(matrix.w_axis)
-}
-
-fn rotation(matrix: Mat4) -> Quat {
-    matrix.to_scale_rotation_translation().1
-}
-
-fn constrain_rotation_to_axis(rotation: Quat, axis: Vec3A) -> Quat {
-    let axis = axis.normalize();
-    let vector = Vec3A::new(rotation.x, rotation.y, rotation.z);
-    let projected = axis * vector.dot(axis);
-    let twist = Quat::from_xyzw(projected.x, projected.y, projected.z, rotation.w);
-    if twist.length_squared() <= f32::EPSILON {
-        Quat::IDENTITY
-    } else {
-        twist.normalize()
-    }
-}
-
-#[derive(Debug)]
-struct ChainLinkState {
-    previous_euler: [f32; 3],
-    plane_mode_angle: f32,
-}
-
-fn get_single_axis_limit(limit: Option<crate::IkAngleLimit>) -> Option<usize> {
-    let limit = limit?;
-    let has = [
-        limit.min.x != 0.0 || limit.max.x != 0.0,
-        limit.min.y != 0.0 || limit.max.y != 0.0,
-        limit.min.z != 0.0 || limit.max.z != 0.0,
-    ];
-    if has[0]
-        && limit.min.y == 0.0
-        && limit.max.y == 0.0
-        && limit.min.z == 0.0
-        && limit.max.z == 0.0
-    {
-        return Some(0);
-    }
-    if has[1]
-        && limit.min.x == 0.0
-        && limit.max.x == 0.0
-        && limit.min.z == 0.0
-        && limit.max.z == 0.0
-    {
-        return Some(1);
-    }
-    if has[2]
-        && limit.min.x == 0.0
-        && limit.max.x == 0.0
-        && limit.min.y == 0.0
-        && limit.max.y == 0.0
-    {
-        return Some(2);
-    }
-    None
-}
-
-fn quat_to_rotation_mat3(rotation: Quat) -> [f32; 9] {
-    let [x, y, z, w] = rotation.normalize().to_array();
-    let x2 = x + x;
-    let y2 = y + y;
-    let z2 = z + z;
-    let xx = x * x2;
-    let xy = x * y2;
-    let xz = x * z2;
-    let yy = y * y2;
-    let yz = y * z2;
-    let zz = z * z2;
-    let wx = w * x2;
-    let wy = w * y2;
-    let wz = w * z2;
-    [
-        1.0 - (yy + zz),
-        xy + wz,
-        xz - wy,
-        xy - wz,
-        1.0 - (xx + zz),
-        yz + wx,
-        xz + wy,
-        yz - wx,
-        1.0 - (xx + yy),
-    ]
-}
-
-fn decompose_euler_xyz(mat: &[f32; 9], before: &[f32; 3]) -> [f32; 3] {
-    let sy = -mat[2];
-    let mut result: [f32; 3];
-    if 1.0 - sy.abs() < 1e-6 {
-        let y = sy.asin();
-        let sx = before[0].sin();
-        let sz = before[2].sin();
-        if sx.abs() < sz.abs() {
-            let cx = before[0].cos();
-            result = if cx > 0.0 {
-                [0.0, y, (-mat[3]).asin()]
-            } else {
-                [std::f32::consts::PI, y, mat[3].asin()]
-            };
-        } else {
-            let cz = before[2].cos();
-            result = if cz > 0.0 {
-                [(-mat[7]).asin(), y, 0.0]
-            } else {
-                [mat[7].asin(), y, std::f32::consts::PI]
-            };
-        }
-    } else {
-        result = [mat[5].atan2(mat[8]), (-mat[2]).asin(), mat[1].atan2(mat[0])];
-    }
-
-    let pi = std::f32::consts::PI;
-    let candidates: [[f32; 3]; 8] = [
-        [result[0] + pi, pi - result[1], result[2] + pi],
-        [result[0] + pi, pi - result[1], result[2] - pi],
-        [result[0] + pi, -pi - result[1], result[2] + pi],
-        [result[0] + pi, -pi - result[1], result[2] - pi],
-        [result[0] - pi, pi - result[1], result[2] + pi],
-        [result[0] - pi, pi - result[1], result[2] - pi],
-        [result[0] - pi, -pi - result[1], result[2] + pi],
-        [result[0] - pi, -pi - result[1], result[2] - pi],
-    ];
-    let mut min_error = diff_angle(result[0], before[0]).abs()
-        + diff_angle(result[1], before[1]).abs()
-        + diff_angle(result[2], before[2]).abs();
-    for candidate in &candidates {
-        let error = diff_angle(candidate[0], before[0]).abs()
-            + diff_angle(candidate[1], before[1]).abs()
-            + diff_angle(candidate[2], before[2]).abs();
-        if error < min_error {
-            min_error = error;
-            result = *candidate;
-        }
-    }
-    result
-}
-
-fn diff_angle(a: f32, b: f32) -> f32 {
-    let diff = normalize_angle(a) - normalize_angle(b);
-    if diff > std::f32::consts::PI {
-        diff - std::f32::consts::TAU
-    } else if diff < -std::f32::consts::PI {
-        diff + std::f32::consts::TAU
-    } else {
-        diff
-    }
-}
-
-fn normalize_angle(angle: f32) -> f32 {
-    let mut result = angle;
-    while result >= std::f32::consts::TAU {
-        result -= std::f32::consts::TAU;
-    }
-    while result < 0.0 {
-        result += std::f32::consts::TAU;
-    }
-    result
-}
-
-fn euler_xyz_to_quat(euler: &[f32; 3]) -> Quat {
-    let [x, y, z] = *euler;
-    let c1 = (x / 2.0).cos();
-    let c2 = (y / 2.0).cos();
-    let c3 = (z / 2.0).cos();
-    let s1 = (x / 2.0).sin();
-    let s2 = (y / 2.0).sin();
-    let s3 = (z / 2.0).sin();
-    Quat::from_xyzw(
-        s1 * c2 * c3 + c1 * s2 * s3,
-        c1 * s2 * c3 - s1 * c2 * s3,
-        c1 * c2 * s3 + s1 * s2 * c3,
-        c1 * c2 * c3 - s1 * s2 * s3,
-    )
-}
-
-struct LimitedAxesLinkStepInput<'a> {
-    local_effector: &'a Vec3A,
-    local_target: &'a Vec3A,
-    link_index: usize,
-    base_rotations: &'a [Quat],
-    ik_rotations: &'a mut [Quat],
-    chain_states: &'a mut [ChainLinkState],
-    limits: crate::IkAngleLimit,
-    limit_angle: f32,
-}
-
-fn solve_limited_axes_link_step(input: LimitedAxesLinkStepInput<'_>) {
-    let state = &mut input.chain_states[input.link_index];
-    let base = input.base_rotations[input.link_index];
-    let current = (input.ik_rotations[input.link_index] * base).normalize();
-    let current_mat = quat_to_rotation_mat3(current);
-    let mut total_euler = decompose_euler_xyz(&current_mat, &state.previous_euler);
-    let mut working_effector = *input.local_effector;
-    let target = input.local_target.normalize();
-
-    for axis_index in [2usize, 1, 0] {
-        let (lower, upper) = limit_axis_bounds(input.limits, axis_index);
-        if lower == 0.0 && upper == 0.0 {
-            let next = total_euler[axis_index].clamp(lower, upper);
-            let applied = next - total_euler[axis_index];
-            total_euler[axis_index] = next;
-            if applied.abs() > 0.0 {
-                working_effector = Quat::from_axis_angle(axis_vec(axis_index).into(), applied)
-                    .mul_vec3a(working_effector);
-            }
-            continue;
-        }
-
-        let axis = axis_vec(axis_index);
-        let signed_angle = signed_projected_angle(working_effector, target, axis);
-        if signed_angle.abs() <= 1.0e-6 {
-            continue;
-        }
-        let step = if input.limit_angle > 0.0 {
-            signed_angle.clamp(-input.limit_angle, input.limit_angle)
-        } else {
-            signed_angle
-        };
-        let next = (total_euler[axis_index] + step).clamp(lower, upper);
-        let applied = next - total_euler[axis_index];
-        total_euler[axis_index] = next;
-        if applied.abs() > 0.0 {
-            working_effector =
-                Quat::from_axis_angle(axis.into(), applied).mul_vec3a(working_effector);
-        }
-    }
-
-    state.previous_euler = total_euler;
-    let chain_rotation = euler_xyz_to_quat(&total_euler).normalize();
-    input.ik_rotations[input.link_index] = (chain_rotation * base.inverse()).normalize();
-}
-
-fn limit_axis_bounds(limits: crate::IkAngleLimit, axis_index: usize) -> (f32, f32) {
-    match axis_index {
-        0 => (limits.min.x, limits.max.x),
-        1 => (limits.min.y, limits.max.y),
-        _ => (limits.min.z, limits.max.z),
-    }
-}
-
-fn axis_vec(axis_index: usize) -> Vec3A {
-    match axis_index {
-        0 => Vec3A::new(1.0, 0.0, 0.0),
-        1 => Vec3A::new(0.0, 1.0, 0.0),
-        _ => Vec3A::new(0.0, 0.0, 1.0),
-    }
-}
-
-fn signed_projected_angle(from: Vec3A, to: Vec3A, axis: Vec3A) -> f32 {
-    let projected_from = from - axis * from.dot(axis);
-    let projected_to = to - axis * to.dot(axis);
-    if projected_from.length_squared() <= f32::EPSILON
-        || projected_to.length_squared() <= f32::EPSILON
-    {
-        return 0.0;
-    }
-    let from_n = projected_from.normalize();
-    let to_n = projected_to.normalize();
-    let dot = from_n.dot(to_n).clamp(-1.0, 1.0);
-    let angle = dot.acos();
-    let sign = axis.dot(from_n.cross(to_n)).signum();
-    angle * if sign == 0.0 { 1.0 } else { sign }
-}
-
-struct PlaneLinkStepInput<'a> {
-    local_effector: &'a Vec3A,
-    local_target: &'a Vec3A,
-    link_index: usize,
-    base_rotations: &'a [Quat],
-    ik_rotations: &'a mut [Quat],
-    chain_states: &'a mut [ChainLinkState],
-    axis_index: usize,
-    limits: crate::IkAngleLimit,
-    iteration: usize,
-    limit_angle: f32,
-}
-
-fn solve_plane_link_step(input: PlaneLinkStepInput<'_>) {
-    let rotate_axis = match input.axis_index {
-        0 => Vec3A::new(1.0, 0.0, 0.0),
-        1 => Vec3A::new(0.0, 1.0, 0.0),
-        _ => Vec3A::new(0.0, 0.0, 1.0),
-    };
-    let local_eff_n = input.local_effector.normalize();
-    let local_tgt_n = input.local_target.normalize();
-
-    let dot = local_eff_n.dot(local_tgt_n).clamp(-1.0, 1.0);
-    let raw_angle = dot.acos();
-    let capped_angle = if input.limit_angle > 0.0 {
-        raw_angle.min(input.limit_angle)
-    } else {
-        raw_angle
-    };
-
-    let target_vec1 =
-        Quat::from_axis_angle(rotate_axis.into(), capped_angle).mul_vec3a(local_eff_n);
-    let target_vec2 =
-        Quat::from_axis_angle(rotate_axis.into(), -capped_angle).mul_vec3a(local_eff_n);
-    let signed_angle = if target_vec1.dot(local_tgt_n) > target_vec2.dot(local_tgt_n) {
-        capped_angle
-    } else {
-        -capped_angle
-    };
-
-    let state = &mut input.chain_states[input.link_index];
-    let mut next_angle = state.plane_mode_angle + signed_angle;
-    let (lower, upper) = match input.axis_index {
-        0 => (input.limits.min.x, input.limits.max.x),
-        1 => (input.limits.min.y, input.limits.max.y),
-        _ => (input.limits.min.z, input.limits.max.z),
-    };
-    let base = input.base_rotations[input.link_index];
-
-    if input.iteration == 0 && (next_angle < lower || next_angle > upper) {
-        if -next_angle > lower && -next_angle < upper {
-            next_angle = -next_angle;
-        } else {
-            let half = (lower + upper) * 0.5;
-            if (half - next_angle).abs() > (half + next_angle).abs() {
-                next_angle = -next_angle;
-            }
-        }
-    }
-
-    state.plane_mode_angle = next_angle.clamp(lower, upper);
-    let chain_rotation = Quat::from_axis_angle(rotate_axis.into(), state.plane_mode_angle);
-    input.ik_rotations[input.link_index] = (chain_rotation * base.inverse()).normalize();
 }
 
 #[cfg(test)]

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -55,6 +55,9 @@ cargo doc --workspace --no-deps
 
 - [three-mmd-loader](https://github.com/yohawing/three-mmd-loader): `mmd-anim` を
   アニメーション・形式処理 backend として利用する Three.js 向け MMD loader。
+- [maya_mmd_tools](https://github.com/yohawing/maya_mmd_tools):
+  Maya 向け MMD アニメーション編集ツールとして利用する Maya プラグイン。 VMDインポート時のフルベイク用と、リグ実装にあたっての正本として利用。
+- [unity-mmd-loader](https://github.com/yohawing/unity-mmd-loader): Unity6、URPに最適化Unity向けMMD Loader。インポーターと、コアアニメーションランタイムとして利用。
 
 Rust API、C ABI、WASM wrapper を通じて、他のホストや製品にも同じ機能を組み込めます。
 


### PR DESCRIPTION
## Summary

- IK solver と append (付与変形) を runtime.rs から独立した primitive モジュールに抽出 (`ik_primitive.rs`, `append_primitive.rs`)
- per-chain IK / per-bone append の C ABI を追加 (opaque handle lifecycle: create → solve → free)
- PMX から rig spec (骨・IK チェーン・付与変形の構造情報) を抽出し、manifest JSON として C ABI 経由で取得可能に
- runtime.rs は primitive に委譲する形にリファクタし ~425 行削減、既存の full runtime 動作は変更なし

## Motivation

Maya / Unity などの host-idiomatic なリグノードから、mmd-anim の IK / append 計算を per-chain / per-bone で呼べるようにする。
full runtime の一括評価ではなく、ホスト側の DG/DAG に組み込める粒度の API が必要だった。

## Changes

| ファイル | 内容 |
|---------|------|
| `ik_primitive.rs` (新規) | `IkChainSolver` + CCD solve + plane/limited-axes/unconstrained link step |
| `append_primitive.rs` (新規) | `solve_append_transform()` 純粋関数 |
| `runtime.rs` | primitive に委譲、-425 行 |
| `mmd-anim-ffi/lib.rs` | IK chain / append solver / rig spec の C ABI + テスト |
| `mmd_runtime.h` | typedef, repr(C) struct, prototype, doc comments |
| `mmd-anim-format/pmx/mod.rs` | `PmxRigSpec` DTO + `parse_pmx_rig_spec()` |

## ABI contract

- 座標系: 左手系 Y-up (MMD 標準)
- 四元数: xyzw
- 行列: column-major f32[16]
- `rig_` prefix で既存 full-runtime struct との命名衝突を回避
- NULL safety: create → NULL on error, free → NULL accepted, solve → false on invalid

## Test plan

- [x] IK primitive parity: full runtime と同一入力で bit-exact な出力 (unconstrained, 2-link, knee plane, limited axes)
- [x] Append primitive parity: ratio/rotation/disabled channel
- [x] Bit determinism: glam fast-math 下で再現性確認
- [x] Deform-order characterization: correct-order vs dependency-order の差分が bounded
- [x] C ABI lifecycle: create → solve → free, NULL safety, short-buffer rejection
- [x] Rig spec manifest: JSON shape validation, null/invalid input handling
- [x] 全 488 テスト pass, clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)