### PR TITLE
Release: CLI refactor, rig primitives, and crates.io publishing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ target/package/
 .codex/
 .claude/
 .agents/
+.ai/
 AGENTS.md
 CLAUDE.md
 
@@ -35,5 +36,4 @@ crates/mmd-anim-wasm/harness/pkg-web/
 
 # local dev artifacts
 artifacts/
-dist/
-examples/viewer/
+viewer/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,56 @@
 version = 4
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13,6 +63,52 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "encoding_rs"
@@ -54,6 +150,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f70749695b063ecbf6b62949ccccde2e733ec3ecbbd71d467dca4e5c6c97cca0"
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -89,6 +197,7 @@ dependencies = [
 name = "mmd-anim-cli"
 version = "0.1.5"
 dependencies = [
+ "clap",
  "glam",
  "mmd-anim-format",
  "mmd-anim-runtime",
@@ -153,6 +262,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "pin-project-lite"
@@ -234,6 +349,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -269,6 +390,12 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "wasm-bindgen"
@@ -313,6 +440,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -89,8 +89,8 @@ Format support overview. "Loading" means parsing a file into structured data.
 | `mmd-anim-format` | PMX/VMD runtime import, format detection, structured loading, and PMX/PMD/VMD/VPD/X/VAC writing. |
 | `mmd-anim-ffi` | C ABI for native hosts. Exposes runtime operations and PMX parts writing. Repository-local for the 0.1.x line. |
 | `mmd-anim-wasm` | `wasm-bindgen` wrapper for browsers. Exposes runtime operations, loading/writing APIs, and PMX parts writing. Workspace-local for the 0.1.x line. |
-| `mmd-anim-cli` | Maintainer diagnostics and verification command-line tool. Repository-local for the 0.1.x line. |
-| `mmd-anim-schema` | Maintainer quality-check schema helper crate. Repository-local for the 0.1.x line. |
+| `mmd-anim-cli` | Command-line tool for inspecting, converting, and diagnosing MMD format files. Installable via `cargo install mmd-anim-cli`. |
+| `mmd-anim-schema` | Shared IR and trace schema used by the CLI and diagnostic tools. |
 
 For normal library use, depend on `mmd-anim`. Advanced users who only need a
 lower layer can depend on `mmd-anim-format` or `mmd-anim-runtime` directly.
@@ -207,17 +207,26 @@ const generatedPmxBytes = exportPmxFromParts(
 The WASM package is not published to crates.io for the 0.1.x line. It is kept in the Rust
 workspace for builds and checks.
 
-## CLI Checks
+## CLI
 
-For local loading and writing checks, use the repository-local `mmd-anim-cli`.
-Available subcommands can be listed with:
+`mmd-anim-cli` is a command-line tool for inspecting, converting, and diagnosing
+MMD format files (PMX, VMD, VPD, PMM, X/VAC).
+
+```powershell
+cargo install mmd-anim-cli
+```
+
+After installation, the `mmd-anim` command is available:
+
+```powershell
+mmd-anim --help
+```
+
+For development, you can also run directly from the workspace:
 
 ```powershell
 cargo run -p mmd-anim-cli -- --help
 ```
-
-This command-line tool is for maintainer diagnostics and is not required for
-public releases.
 
 ## Current Limitations
 

--- a/crates/mmd-anim-cli/Cargo.toml
+++ b/crates/mmd-anim-cli/Cargo.toml
@@ -9,7 +9,6 @@ readme.workspace = true
 keywords.workspace = true
 categories.workspace = true
 description = "CLI diagnostics and roundtrip tools for mmd-anim"
-publish = false
 
 [[bin]]
 name = "mmd-anim"

--- a/crates/mmd-anim-cli/Cargo.toml
+++ b/crates/mmd-anim-cli/Cargo.toml
@@ -17,6 +17,7 @@ path = "src/main.rs"
 doc = false
 
 [dependencies]
+clap = { version = "4", features = ["derive"] }
 glam.workspace = true
 mmd-anim-runtime.workspace = true
 mmd-anim-format = { path = "../mmd-anim-format", version = "0.1.5" }

--- a/crates/mmd-anim-cli/src/commands/bench.rs
+++ b/crates/mmd-anim-cli/src/commands/bench.rs
@@ -1,4 +1,4 @@
-use std::{fs, path::PathBuf, process::ExitCode, sync::Arc, time::Instant};
+use std::{path::PathBuf, process::ExitCode, sync::Arc, time::Instant};
 
 use glam::{Quat, Vec3A};
 use mmd_anim_runtime::{
@@ -6,7 +6,7 @@ use mmd_anim_runtime::{
     MovableBoneKeyframe, MovableBoneTrack, RuntimeInstance,
 };
 
-use crate::{copy_world_matrices_to_f32, f32_checksum, translation_checksum};
+use crate::{copy_world_matrices_to_f32, f32_checksum, read_file, translation_checksum};
 
 pub(crate) const BENCH_PAIR_USAGE: &str = "usage: mmd-anim bench-pair <model.pmx> <motion.vmd> [start-frame] [frame-count] [step] [--no-ik] [--ik-tolerance <value>] [--ik-max-iterations-cap <count>]";
 
@@ -25,8 +25,8 @@ pub(crate) fn bench_pair(cfg: BenchPairConfig) -> Result<ExitCode, Box<dyn std::
     let total_start = Instant::now();
 
     let read_start = Instant::now();
-    let pmx_bytes = fs::read(&cfg.pmx_path)?;
-    let vmd_bytes = fs::read(&cfg.vmd_path)?;
+    let pmx_bytes = read_file(&cfg.pmx_path)?;
+    let vmd_bytes = read_file(&cfg.vmd_path)?;
     let read_elapsed = read_start.elapsed();
 
     let pmx_start = Instant::now();

--- a/crates/mmd-anim-cli/src/commands/bench.rs
+++ b/crates/mmd-anim-cli/src/commands/bench.rs
@@ -106,40 +106,32 @@ pub(crate) fn bench_pair(cfg: BenchPairConfig) -> Result<ExitCode, Box<dyn std::
     let ms_per_frame = eval_ms / cfg.frame_count as f64;
     let fps = cfg.frame_count as f64 / eval_elapsed.as_secs_f64();
 
+    let ik_display = if cfg.solve_ik {
+        solver_count.to_string()
+    } else {
+        "disabled".to_owned()
+    };
+    let ik_cap_display = cfg
+        .ik_options
+        .max_iterations_cap
+        .map(|value| value.to_string())
+        .unwrap_or_else(|| "none".to_owned());
+    println!("bench-pair:");
     println!(
-        "bench-pair: bones={} ik={} ikTolerance={:.8} ikMaxIterationsCap={} append={} fixedAxis={} vmdBoneKeys={} vmdMorphKeys={} clipBoneTracks={} clipMorphTracks={} propertyTrack={} clipFrameRange={} frames={} startFrame={:.3} step={:.3} readMs={:.3} pmxImportMs={:.3} vmdImportMs={:.3} clipBuildMs={:.3} evalMs={:.3} msPerFrame={:.6} fps={:.1} totalMs={:.3} checksum={:08x} morphChecksum={:08x}",
-        bone_count,
-        if cfg.solve_ik {
-            solver_count.to_string()
-        } else {
-            "disabled".to_owned()
-        },
-        cfg.ik_options.tolerance,
-        cfg.ik_options
-            .max_iterations_cap
-            .map(|value| value.to_string())
-            .unwrap_or_else(|| "none".to_owned()),
-        append_count,
-        fixed_axis_count,
-        vmd.bone_keyframes.len(),
-        vmd.morph_keyframes.len(),
-        clip.bone_track_count(),
-        clip.morph_track_count(),
-        clip.has_property_track(),
-        frame_range,
-        cfg.frame_count,
-        cfg.start_frame,
-        cfg.step,
-        read_elapsed.as_secs_f64() * 1000.0,
-        pmx_elapsed.as_secs_f64() * 1000.0,
-        vmd_elapsed.as_secs_f64() * 1000.0,
-        clip_elapsed.as_secs_f64() * 1000.0,
-        eval_ms,
-        ms_per_frame,
-        fps,
-        total_elapsed.as_secs_f64() * 1000.0,
-        checksum,
-        morph_checksum,
+        "  model:   bones={} ik={} ikTolerance={:.8} ikMaxIterationsCap={} append={} fixedAxis={}",
+        bone_count, ik_display, cfg.ik_options.tolerance, ik_cap_display, append_count, fixed_axis_count,
+    );
+    println!(
+        "  motion:  vmdBoneKeys={} vmdMorphKeys={} clipBoneTracks={} clipMorphTracks={} propertyTrack={} clipFrameRange={}",
+        vmd.bone_keyframes.len(), vmd.morph_keyframes.len(), clip.bone_track_count(), clip.morph_track_count(), clip.has_property_track(), frame_range,
+    );
+    println!(
+        "  timing:  readMs={:.3} pmxImportMs={:.3} vmdImportMs={:.3} clipBuildMs={:.3} evalMs={:.3} totalMs={:.3}",
+        read_elapsed.as_secs_f64() * 1000.0, pmx_elapsed.as_secs_f64() * 1000.0, vmd_elapsed.as_secs_f64() * 1000.0, clip_elapsed.as_secs_f64() * 1000.0, eval_ms, total_elapsed.as_secs_f64() * 1000.0,
+    );
+    println!(
+        "  result:  frames={} startFrame={:.3} step={:.3} msPerFrame={:.6} fps={:.1} checksum={:08x} morphChecksum={:08x}",
+        cfg.frame_count, cfg.start_frame, cfg.step, ms_per_frame, fps, checksum, morph_checksum,
     );
     if cfg.solve_ik {
         let stats = runtime.ik_runtime_stats();

--- a/crates/mmd-anim-cli/src/commands/bench.rs
+++ b/crates/mmd-anim-cli/src/commands/bench.rs
@@ -1,0 +1,510 @@
+use std::{
+    fs,
+    path::PathBuf,
+    process::ExitCode,
+    sync::Arc,
+    time::Instant,
+};
+
+use glam::{Quat, Vec3A};
+use mmd_anim_runtime::{
+    AnimationClip, BoneAnimationBinding, BoneIndex, BoneInit, IkSolveOptions,
+    ModelArena, MovableBoneKeyframe, MovableBoneTrack, RuntimeInstance,
+};
+
+use crate::{copy_world_matrices_to_f32, f32_checksum, translation_checksum};
+
+pub(crate) const BENCH_PAIR_USAGE: &str = "usage: mmd-anim bench-pair <model.pmx> <motion.vmd> [start-frame] [frame-count] [step] [--no-ik] [--ik-tolerance <value>] [--ik-max-iterations-cap <count>]";
+
+#[derive(Debug)]
+pub(crate) struct BenchPairConfig {
+    pmx_path: PathBuf,
+    vmd_path: PathBuf,
+    start_frame: f32,
+    frame_count: usize,
+    step: f32,
+    solve_ik: bool,
+    ik_options: IkSolveOptions,
+}
+
+pub(crate) fn bench_pair(cfg: BenchPairConfig) -> Result<ExitCode, Box<dyn std::error::Error>> {
+    let total_start = Instant::now();
+
+    let read_start = Instant::now();
+    let pmx_bytes = fs::read(&cfg.pmx_path)?;
+    let vmd_bytes = fs::read(&cfg.vmd_path)?;
+    let read_elapsed = read_start.elapsed();
+
+    let pmx_start = Instant::now();
+    let pmx = mmd_anim_format::import_pmx_runtime(&pmx_bytes)?;
+    let pmx_elapsed = pmx_start.elapsed();
+
+    let vmd_start = Instant::now();
+    let vmd = mmd_anim_format::import_vmd_motion(&vmd_bytes)?;
+    let vmd_elapsed = vmd_start.elapsed();
+
+    let bone_count = pmx.model.bone_count();
+    let append_count = pmx.model.append_transforms().len();
+    let fixed_axis_count = pmx.model.fixed_axis_count();
+    let solver_count = pmx.model.ik_count();
+    let ik_solver_summaries = pmx
+        .model
+        .ik_solvers()
+        .iter()
+        .enumerate()
+        .map(|(index, solver)| {
+            let name = pmx
+                .bone_names
+                .get(solver.ik_bone.as_usize())
+                .cloned()
+                .unwrap_or_else(|| "<unknown>".to_owned());
+            (
+                index,
+                solver.ik_bone.as_usize(),
+                name,
+                solver.iteration_count,
+                solver.links.len(),
+            )
+        })
+        .collect::<Vec<_>>();
+    let morph_count = pmx
+        .morph_name_to_index
+        .values()
+        .map(|index| index.as_usize() + 1)
+        .max()
+        .unwrap_or(0);
+
+    let clip_start = Instant::now();
+    let clip = mmd_anim_format::build_pair_clip(
+        &vmd,
+        &pmx.bone_name_to_index,
+        &pmx.morph_name_to_index,
+        &pmx.ik_solver_bone_name_to_index,
+        solver_count,
+    );
+    let clip_elapsed = clip_start.elapsed();
+
+    let model = Arc::new(pmx.model);
+    let mut runtime = RuntimeInstance::new_with_counts(model, morph_count, solver_count);
+    runtime.reset_ik_runtime_stats();
+
+    let eval_start = Instant::now();
+    let mut checksum = 0u32;
+    let mut morph_checksum = 0u32;
+    for i in 0..cfg.frame_count {
+        let frame = cfg.start_frame + cfg.step * i as f32;
+        if cfg.solve_ik {
+            runtime.evaluate_clip_frame_with_ik_options(&clip, frame, cfg.ik_options);
+        } else {
+            runtime.evaluate_clip_frame_without_ik(&clip, frame);
+        }
+        checksum = checksum.rotate_left(1) ^ translation_checksum(runtime.world_matrices());
+        morph_checksum = morph_checksum.rotate_left(1) ^ f32_checksum(runtime.morph_weights());
+    }
+    let eval_elapsed = eval_start.elapsed();
+    let total_elapsed = total_start.elapsed();
+
+    let frame_range = clip
+        .frame_range()
+        .map(|(first, last)| format!("{first}..{last}"))
+        .unwrap_or_else(|| "none".to_owned());
+    let eval_ms = eval_elapsed.as_secs_f64() * 1000.0;
+    let ms_per_frame = eval_ms / cfg.frame_count as f64;
+    let fps = cfg.frame_count as f64 / eval_elapsed.as_secs_f64();
+
+    println!(
+        "bench-pair: bones={} ik={} ikTolerance={:.8} ikMaxIterationsCap={} append={} fixedAxis={} vmdBoneKeys={} vmdMorphKeys={} clipBoneTracks={} clipMorphTracks={} propertyTrack={} clipFrameRange={} frames={} startFrame={:.3} step={:.3} readMs={:.3} pmxImportMs={:.3} vmdImportMs={:.3} clipBuildMs={:.3} evalMs={:.3} msPerFrame={:.6} fps={:.1} totalMs={:.3} checksum={:08x} morphChecksum={:08x}",
+        bone_count,
+        if cfg.solve_ik {
+            solver_count.to_string()
+        } else {
+            "disabled".to_owned()
+        },
+        cfg.ik_options.tolerance,
+        cfg.ik_options
+            .max_iterations_cap
+            .map(|value| value.to_string())
+            .unwrap_or_else(|| "none".to_owned()),
+        append_count,
+        fixed_axis_count,
+        vmd.bone_keyframes.len(),
+        vmd.morph_keyframes.len(),
+        clip.bone_track_count(),
+        clip.morph_track_count(),
+        clip.has_property_track(),
+        frame_range,
+        cfg.frame_count,
+        cfg.start_frame,
+        cfg.step,
+        read_elapsed.as_secs_f64() * 1000.0,
+        pmx_elapsed.as_secs_f64() * 1000.0,
+        vmd_elapsed.as_secs_f64() * 1000.0,
+        clip_elapsed.as_secs_f64() * 1000.0,
+        eval_ms,
+        ms_per_frame,
+        fps,
+        total_elapsed.as_secs_f64() * 1000.0,
+        checksum,
+        morph_checksum,
+    );
+    if cfg.solve_ik {
+        let stats = runtime.ik_runtime_stats();
+        let total_evaluations = stats
+            .iter()
+            .map(|stats| stats.solver_evaluations)
+            .sum::<u64>();
+        let configured_iterations = stats
+            .iter()
+            .map(|stats| stats.configured_iterations)
+            .sum::<u64>();
+        let executed_iterations = stats
+            .iter()
+            .map(|stats| stats.executed_iterations)
+            .sum::<u64>();
+        let skipped_iterations = configured_iterations.saturating_sub(executed_iterations);
+        let tolerance_precheck_breaks = stats
+            .iter()
+            .map(|stats| stats.tolerance_precheck_breaks)
+            .sum::<u64>();
+        let tolerance_post_iteration_breaks = stats
+            .iter()
+            .map(|stats| stats.tolerance_post_iteration_breaks)
+            .sum::<u64>();
+        let rollback_breaks = stats.iter().map(|stats| stats.rollback_breaks).sum::<u64>();
+        let max_iteration_exhaustions = stats
+            .iter()
+            .map(|stats| stats.max_iteration_exhaustions)
+            .sum::<u64>();
+        let link_steps = stats.iter().map(|stats| stats.link_steps).sum::<u64>();
+        let skip_ratio = if configured_iterations == 0 {
+            0.0
+        } else {
+            skipped_iterations as f64 / configured_iterations as f64
+        };
+        println!(
+            "bench-pair-ik-stats: solverEvaluations={} configuredIterations={} executedIterations={} skippedIterations={} skippedRatio={:.3} tolerancePrecheckBreaks={} tolerancePostIterationBreaks={} rollbackBreaks={} maxIterationExhaustions={} linkSteps={}",
+            total_evaluations,
+            configured_iterations,
+            executed_iterations,
+            skipped_iterations,
+            skip_ratio,
+            tolerance_precheck_breaks,
+            tolerance_post_iteration_breaks,
+            rollback_breaks,
+            max_iteration_exhaustions,
+            link_steps,
+        );
+
+        let mut ranked = stats
+            .iter()
+            .enumerate()
+            .map(|(index, stats)| (index, *stats))
+            .collect::<Vec<_>>();
+        ranked.sort_by_key(|(_, stats)| {
+            std::cmp::Reverse((stats.executed_iterations, stats.configured_iterations))
+        });
+        for (index, stats) in ranked.into_iter().take(8) {
+            let (solver_index, bone_index, name, max_iterations, links) =
+                &ik_solver_summaries[index];
+            let skipped = stats
+                .configured_iterations
+                .saturating_sub(stats.executed_iterations);
+            let avg_final_distance = if stats.solver_evaluations == 0 {
+                0.0
+            } else {
+                stats.final_distance_sum / stats.solver_evaluations as f64
+            };
+            let avg_exhausted_final_distance = if stats.max_iteration_exhaustions == 0 {
+                0.0
+            } else {
+                stats.exhausted_final_distance_sum / stats.max_iteration_exhaustions as f64
+            };
+            println!(
+                "bench-pair-ik-solver: solver={} bone={} name={} maxIterations={} links={} evaluations={} configuredIterations={} executedIterations={} skippedIterations={} precheckBreaks={} postBreaks={} rollbackBreaks={} exhausted={} avgFinalDistance={:.8} maxFinalDistance={:.8} avgExhaustedFinalDistance={:.8} maxExhaustedFinalDistance={:.8}",
+                solver_index,
+                bone_index,
+                name,
+                max_iterations,
+                links,
+                stats.solver_evaluations,
+                stats.configured_iterations,
+                stats.executed_iterations,
+                skipped,
+                stats.tolerance_precheck_breaks,
+                stats.tolerance_post_iteration_breaks,
+                stats.rollback_breaks,
+                stats.max_iteration_exhaustions,
+                avg_final_distance,
+                stats.final_distance_max,
+                avg_exhausted_final_distance,
+                stats.exhausted_final_distance_max,
+            );
+        }
+    }
+
+    Ok(ExitCode::SUCCESS)
+}
+
+#[derive(Debug)]
+pub(crate) struct BenchSyntheticConfig {
+    pub(crate) models: usize,
+    pub(crate) bones: usize,
+    pub(crate) frames: u32,
+    pub(crate) use_json: bool,
+}
+
+pub(crate) fn bench_synthetic(cfg: BenchSyntheticConfig) -> Result<ExitCode, Box<dyn std::error::Error>> {
+    let model_count = cfg.models;
+    let bone_count = cfg.bones;
+    let frame_count = cfg.frames;
+    let use_json = cfg.use_json;
+    if model_count == 0 || bone_count == 0 || frame_count == 0 {
+        return Err("models, bones, and frames must be positive".into());
+    }
+
+    // Build chain of bones: bone 0 = root, each child parented to previous
+    let mut bones = Vec::with_capacity(bone_count);
+    for i in 0..bone_count {
+        let parent = if i == 0 {
+            None
+        } else {
+            Some(BoneIndex(i as u32 - 1))
+        };
+        bones.push(BoneInit::new(parent, Vec3A::new(0.0, i as f32 * 5.0, 0.0)));
+    }
+    let model = Arc::new(ModelArena::new(bones)?);
+
+    // Build clip with two keyframes per bone (linear interpolation)
+    let mut bone_tracks = Vec::with_capacity(bone_count);
+    for i in 0..bone_count {
+        let angle = 0.1 + (i as f32) * 0.02;
+        let track = MovableBoneTrack::from_keyframes(vec![
+            MovableBoneKeyframe::new(0, Vec3A::ZERO, Quat::IDENTITY),
+            MovableBoneKeyframe::new(
+                30,
+                Vec3A::new(1.0, 0.0, 0.0),
+                Quat::from_axis_angle(Vec3A::Y.into(), angle),
+            ),
+        ]);
+        bone_tracks.push(BoneAnimationBinding {
+            bone: BoneIndex(i as u32),
+            track,
+        });
+    }
+    let clip = AnimationClip::new(bone_tracks);
+
+    // Create model_count independent RuntimeInstances
+    let mut runtimes: Vec<RuntimeInstance> = (0..model_count)
+        .map(|_| RuntimeInstance::new(Arc::clone(&model)))
+        .collect();
+    let mut matrix_scratch = vec![0.0f32; bone_count * 16];
+
+    // Warm-up: one call to ensure any lazy init is done
+    for runtime in &mut runtimes {
+        runtime.evaluate_clip_frame(&clip, 0.0);
+        copy_world_matrices_to_f32(runtime.world_matrices(), &mut matrix_scratch);
+    }
+
+    // Timed loop
+    let mut rolling_checksum: u32 = 0;
+    let start = Instant::now();
+    for frame in 0..frame_count {
+        let frame_f = frame as f32;
+        for runtime in &mut runtimes {
+            runtime.evaluate_clip_frame(&clip, frame_f);
+            copy_world_matrices_to_f32(runtime.world_matrices(), &mut matrix_scratch);
+            rolling_checksum = rolling_checksum.wrapping_add(f32_checksum(&matrix_scratch));
+        }
+    }
+    let elapsed = start.elapsed();
+
+    // Accumulate checksum from final state (prevents dead-code elimination)
+    let mut final_checksum: u32 = 0;
+    for runtime in &runtimes {
+        final_checksum =
+            final_checksum.wrapping_add(translation_checksum(runtime.world_matrices()));
+    }
+    final_checksum ^= rolling_checksum;
+
+    let total_frames = frame_count as u64 * model_count as u64;
+    let elapsed_ms = elapsed.as_secs_f64() * 1000.0;
+    let fps = total_frames as f64 / elapsed.as_secs_f64();
+
+    if use_json {
+        println!(
+            r#"{{"models":{},"bones":{},"frames":{},"elapsedMs":{:.3},"totalFrames":{},"fps":{:.1},"checksum":"{:08x}"}}"#,
+            model_count, bone_count, frame_count, elapsed_ms, total_frames, fps, final_checksum
+        );
+    } else {
+        println!(
+            "bench-synthetic: models={} bones={} frames={} elapsedMs={:.3} totalFrames={} fps={:.1} checksum={:08x}",
+            model_count, bone_count, frame_count, elapsed_ms, total_frames, fps, final_checksum
+        );
+    }
+
+    Ok(ExitCode::SUCCESS)
+}
+
+pub(crate) fn parse_bench_synthetic_args(
+    args: &mut impl Iterator<Item = String>,
+) -> Result<BenchSyntheticConfig, Box<dyn std::error::Error>> {
+    let raw: Vec<String> = args.collect();
+    let mut use_json = false;
+    let mut positional = Vec::new();
+
+    for token in &raw {
+        if token == "--json" {
+            use_json = true;
+        } else if token.starts_with("--") {
+            return Err(format!("unknown flag: {token}").into());
+        } else {
+            positional.push(token.clone());
+        }
+    }
+
+    let mut pos_iter = positional.into_iter();
+    let models = optional_positive_usize_arg(&mut pos_iter, 1, "models")?;
+    let bones = optional_positive_usize_arg(&mut pos_iter, 32, "bones")?;
+    let frames = optional_positive_u32_arg(&mut pos_iter, 1000, "frames")?;
+    if let Some(extra) = pos_iter.next() {
+        return Err(format!("unexpected extra argument: {extra}").into());
+    }
+
+    Ok(BenchSyntheticConfig {
+        models,
+        bones,
+        frames,
+        use_json,
+    })
+}
+
+pub(crate) fn parse_bench_pair_args(
+    args: &mut impl Iterator<Item = String>,
+) -> Result<BenchPairConfig, Box<dyn std::error::Error>> {
+    let raw: Vec<String> = args.collect();
+    let mut solve_ik = true;
+    let mut ik_tolerance = IkSolveOptions::default().tolerance;
+    let mut ik_max_iterations_cap = None;
+    let mut positional = Vec::new();
+
+    let mut raw_iter = raw.into_iter();
+    while let Some(token) = raw_iter.next() {
+        match token.as_str() {
+            "--no-ik" => solve_ik = false,
+            "--ik-tolerance" => {
+                let value = raw_iter.next().ok_or("missing value for --ik-tolerance")?;
+                ik_tolerance = parse_finite_f32(&value, "ik-tolerance")?;
+                if ik_tolerance < 0.0 {
+                    return Err("ik-tolerance must be non-negative".into());
+                }
+            }
+            "--ik-max-iterations-cap" => {
+                let value = raw_iter
+                    .next()
+                    .ok_or("missing value for --ik-max-iterations-cap")?;
+                ik_max_iterations_cap = Some(parse_positive_u32(&value, "ik-max-iterations-cap")?);
+            }
+            _ if token.starts_with("--") => {
+                return Err(format!("unknown flag: {token}").into());
+            }
+            _ => positional.push(token),
+        }
+    }
+
+    let mut pos_iter = positional.into_iter();
+    let pmx_path = PathBuf::from(pos_iter.next().ok_or(BENCH_PAIR_USAGE)?);
+    let vmd_path = PathBuf::from(pos_iter.next().ok_or(BENCH_PAIR_USAGE)?);
+    let start_frame = optional_f32_parse_arg(&mut pos_iter, 0.0, "start-frame")?;
+    let frame_count = optional_positive_usize_arg(&mut pos_iter, 1000, "frame-count")?;
+    let step = optional_f32_parse_arg(&mut pos_iter, 1.0, "step")?;
+    if step <= 0.0 {
+        return Err("step must be positive".into());
+    }
+    if let Some(extra) = pos_iter.next() {
+        return Err(format!("unexpected extra argument: {extra}").into());
+    }
+
+    Ok(BenchPairConfig {
+        pmx_path,
+        vmd_path,
+        start_frame,
+        frame_count,
+        step,
+        solve_ik,
+        ik_options: IkSolveOptions {
+            tolerance: ik_tolerance,
+            max_iterations_cap: ik_max_iterations_cap,
+        },
+    })
+}
+
+fn optional_positive_usize_arg(
+    args: &mut impl Iterator<Item = String>,
+    default: usize,
+    label: &str,
+) -> Result<usize, Box<dyn std::error::Error>> {
+    let Some(value) = args.next() else {
+        return Ok(default);
+    };
+    let parsed = value
+        .parse::<usize>()
+        .map_err(|_| format!("invalid {label}: {value}"))?;
+    if parsed == 0 {
+        return Err(format!("{label} must be positive").into());
+    }
+    Ok(parsed)
+}
+
+fn optional_positive_u32_arg(
+    args: &mut impl Iterator<Item = String>,
+    default: u32,
+    label: &str,
+) -> Result<u32, Box<dyn std::error::Error>> {
+    let Some(value) = args.next() else {
+        return Ok(default);
+    };
+    let parsed = value
+        .parse::<u32>()
+        .map_err(|_| format!("invalid {label}: {value}"))?;
+    if parsed == 0 {
+        return Err(format!("{label} must be positive").into());
+    }
+    Ok(parsed)
+}
+
+fn parse_positive_u32(value: &str, label: &str) -> Result<u32, Box<dyn std::error::Error>> {
+    let parsed = value
+        .parse::<u32>()
+        .map_err(|_| format!("invalid {label}: {value}"))?;
+    if parsed == 0 {
+        return Err(format!("{label} must be positive").into());
+    }
+    Ok(parsed)
+}
+
+fn optional_f32_parse_arg(
+    args: &mut impl Iterator<Item = String>,
+    default: f32,
+    label: &str,
+) -> Result<f32, Box<dyn std::error::Error>> {
+    let Some(value) = args.next() else {
+        return Ok(default);
+    };
+    let parsed = value
+        .parse::<f32>()
+        .map_err(|_| format!("invalid {label}: {value}"))?;
+    if !parsed.is_finite() {
+        return Err(format!("{label} must be finite").into());
+    }
+    Ok(parsed)
+}
+
+fn parse_finite_f32(value: &str, label: &str) -> Result<f32, Box<dyn std::error::Error>> {
+    let parsed = value
+        .parse::<f32>()
+        .map_err(|_| format!("invalid {label}: {value}"))?;
+    if !parsed.is_finite() {
+        return Err(format!("{label} must be finite").into());
+    }
+    Ok(parsed)
+}

--- a/crates/mmd-anim-cli/src/commands/bench.rs
+++ b/crates/mmd-anim-cli/src/commands/bench.rs
@@ -1,15 +1,9 @@
-use std::{
-    fs,
-    path::PathBuf,
-    process::ExitCode,
-    sync::Arc,
-    time::Instant,
-};
+use std::{fs, path::PathBuf, process::ExitCode, sync::Arc, time::Instant};
 
 use glam::{Quat, Vec3A};
 use mmd_anim_runtime::{
-    AnimationClip, BoneAnimationBinding, BoneIndex, BoneInit, IkSolveOptions,
-    ModelArena, MovableBoneKeyframe, MovableBoneTrack, RuntimeInstance,
+    AnimationClip, BoneAnimationBinding, BoneIndex, BoneInit, IkSolveOptions, ModelArena,
+    MovableBoneKeyframe, MovableBoneTrack, RuntimeInstance,
 };
 
 use crate::{copy_world_matrices_to_f32, f32_checksum, translation_checksum};
@@ -253,7 +247,9 @@ pub(crate) struct BenchSyntheticConfig {
     pub(crate) use_json: bool,
 }
 
-pub(crate) fn bench_synthetic(cfg: BenchSyntheticConfig) -> Result<ExitCode, Box<dyn std::error::Error>> {
+pub(crate) fn bench_synthetic(
+    cfg: BenchSyntheticConfig,
+) -> Result<ExitCode, Box<dyn std::error::Error>> {
     let model_count = cfg.models;
     let bone_count = cfg.bones;
     let frame_count = cfg.frames;

--- a/crates/mmd-anim-cli/src/commands/compare.rs
+++ b/crates/mmd-anim-cli/src/commands/compare.rs
@@ -1,0 +1,1018 @@
+use std::{
+    collections::{HashMap, HashSet},
+    fs,
+    path::{Path, PathBuf},
+    process::ExitCode,
+    sync::Arc,
+};
+
+use mmd_anim_format::vmd::VmdBoneKeyframeRaw;
+use mmd_anim_runtime::{BoneIndex, IkSolveOptions, ModelArena, MorphIndex, RuntimeInstance};
+use mmd_anim_schema::{
+    DEFAULT_FOCUSED_IK_BONE_NAMES, MmdDumperOracleBone, MmdDumperOracleDump,
+    MmdDumperOracleModel,
+};
+
+use super::golden;
+
+pub(crate) const DIAGNOSE_NUMERIC_BONE_USAGE: &str = "usage: mmd-anim diagnose-numeric-bone <manifest.json> <case-name> <oracle-frame> [--eval-frame <frame>] <bone-name> [bone-name...]";
+
+pub(crate) fn compare_numeric_manifest(path: &Path) -> Result<ExitCode, Box<dyn std::error::Error>> {
+    const EPSILON: f64 = 0.003;
+
+    let manifest_dir = path.parent().unwrap_or_else(|| Path::new("."));
+    let manifest_bytes = fs::read(path)
+        .map_err(|error| format!("failed to read manifest {}: {}", path.display(), error))?;
+    let manifest: serde_json::Value = serde_json::from_slice(&manifest_bytes)?;
+    let out_dir = manifest
+        .pointer("/defaults/outDir")
+        .and_then(|value| value.as_str())
+        .map(|path| resolve_manifest_path(manifest_dir, path));
+    let default_epsilon = manifest
+        .pointer("/defaults/compare/epsilon")
+        .or_else(|| manifest.pointer("/defaults/epsilon"))
+        .and_then(|value| value.as_f64())
+        .unwrap_or(EPSILON);
+    let default_focus_bones = json_string_array(&manifest, "/defaults/focus/bones");
+    let default_motion_eval_frame_offset = json_f32(&manifest, "/defaults/compare/evalFrameOffset")
+        .or_else(|| json_f32(&manifest, "/defaults/evalFrameOffset"))
+        .unwrap_or(0.0);
+    let cases = manifest
+        .get("cases")
+        .and_then(|value| value.as_array())
+        .ok_or("numeric compare manifest is missing cases")?;
+    let mut camera_stats = CameraNumericCompareStats::default();
+    let mut motion_stats = MotionNumericCompareStats::default();
+
+    for case in cases {
+        let name = case
+            .get("name")
+            .and_then(|value| value.as_str())
+            .ok_or("numeric compare case is missing name")?;
+        let kind = case
+            .get("kind")
+            .and_then(|value| value.as_str())
+            .ok_or_else(|| format!("{name} is missing kind"))?;
+        match kind {
+            "camera-vmd" => {
+                let case_dir = out_dir.as_ref().map(|out_dir| out_dir.join(name));
+                compare_camera_numeric_case(
+                    case,
+                    manifest_dir,
+                    case_dir.as_deref(),
+                    default_epsilon,
+                    &mut camera_stats,
+                )?;
+            }
+            "motion-numeric" | "physics-coarse" => {
+                compare_motion_numeric_case(
+                    case,
+                    manifest_dir,
+                    default_epsilon,
+                    default_focus_bones.as_deref(),
+                    default_motion_eval_frame_offset,
+                    &mut motion_stats,
+                )?;
+            }
+            _ => {
+                return Err(format!(
+                    "numeric compare case {} has unsupported kind {}; supported kinds: camera-vmd, motion-numeric, physics-coarse",
+                    name, kind
+                )
+                .into());
+            }
+        }
+    }
+
+    let failure_count = numeric_compare_failure_count(&camera_stats, &motion_stats);
+    if failure_count == 0 {
+        println!(
+            "Numeric compare: ok cameraCases={} cameraFrames={} cameraMaxDelta={:.6} motionCases={} motionComparedCases={} motionSkippedUnsupported={} motionMissing={} motionImportErrors={} motionFrames={} motionBones={} motionMaxAbsError={:.6} motionWorst={} motionSkippedTargets={} defaultEpsilon={}",
+            camera_stats.compared_cases,
+            camera_stats.compared_frames,
+            camera_stats.max_delta,
+            motion_stats.total_cases,
+            motion_stats.compared_cases,
+            motion_stats.skipped_unsupported,
+            motion_stats.missing,
+            motion_stats.import_errors,
+            motion_stats.compared_frames,
+            motion_stats.compared_bones,
+            motion_stats.max_abs_error,
+            motion_stats.worst,
+            motion_stats.skipped_targets_csv(),
+            default_epsilon
+        );
+        Ok(ExitCode::SUCCESS)
+    } else {
+        Err(format!(
+            "Numeric compare failed: failures={} cameraMismatches={} motionMismatches={} motionMissing={} motionImportErrors={} cameraMaxDelta={:.6} motionMaxAbsError={:.6} motionWorst={} defaultEpsilon={}",
+            failure_count,
+            camera_stats.mismatch_count,
+            motion_stats.mismatch_count,
+            motion_stats.missing,
+            motion_stats.import_errors,
+            camera_stats.max_delta,
+            motion_stats.max_abs_error,
+            motion_stats.worst,
+            default_epsilon
+        )
+        .into())
+    }
+}
+
+#[derive(Default)]
+pub(crate) struct CameraNumericCompareStats {
+    pub(crate) compared_cases: usize,
+    pub(crate) compared_frames: usize,
+    pub(crate) mismatch_count: usize,
+    pub(crate) max_delta: f64,
+}
+
+fn compare_camera_numeric_case(
+    case: &serde_json::Value,
+    manifest_dir: &Path,
+    case_dir: Option<&Path>,
+    default_epsilon: f64,
+    stats: &mut CameraNumericCompareStats,
+) -> Result<ExitCode, Box<dyn std::error::Error>> {
+    let name = case
+        .get("name")
+        .and_then(|value| value.as_str())
+        .ok_or("numeric compare case is missing name")?;
+    let epsilon = case
+        .pointer("/compare/epsilon")
+        .and_then(|value| value.as_f64())
+        .unwrap_or(default_epsilon);
+    let oracle_path = resolve_camera_oracle_path(case, manifest_dir, case_dir)?;
+    let oracle_bytes = fs::read(&oracle_path).map_err(|error| {
+        format!(
+            "failed to read camera oracle for case {} at {}: {}",
+            name,
+            oracle_path.display(),
+            error
+        )
+    })?;
+    let oracle: serde_json::Value = serde_json::from_slice(&oracle_bytes)?;
+    let camera_vmd = resolve_camera_vmd_path(case, manifest_dir, case_dir)?;
+    let camera_vmd_bytes = fs::read(&camera_vmd).map_err(|error| {
+        format!(
+            "failed to read camera VMD for case {} at {}: {}",
+            name,
+            camera_vmd.display(),
+            error
+        )
+    })?;
+    let parsed = mmd_anim_format::parse_vmd_animation(&camera_vmd_bytes)?;
+    let frames = oracle
+        .get("frames")
+        .and_then(|value| value.as_array())
+        .ok_or_else(|| format!("{} is missing frames", oracle_path.display()))?;
+
+    stats.compared_cases += 1;
+    for frame_record in frames {
+        let frame = frame_record
+            .get("frame")
+            .and_then(|value| value.as_f64())
+            .ok_or_else(|| format!("{name} has a frame record without frame"))?;
+        let expected = frame_record
+            .get("camera")
+            .ok_or_else(|| format!("{name} frame {frame} is missing camera"))?;
+        let actual = mmd_anim_format::sample_vmd_camera_frames(&parsed.camera_frames, frame as f32)
+            .ok_or_else(|| format!("{} has no camera frames", camera_vmd.display()))?;
+
+        stats.compared_frames += 1;
+        stats.mismatch_count += compare_camera_scalar(
+            name,
+            frame,
+            "distance",
+            actual.distance as f64,
+            expected_number(expected, "distance")?,
+            epsilon,
+            &mut stats.max_delta,
+        );
+        stats.mismatch_count += compare_camera_vec3(
+            name,
+            frame,
+            "position",
+            actual.position,
+            expected_array3(expected, "position")?,
+            epsilon,
+            &mut stats.max_delta,
+        );
+        stats.mismatch_count += compare_camera_vec3(
+            name,
+            frame,
+            "rotation",
+            actual.rotation,
+            expected_array3(expected, "rotation")?,
+            epsilon,
+            &mut stats.max_delta,
+        );
+        stats.mismatch_count += compare_camera_scalar(
+            name,
+            frame,
+            "fov",
+            actual.fov as f64,
+            expected_number(expected, "fov")?,
+            epsilon,
+            &mut stats.max_delta,
+        );
+        let expected_perspective = expected
+            .get("perspective")
+            .and_then(|value| value.as_bool())
+            .ok_or_else(|| format!("{name} frame {frame} camera.perspective is missing"))?;
+        if actual.perspective != expected_perspective {
+            stats.mismatch_count += 1;
+            eprintln!(
+                "camera mismatch case={} frame={} field=perspective actual={} expected={}",
+                name, frame, actual.perspective, expected_perspective
+            );
+        }
+    }
+    Ok(ExitCode::SUCCESS)
+}
+
+#[derive(Default)]
+pub(crate) struct MotionNumericCompareStats {
+    pub(crate) total_cases: usize,
+    pub(crate) compared_cases: usize,
+    pub(crate) skipped_unsupported: usize,
+    pub(crate) missing: usize,
+    pub(crate) import_errors: usize,
+    pub(crate) compared_frames: usize,
+    pub(crate) compared_bones: usize,
+    pub(crate) mismatch_count: usize,
+    pub(crate) skipped_targets: HashSet<String>,
+    pub(crate) max_abs_error: f32,
+    pub(crate) worst: String,
+}
+
+pub(crate) fn numeric_compare_failure_count(
+    camera_stats: &CameraNumericCompareStats,
+    motion_stats: &MotionNumericCompareStats,
+) -> usize {
+    camera_stats.mismatch_count
+        + motion_stats.mismatch_count
+        + motion_stats.missing
+        + motion_stats.import_errors
+}
+
+impl MotionNumericCompareStats {
+    fn skipped_targets_csv(&self) -> String {
+        let mut targets: Vec<_> = self.skipped_targets.iter().cloned().collect();
+        targets.sort();
+        targets.join(",")
+    }
+}
+
+fn compare_motion_numeric_case(
+    case: &serde_json::Value,
+    manifest_dir: &Path,
+    default_epsilon: f64,
+    default_focus_bones: Option<&[String]>,
+    default_eval_frame_offset: f32,
+    stats: &mut MotionNumericCompareStats,
+) -> Result<ExitCode, Box<dyn std::error::Error>> {
+    stats.total_cases += 1;
+    if stats.worst.is_empty() {
+        stats.worst = String::from("none");
+    }
+    let name = case
+        .get("name")
+        .and_then(|value| value.as_str())
+        .ok_or("numeric compare case is missing name")?;
+    let epsilon = case
+        .pointer("/compare/epsilon")
+        .and_then(|value| value.as_f64())
+        .unwrap_or(default_epsilon) as f32;
+    let eval_frame_offset = json_f32(case, "/compare/evalFrameOffset")
+        .or_else(|| json_f32(case, "/metadata/evalFrameOffset"))
+        .unwrap_or(default_eval_frame_offset);
+    collect_unsupported_targets(case, &mut stats.skipped_targets);
+
+    let model_path = match case
+        .pointer("/assets/model")
+        .and_then(|value| value.as_str())
+        .map(|value| resolve_manifest_path(manifest_dir, value))
+    {
+        Some(path) => path,
+        None => {
+            stats.missing += 1;
+            eprintln!("missing: {name} assets.model");
+            return Ok(ExitCode::SUCCESS);
+        }
+    };
+    let motion_path = match case
+        .pointer("/assets/motion")
+        .and_then(|value| value.as_str())
+        .map(|value| resolve_manifest_path(manifest_dir, value))
+    {
+        Some(path) => path,
+        None => {
+            stats.missing += 1;
+            eprintln!("missing: {name} assets.motion");
+            return Ok(ExitCode::SUCCESS);
+        }
+    };
+    let oracle_path = match case
+        .pointer("/oracle/path")
+        .and_then(|value| value.as_str())
+        .map(|value| resolve_manifest_path(manifest_dir, value))
+    {
+        Some(path) => path,
+        None => {
+            stats.missing += 1;
+            eprintln!("missing: {name} oracle.path");
+            return Ok(ExitCode::SUCCESS);
+        }
+    };
+
+    if !golden::is_supported_golden_model(&model_path) {
+        stats.skipped_unsupported += 1;
+        eprintln!("skipped unsupported model: {}", model_path.display());
+        return Ok(ExitCode::SUCCESS);
+    }
+    if !model_path.exists() || !motion_path.exists() || !oracle_path.exists() {
+        stats.missing += 1;
+        if !model_path.exists() {
+            eprintln!("missing: {}", model_path.display());
+        }
+        if !motion_path.exists() {
+            eprintln!("missing: {}", motion_path.display());
+        }
+        if !oracle_path.exists() {
+            eprintln!("missing: {}", oracle_path.display());
+        }
+        return Ok(ExitCode::SUCCESS);
+    }
+
+    let frames = numeric_case_frames(case)?;
+    let dump =
+        MmdDumperOracleDump::from_jsonl_str(&fs::read_to_string(&oracle_path)?, Some(&frames))?;
+    let focus_bones = motion_case_focus_bones(case, default_focus_bones);
+    let focus_bone_names: Vec<&str> = focus_bones.iter().map(String::as_str).collect();
+
+    let model_bytes = fs::read(&model_path)?;
+    let model_import = match golden::import_golden_runtime_model(&model_path, &model_bytes) {
+        Ok(import) => import,
+        Err(error) => {
+            stats.import_errors += 1;
+            eprintln!("import-error: {}: {}", model_path.display(), error);
+            return Ok(ExitCode::SUCCESS);
+        }
+    };
+    let vmd_bytes = fs::read(&motion_path)?;
+    let vmd = match mmd_anim_format::import_vmd_motion(&vmd_bytes) {
+        Ok(vmd) => vmd,
+        Err(error) => {
+            stats.import_errors += 1;
+            eprintln!("import-error: {}: {}", motion_path.display(), error);
+            return Ok(ExitCode::SUCCESS);
+        }
+    };
+
+    let solver_count = model_import.model.ik_count();
+    let clip = mmd_anim_format::build_pair_clip_with_options(
+        &vmd,
+        &model_import.bone_name_to_index,
+        &model_import.morph_name_to_index,
+        &model_import.ik_solver_bone_name_to_index,
+        solver_count,
+        mmd_anim_format::VmdClipBuildOptions {
+            honor_property_ik: false,
+        },
+    );
+
+    let model = Arc::new(model_import.model);
+    let morph_count = model_import
+        .morph_name_to_index
+        .values()
+        .map(|index| index.as_usize() + 1)
+        .max()
+        .unwrap_or(0);
+    let mut runtime =
+        RuntimeInstance::new_with_counts(Arc::clone(&model), morph_count, solver_count);
+
+    for oracle_frame in &dump.frames {
+        let eval_frame = oracle_frame.frame as f32 + eval_frame_offset;
+        runtime.evaluate_clip_frame(&clip, eval_frame);
+        let Some(model0) = oracle_frame.models.first() else {
+            continue;
+        };
+        let world_matrices = runtime.world_matrices();
+        for oracle_bone in model0.focused_ik_bones(&focus_bone_names) {
+            if oracle_bone.index < 0 {
+                continue;
+            }
+            let index = oracle_bone.index as usize;
+            if index >= world_matrices.len() {
+                continue;
+            }
+            let runtime_matrix = world_matrices[index].to_cols_array();
+            for (component, actual) in runtime_matrix.iter().enumerate() {
+                let abs_error = (*actual - oracle_bone.world_matrix[component]).abs();
+                if abs_error > stats.max_abs_error {
+                    stats.max_abs_error = abs_error;
+                    stats.worst = format!("{}:{}:{}", name, oracle_frame.frame, oracle_bone.name);
+                }
+                if abs_error > epsilon {
+                    stats.mismatch_count += 1;
+                    eprintln!(
+                        "motion mismatch case={} frame={} evalFrame={:.3} bone={} component={} actual={:.9} expected={:.9} delta={:.9} epsilon={:.9}",
+                        name,
+                        oracle_frame.frame,
+                        eval_frame,
+                        oracle_bone.name,
+                        component,
+                        actual,
+                        oracle_bone.world_matrix[component],
+                        abs_error,
+                        epsilon
+                    );
+                }
+            }
+            stats.compared_bones += 1;
+        }
+        stats.compared_frames += 1;
+    }
+    stats.compared_cases += 1;
+    Ok(ExitCode::SUCCESS)
+}
+
+pub(crate) fn diagnose_numeric_bones(
+    manifest_path: &Path,
+    case_name: &str,
+    oracle_frame_number: f32,
+    eval_frame: f32,
+    bone_names: &[String],
+) -> Result<ExitCode, Box<dyn std::error::Error>> {
+    let manifest_dir = manifest_path.parent().unwrap_or_else(|| Path::new("."));
+    let manifest: serde_json::Value = serde_json::from_str(&fs::read_to_string(manifest_path)?)?;
+    let cases = manifest
+        .get("cases")
+        .and_then(|value| value.as_array())
+        .ok_or("numeric manifest is missing cases")?;
+    let case = cases
+        .iter()
+        .find(|case| case.get("name").and_then(|value| value.as_str()) == Some(case_name))
+        .ok_or_else(|| format!("numeric manifest has no case named {case_name}"))?;
+
+    let model_path = case
+        .pointer("/assets/model")
+        .and_then(|value| value.as_str())
+        .map(|value| resolve_manifest_path(manifest_dir, value))
+        .ok_or("case is missing assets.model")?;
+    let motion_path = case
+        .pointer("/assets/motion")
+        .and_then(|value| value.as_str())
+        .map(|value| resolve_manifest_path(manifest_dir, value))
+        .ok_or("case is missing assets.motion")?;
+    let oracle_path = case
+        .pointer("/oracle/path")
+        .and_then(|value| value.as_str())
+        .map(|value| resolve_manifest_path(manifest_dir, value))
+        .ok_or("case is missing oracle.path")?;
+
+    let target_frame = oracle_frame_number.round() as i32;
+    let dump = MmdDumperOracleDump::from_jsonl_str(
+        &fs::read_to_string(&oracle_path)?,
+        Some(&[target_frame]),
+    )?;
+    let oracle_frame = dump
+        .find_frame(target_frame)
+        .ok_or_else(|| format!("oracle has no frame {target_frame}"))?;
+    let oracle_model = oracle_frame
+        .models
+        .first()
+        .ok_or_else(|| format!("oracle frame {target_frame} has no model"))?;
+
+    let model_bytes = fs::read(&model_path)?;
+    let model_import = golden::import_golden_runtime_model(&model_path, &model_bytes)?;
+    let vmd = mmd_anim_format::import_vmd_motion(&fs::read(&motion_path)?)?;
+    let solver_count = model_import.model.ik_count();
+    let clip = mmd_anim_format::build_pair_clip_with_options(
+        &vmd,
+        &model_import.bone_name_to_index,
+        &model_import.morph_name_to_index,
+        &model_import.ik_solver_bone_name_to_index,
+        solver_count,
+        mmd_anim_format::VmdClipBuildOptions {
+            honor_property_ik: false,
+        },
+    );
+
+    let morph_count = model_import
+        .morph_name_to_index
+        .values()
+        .map(|index| index.as_usize() + 1)
+        .max()
+        .unwrap_or(0);
+    let model = Arc::new(model_import.model);
+    let mut pre_ik =
+        RuntimeInstance::new_with_counts(Arc::clone(&model), morph_count, solver_count);
+    let mut post_ik =
+        RuntimeInstance::new_with_counts(Arc::clone(&model), morph_count, solver_count);
+    pre_ik.evaluate_clip_frame_without_ik(&clip, eval_frame);
+    post_ik.evaluate_clip_frame_with_ik_options(&clip, eval_frame, IkSolveOptions::default());
+
+    println!(
+        "numeric bone diagnosis case={} oracleFrame={:.3} evalFrame={:.3} model={} motion={} oracle={}",
+        case_name,
+        oracle_frame_number,
+        eval_frame,
+        model_path.display(),
+        motion_path.display(),
+        oracle_path.display()
+    );
+    for bone_name in bone_names {
+        let normalized = mmd_anim_format::normalize_vmd_name(bone_name.as_bytes());
+        let Some(index) = model_import
+            .bone_name_to_index
+            .get(bone_name.as_bytes())
+            .or_else(|| model_import.bone_name_to_index.get(&normalized))
+            .copied()
+        else {
+            println!("bone={} missing runtimeIndex", bone_name);
+            continue;
+        };
+        let Some(oracle_bone) = oracle_model.find_bone(bone_name) else {
+            println!(
+                "bone={} runtimeIndex={} missing oracleBone",
+                bone_name,
+                index.as_usize()
+            );
+            continue;
+        };
+        let pre = pre_ik.world_matrices()[index.as_usize()].to_cols_array();
+        let post = post_ik.world_matrices()[index.as_usize()].to_cols_array();
+        let (pre_component, pre_delta) = max_matrix_delta(&pre, &oracle_bone.world_matrix);
+        let (post_component, post_delta) = max_matrix_delta(&post, &oracle_bone.world_matrix);
+        let pre_pos_delta = position_delta(&pre, &oracle_bone.world_matrix);
+        let post_pos_delta = position_delta(&post, &oracle_bone.world_matrix);
+        let pre_local_pos = pre_ik.pose().local_position_offset(index);
+        let post_local_pos = post_ik.pose().local_position_offset(index);
+        let pre_local_rot = pre_ik.pose().local_rotation(index);
+        let post_local_rot = post_ik.pose().local_rotation(index);
+        let pre_local_axis = pre_local_rot.to_axis_angle();
+        let post_local_axis = post_local_rot.to_axis_angle();
+        let oracle_local = oracle_local_matrix(oracle_model, &model, oracle_bone);
+        let (_, oracle_local_rot, oracle_local_pos) =
+            glam::Mat4::from_cols_array(&oracle_local).to_scale_rotation_translation();
+        let oracle_local_axis = oracle_local_rot.to_axis_angle();
+        let vmd_keyframes: Vec<_> = vmd
+            .bone_keyframes
+            .iter()
+            .filter(|kf| {
+                model_import
+                    .bone_name_to_index
+                    .get(&kf.bone_name_normalized)
+                    == Some(&index)
+            })
+            .collect();
+        let vmd_lookup_frame = eval_frame;
+        let exact_vmd_keyframes: Vec<_> = vmd_keyframes
+            .iter()
+            .copied()
+            .filter(|kf| kf.frame as f32 == vmd_lookup_frame)
+            .collect();
+        let exact_vmd_rotation = exact_vmd_keyframes
+            .first()
+            .map(|kf| kf.rotation.to_axis_angle());
+        let prev_vmd_keyframe = vmd_keyframes
+            .iter()
+            .copied()
+            .filter(|kf| kf.frame as f32 <= vmd_lookup_frame)
+            .max_by_key(|kf| kf.frame)
+            .map(format_vmd_keyframe)
+            .unwrap_or_else(|| "none".to_owned());
+        let next_vmd_keyframe = vmd_keyframes
+            .iter()
+            .copied()
+            .filter(|kf| kf.frame as f32 > vmd_lookup_frame)
+            .min_by_key(|kf| kf.frame)
+            .map(format_vmd_keyframe)
+            .unwrap_or_else(|| "none".to_owned());
+        let bone_morphs =
+            describe_active_bone_morphs(&model_import.morph_name_to_index, &post_ik, &model, index);
+        println!(
+            "bone={} index={} oracleIndex={} preMaxDelta={:.9}@{} postMaxDelta={:.9}@{} prePosDelta=({:.6},{:.6},{:.6}) postPosDelta=({:.6},{:.6},{:.6}) prePos=({:.6},{:.6},{:.6}) postPos=({:.6},{:.6},{:.6}) oraclePos=({:.6},{:.6},{:.6}) preLocalOffset=({:.6},{:.6},{:.6}) postLocalOffset=({:.6},{:.6},{:.6}) oracleLocalPos=({:.6},{:.6},{:.6}) preLocalRotAxis=({:.6},{:.6},{:.6}) preLocalRotAngle={:.6} postLocalRotAxis=({:.6},{:.6},{:.6}) postLocalRotAngle={:.6} oracleLocalRotAxis=({:.6},{:.6},{:.6}) oracleLocalRotAngle={:.6} vmdKeys={} exactVmdKeys={} exactVmdRot={} prevVmd={} nextVmd={} activeBoneMorphs={}",
+            bone_name,
+            index.as_usize(),
+            oracle_bone.index,
+            pre_delta,
+            pre_component,
+            post_delta,
+            post_component,
+            pre_pos_delta[0],
+            pre_pos_delta[1],
+            pre_pos_delta[2],
+            post_pos_delta[0],
+            post_pos_delta[1],
+            post_pos_delta[2],
+            pre[12],
+            pre[13],
+            pre[14],
+            post[12],
+            post[13],
+            post[14],
+            oracle_bone.world_matrix[12],
+            oracle_bone.world_matrix[13],
+            oracle_bone.world_matrix[14],
+            pre_local_pos.x,
+            pre_local_pos.y,
+            pre_local_pos.z,
+            post_local_pos.x,
+            post_local_pos.y,
+            post_local_pos.z,
+            oracle_local_pos.x,
+            oracle_local_pos.y,
+            oracle_local_pos.z,
+            pre_local_axis.0.x,
+            pre_local_axis.0.y,
+            pre_local_axis.0.z,
+            pre_local_axis.1,
+            post_local_axis.0.x,
+            post_local_axis.0.y,
+            post_local_axis.0.z,
+            post_local_axis.1,
+            oracle_local_axis.0.x,
+            oracle_local_axis.0.y,
+            oracle_local_axis.0.z,
+            oracle_local_axis.1,
+            vmd_keyframes.len(),
+            exact_vmd_keyframes.len(),
+            exact_vmd_rotation
+                .map(|axis| format!(
+                    "axis=({:.6},{:.6},{:.6}) angle={:.6}",
+                    axis.0.x, axis.0.y, axis.0.z, axis.1
+                ))
+                .unwrap_or_else(|| "none".to_owned()),
+            prev_vmd_keyframe,
+            next_vmd_keyframe,
+            bone_morphs,
+        );
+    }
+
+    Ok(ExitCode::SUCCESS)
+}
+
+pub(crate) struct DiagnoseNumericBoneOptions {
+    pub(crate) eval_frame: f32,
+    pub(crate) bone_names: Vec<String>,
+}
+
+pub(crate) fn parse_diagnose_numeric_bone_rest(
+    rest: Vec<String>,
+    default_eval_frame: f32,
+) -> DiagnoseNumericBoneOptions {
+    let mut eval_frame = default_eval_frame;
+    let mut bone_names = Vec::new();
+    let mut iter = rest.into_iter();
+    while let Some(arg) = iter.next() {
+        if arg == "--eval-frame" {
+            let Some(value) = iter.next() else {
+                eprintln!("{DIAGNOSE_NUMERIC_BONE_USAGE}");
+                std::process::exit(1);
+            };
+            eval_frame = value.parse().unwrap_or_else(|_| {
+                eprintln!("{DIAGNOSE_NUMERIC_BONE_USAGE}");
+                std::process::exit(1);
+            });
+        } else if arg.starts_with("--") {
+            eprintln!("unknown flag: {arg}");
+            eprintln!("{DIAGNOSE_NUMERIC_BONE_USAGE}");
+            std::process::exit(1);
+        } else {
+            bone_names.push(arg);
+        }
+    }
+    DiagnoseNumericBoneOptions {
+        eval_frame,
+        bone_names,
+    }
+}
+
+fn describe_active_bone_morphs(
+    morph_name_to_index: &HashMap<Vec<u8>, MorphIndex>,
+    runtime: &RuntimeInstance,
+    model: &ModelArena,
+    target_bone: BoneIndex,
+) -> String {
+    let mut entries = Vec::new();
+    for morph_index in 0..model.morph_count() as usize {
+        let span = model.bone_morph_spans()[morph_index];
+        if span.count == 0 {
+            continue;
+        }
+        let weight = runtime.pose().morph_weight(MorphIndex(morph_index as u32));
+        for offset_index in span.start..span.start + span.count {
+            let offset = model.bone_morph_offsets()[offset_index as usize];
+            if offset.target_bone != target_bone {
+                continue;
+            }
+            let axis = offset.rotation_offset.to_axis_angle();
+            entries.push(format!(
+                "morph={} name={} weight={:.6} pos=({:.6},{:.6},{:.6}) rotAxis=({:.6},{:.6},{:.6}) rotAngle={:.6}",
+                morph_index,
+                morph_names_for_index(morph_name_to_index, MorphIndex(morph_index as u32)).join("|"),
+                weight,
+                offset.position_offset.x,
+                offset.position_offset.y,
+                offset.position_offset.z,
+                axis.0.x,
+                axis.0.y,
+                axis.0.z,
+                axis.1
+            ));
+        }
+    }
+    if entries.is_empty() {
+        "none".to_owned()
+    } else {
+        entries.join(";")
+    }
+}
+
+fn morph_names_for_index(
+    morph_name_to_index: &HashMap<Vec<u8>, MorphIndex>,
+    target_index: MorphIndex,
+) -> Vec<String> {
+    let mut names: Vec<String> = morph_name_to_index
+        .iter()
+        .filter_map(|(name, index)| {
+            if *index != target_index {
+                return None;
+            }
+            String::from_utf8(name.clone()).ok()
+        })
+        .collect();
+    names.sort();
+    names.dedup();
+    names
+}
+
+fn format_vmd_keyframe(kf: &VmdBoneKeyframeRaw) -> String {
+    let axis = kf.rotation.to_axis_angle();
+    format!(
+        "frame={} pos=({:.6},{:.6},{:.6}) rotAxis=({:.6},{:.6},{:.6}) rotAngle={:.6}",
+        kf.frame, kf.position.x, kf.position.y, kf.position.z, axis.0.x, axis.0.y, axis.0.z, axis.1
+    )
+}
+
+fn oracle_local_matrix(
+    oracle_model: &MmdDumperOracleModel,
+    model: &ModelArena,
+    oracle_bone: &MmdDumperOracleBone,
+) -> [f32; 16] {
+    let bone_matrix = glam::Mat4::from_cols_array(&oracle_bone.world_matrix);
+    let Some(parent) = model.parent_index(BoneIndex(oracle_bone.index as u32)) else {
+        return oracle_bone.world_matrix;
+    };
+    let Some(parent_bone) = oracle_model
+        .bones
+        .iter()
+        .find(|bone| bone.index == parent.as_usize() as i32)
+    else {
+        return oracle_bone.world_matrix;
+    };
+    let parent_matrix = glam::Mat4::from_cols_array(&parent_bone.world_matrix);
+    (parent_matrix.inverse() * bone_matrix).to_cols_array()
+}
+
+fn max_matrix_delta(actual: &[f32; 16], expected: &[f32; 16]) -> (usize, f32) {
+    let mut max_component = 0;
+    let mut max_delta = 0.0f32;
+    for component in 0..16 {
+        let delta = (actual[component] - expected[component]).abs();
+        if delta > max_delta {
+            max_component = component;
+            max_delta = delta;
+        }
+    }
+    (max_component, max_delta)
+}
+
+fn position_delta(actual: &[f32; 16], expected: &[f32; 16]) -> [f32; 3] {
+    [
+        actual[12] - expected[12],
+        actual[13] - expected[13],
+        actual[14] - expected[14],
+    ]
+}
+
+pub(crate) fn motion_case_focus_bones(
+    case: &serde_json::Value,
+    default_focus_bones: Option<&[String]>,
+) -> Vec<String> {
+    json_string_array(case, "/metadata/focus/bones")
+        .or_else(|| json_string_array(case, "/focus/bones"))
+        .or_else(|| default_focus_bones.map(|bones| bones.to_vec()))
+        .unwrap_or_else(|| {
+            DEFAULT_FOCUSED_IK_BONE_NAMES
+                .iter()
+                .map(|name| (*name).to_owned())
+                .collect()
+        })
+}
+
+pub(crate) fn json_string_array(value: &serde_json::Value, pointer: &str) -> Option<Vec<String>> {
+    let values = value.pointer(pointer)?.as_array()?;
+    let strings: Vec<String> = values
+        .iter()
+        .filter_map(|value| value.as_str().map(ToOwned::to_owned))
+        .collect();
+    (!strings.is_empty()).then_some(strings)
+}
+
+pub(crate) fn json_f32(value: &serde_json::Value, pointer: &str) -> Option<f32> {
+    value.pointer(pointer)?.as_f64().map(|value| value as f32)
+}
+
+fn collect_unsupported_targets(case: &serde_json::Value, skipped_targets: &mut HashSet<String>) {
+    let Some(targets) = case
+        .pointer("/compare/targets")
+        .and_then(|value| value.as_array())
+    else {
+        return;
+    };
+    for target in targets {
+        let Some(target) = target.as_str() else {
+            continue;
+        };
+        if !matches!(target, "bones") {
+            skipped_targets.insert(target.to_owned());
+        }
+    }
+}
+
+fn numeric_case_frames(case: &serde_json::Value) -> Result<Vec<i32>, Box<dyn std::error::Error>> {
+    let frames = case
+        .get("frames")
+        .and_then(|value| value.as_array())
+        .ok_or("numeric compare case is missing frames")?;
+    frames
+        .iter()
+        .map(|frame| {
+            frame
+                .as_i64()
+                .and_then(|frame| i32::try_from(frame).ok())
+                .ok_or_else(|| "numeric compare frame must be an i32".into())
+        })
+        .collect()
+}
+
+pub(crate) fn resolve_manifest_path(manifest_dir: &Path, value: &str) -> PathBuf {
+    let path = PathBuf::from(value);
+    if path.is_absolute() {
+        path
+    } else {
+        manifest_dir.join(path)
+    }
+}
+
+fn resolve_camera_vmd_path(
+    case: &serde_json::Value,
+    manifest_dir: &Path,
+    case_dir: Option<&Path>,
+) -> Result<PathBuf, Box<dyn std::error::Error>> {
+    let camera_vmd = case
+        .pointer("/assets/cameraMotion")
+        .or_else(|| case.pointer("/assets/cameraVmd"))
+        .or_else(|| case.get("cameraVmd"))
+        .or_else(|| case.get("cameraMotion"))
+        .and_then(|value| value.as_str())
+        .ok_or("camera manifest case is missing assets.cameraMotion/cameraVmd")?;
+    let camera_vmd = resolve_manifest_path(manifest_dir, camera_vmd);
+    if camera_vmd.exists() {
+        return Ok(camera_vmd);
+    }
+
+    let fixture_path = case
+        .get("fixture")
+        .and_then(|value| value.as_str())
+        .map(|path| resolve_manifest_path(manifest_dir, path))
+        .or_else(|| case_dir.map(|case_dir| case_dir.join("fixture.json")));
+    let Some(fixture_path) = fixture_path else {
+        return Err(format!(
+            "{} does not exist and no fixture path is available",
+            camera_vmd.display()
+        )
+        .into());
+    };
+    let fixture: serde_json::Value = serde_json::from_slice(&fs::read(&fixture_path)?)?;
+    let staged = fixture
+        .get("stagedCameraVmd")
+        .or_else(|| fixture.get("stagedCameraMotion"))
+        .and_then(|value| value.as_str())
+        .ok_or_else(|| {
+            format!(
+                "{} does not exist and {} is missing stagedCameraVmd/stagedCameraMotion",
+                camera_vmd.display(),
+                fixture_path.display()
+            )
+        })?;
+    let fixture_dir = fixture_path.parent().unwrap_or(manifest_dir);
+    Ok(resolve_manifest_path(fixture_dir, staged))
+}
+
+fn resolve_camera_oracle_path(
+    case: &serde_json::Value,
+    manifest_dir: &Path,
+    case_dir: Option<&Path>,
+) -> Result<PathBuf, Box<dyn std::error::Error>> {
+    if let Some(output) = case
+        .pointer("/oracle/path")
+        .or_else(|| case.get("output"))
+        .and_then(|value| value.as_str())
+    {
+        return Ok(resolve_manifest_path(manifest_dir, output));
+    }
+    if let Some(case_dir) = case_dir {
+        return Ok(case_dir.join("oracle.actual.json"));
+    }
+    Err(
+        "camera manifest case is missing oracle.path/output and no defaults.outDir is available"
+            .into(),
+    )
+}
+
+fn expected_number(
+    camera: &serde_json::Value,
+    field: &str,
+) -> Result<f64, Box<dyn std::error::Error>> {
+    camera
+        .get(field)
+        .and_then(|value| value.as_f64())
+        .ok_or_else(|| format!("camera.{field} is missing").into())
+}
+
+fn expected_array3(
+    camera: &serde_json::Value,
+    field: &str,
+) -> Result<[f64; 3], Box<dyn std::error::Error>> {
+    let values = camera
+        .get(field)
+        .and_then(|value| value.as_array())
+        .ok_or_else(|| format!("camera.{field} is missing"))?;
+    if values.len() != 3 {
+        return Err(format!("camera.{field} must have exactly 3 values").into());
+    }
+    Ok([
+        values[0]
+            .as_f64()
+            .ok_or_else(|| format!("camera.{field}[0] is not a number"))?,
+        values[1]
+            .as_f64()
+            .ok_or_else(|| format!("camera.{field}[1] is not a number"))?,
+        values[2]
+            .as_f64()
+            .ok_or_else(|| format!("camera.{field}[2] is not a number"))?,
+    ])
+}
+
+fn compare_camera_vec3(
+    case_name: &str,
+    frame: f64,
+    field: &str,
+    actual: [f32; 3],
+    expected: [f64; 3],
+    epsilon: f64,
+    max_delta: &mut f64,
+) -> usize {
+    let mut mismatches = 0usize;
+    for component in 0..3 {
+        mismatches += compare_camera_scalar(
+            case_name,
+            frame,
+            &format!("{field}[{component}]"),
+            actual[component] as f64,
+            expected[component],
+            epsilon,
+            max_delta,
+        );
+    }
+    mismatches
+}
+
+fn compare_camera_scalar(
+    case_name: &str,
+    frame: f64,
+    field: &str,
+    actual: f64,
+    expected: f64,
+    epsilon: f64,
+    max_delta: &mut f64,
+) -> usize {
+    let delta = (actual - expected).abs();
+    *max_delta = (*max_delta).max(delta);
+    if delta <= epsilon {
+        0
+    } else {
+        eprintln!(
+            "camera mismatch case={} frame={} field={} actual={:.9} expected={:.9} delta={:.9}",
+            case_name, frame, field, actual, expected, delta
+        );
+        1
+    }
+}

--- a/crates/mmd-anim-cli/src/commands/compare.rs
+++ b/crates/mmd-anim-cli/src/commands/compare.rs
@@ -9,7 +9,7 @@ use std::{
 use mmd_anim_format::vmd::VmdBoneKeyframeRaw;
 use mmd_anim_runtime::{BoneIndex, IkSolveOptions, ModelArena, MorphIndex, RuntimeInstance};
 use mmd_anim_schema::{
-    MmdDumperOracleBone, MmdDumperOracleDump, MmdDumperOracleModel, DEFAULT_FOCUSED_IK_BONE_NAMES,
+    DEFAULT_FOCUSED_IK_BONE_NAMES, MmdDumperOracleBone, MmdDumperOracleDump, MmdDumperOracleModel,
 };
 
 use super::golden;

--- a/crates/mmd-anim-cli/src/commands/compare.rs
+++ b/crates/mmd-anim-cli/src/commands/compare.rs
@@ -9,15 +9,16 @@ use std::{
 use mmd_anim_format::vmd::VmdBoneKeyframeRaw;
 use mmd_anim_runtime::{BoneIndex, IkSolveOptions, ModelArena, MorphIndex, RuntimeInstance};
 use mmd_anim_schema::{
-    DEFAULT_FOCUSED_IK_BONE_NAMES, MmdDumperOracleBone, MmdDumperOracleDump,
-    MmdDumperOracleModel,
+    MmdDumperOracleBone, MmdDumperOracleDump, MmdDumperOracleModel, DEFAULT_FOCUSED_IK_BONE_NAMES,
 };
 
 use super::golden;
 
 pub(crate) const DIAGNOSE_NUMERIC_BONE_USAGE: &str = "usage: mmd-anim diagnose-numeric-bone <manifest.json> <case-name> <oracle-frame> [--eval-frame <frame>] <bone-name> [bone-name...]";
 
-pub(crate) fn compare_numeric_manifest(path: &Path) -> Result<ExitCode, Box<dyn std::error::Error>> {
+pub(crate) fn compare_numeric_manifest(
+    path: &Path,
+) -> Result<ExitCode, Box<dyn std::error::Error>> {
     const EPSILON: f64 = 0.003;
 
     let manifest_dir = path.parent().unwrap_or_else(|| Path::new("."));

--- a/crates/mmd-anim-cli/src/commands/export.rs
+++ b/crates/mmd-anim-cli/src/commands/export.rs
@@ -1,11 +1,13 @@
-use std::{fs, path::Path, process::ExitCode};
+use std::{path::Path, process::ExitCode};
 
 use serde_json::json;
+
+use crate::{diagnostics_suffix, read_file, read_text_file, unsupported_format_error, write_file};
 
 pub(crate) fn export_roundtrip_summary(
     path: &Path,
 ) -> Result<ExitCode, Box<dyn std::error::Error>> {
-    let data = fs::read(path)?;
+    let data = read_file(path)?;
     match mmd_anim_format::detect_mmd_format(&data, path.file_name().and_then(|v| v.to_str())) {
         mmd_anim_format::MmdFormatKind::Vmd => {
             let parsed = mmd_anim_format::parse_vmd_animation(&data)?;
@@ -87,13 +89,13 @@ pub(crate) fn export_roundtrip_summary(
             let _reparsed = mmd_anim_format::parse_pmm_manifest(&exported)?;
             ensure_pmm_lossless_roundtrip(&data, &exported)?;
             println!(
-                "PMM export roundtrip: ok bytesIn={} bytesOut={} version={} modelReferences={} assetReferences={} diagnostics={}",
+                "PMM export roundtrip: ok bytesIn={} bytesOut={} version={} modelReferences={} assetReferences={}{}",
                 data.len(),
                 exported.len(),
                 parsed.version,
                 parsed.model_paths.len(),
                 parsed.asset_summary.reference_count,
-                parsed.diagnostics.len()
+                diagnostics_suffix(parsed.diagnostics.len())
             );
             Ok(ExitCode::SUCCESS)
         }
@@ -104,21 +106,22 @@ pub(crate) fn export_roundtrip_summary(
             let reparsed = mmd_anim_format::parse_accessory_manifest(&exported, file_name)?;
             ensure_accessory_roundtrip(&parsed, &reparsed)?;
             println!(
-                "{} export roundtrip: ok bytesIn={} bytesOut={} textures={} diagnostics={}",
+                "{} export roundtrip: ok bytesIn={} bytesOut={} textures={}{}",
                 parsed.format.to_ascii_uppercase(),
                 data.len(),
                 exported.len(),
                 parsed.texture_references.len(),
-                parsed.diagnostics.len()
+                diagnostics_suffix(parsed.diagnostics.len())
             );
             Ok(ExitCode::SUCCESS)
         }
+        mmd_anim_format::MmdFormatKind::Unknown => Err(unsupported_format_error(path)),
         kind => Err(format!("export roundtrip is not implemented for {kind:?}").into()),
     }
 }
 
 pub(crate) fn export_roundtrip_json(path: &Path) -> Result<ExitCode, Box<dyn std::error::Error>> {
-    let data = fs::read(path)?;
+    let data = read_file(path)?;
     let result = match mmd_anim_format::detect_mmd_format(
         &data,
         path.file_name().and_then(|v| v.to_str()),
@@ -208,6 +211,7 @@ pub(crate) fn export_roundtrip_json(path: &Path) -> Result<ExitCode, Box<dyn std
                 &parsed,
             )
         }
+        mmd_anim_format::MmdFormatKind::Unknown => return Err(unsupported_format_error(path)),
         kind => return Err(format!("export roundtrip is not implemented for {kind:?}").into()),
     };
     println!("{}", serde_json::to_string_pretty(&result)?);
@@ -217,7 +221,7 @@ pub(crate) fn export_roundtrip_json(path: &Path) -> Result<ExitCode, Box<dyn std
 pub(crate) fn export_json_roundtrip_summary(
     path: &Path,
 ) -> Result<ExitCode, Box<dyn std::error::Error>> {
-    let data = fs::read(path)?;
+    let data = read_file(path)?;
     match mmd_anim_format::detect_mmd_format(&data, path.file_name().and_then(|v| v.to_str())) {
         mmd_anim_format::MmdFormatKind::Vmd => {
             let parsed = mmd_anim_format::parse_vmd_animation(&data)?;
@@ -315,16 +319,17 @@ pub(crate) fn export_json_roundtrip_summary(
             let reparsed = mmd_anim_format::parse_accessory_manifest(&exported, file_name)?;
             ensure_accessory_roundtrip(&parsed, &reparsed)?;
             println!(
-                "{} export JSON roundtrip: ok jsonBytes={} bytesIn={} bytesOut={} textures={} diagnostics={}",
+                "{} export JSON roundtrip: ok jsonBytes={} bytesIn={} bytesOut={} textures={}{}",
                 parsed.format.to_ascii_uppercase(),
                 json.len(),
                 data.len(),
                 exported.len(),
                 parsed.texture_references.len(),
-                parsed.diagnostics.len()
+                diagnostics_suffix(parsed.diagnostics.len())
             );
             Ok(ExitCode::SUCCESS)
         }
+        mmd_anim_format::MmdFormatKind::Unknown => Err(unsupported_format_error(path)),
         kind => Err(format!("export JSON roundtrip is not implemented for {kind:?}").into()),
     }
 }
@@ -332,7 +337,7 @@ pub(crate) fn export_json_roundtrip_summary(
 pub(crate) fn export_json_roundtrip_json(
     path: &Path,
 ) -> Result<ExitCode, Box<dyn std::error::Error>> {
-    let data = fs::read(path)?;
+    let data = read_file(path)?;
     let result = match mmd_anim_format::detect_mmd_format(
         &data,
         path.file_name().and_then(|v| v.to_str()),
@@ -419,6 +424,9 @@ pub(crate) fn export_json_roundtrip_json(
                 &parsed,
             )
         }
+        mmd_anim_format::MmdFormatKind::Unknown => {
+            return Err(unsupported_format_error(path));
+        }
         kind => {
             return Err(format!("export JSON roundtrip is not implemented for {kind:?}").into());
         }
@@ -431,7 +439,7 @@ pub(crate) fn export_format(
     input: &Path,
     output: &Path,
 ) -> Result<ExitCode, Box<dyn std::error::Error>> {
-    let data = fs::read(input)?;
+    let data = read_file(input)?;
     let kind =
         mmd_anim_format::detect_mmd_format(&data, input.file_name().and_then(|v| v.to_str()));
     let (exported, kind_label): (Vec<u8>, &str) = match kind {
@@ -461,9 +469,10 @@ pub(crate) fn export_format(
             let label: &'static str = if parsed.format == "vac" { "VAC" } else { "X" };
             (mmd_anim_format::export_accessory_manifest(&parsed), label)
         }
+        mmd_anim_format::MmdFormatKind::Unknown => return Err(unsupported_format_error(input)),
         kind => return Err(format!("export is not supported for {kind:?}").into()),
     };
-    fs::write(output, &exported)?;
+    write_file(output, &exported)?;
     println!(
         "{kind_label} export: ok bytesIn={} bytesOut={} output={}",
         data.len(),
@@ -506,8 +515,8 @@ pub(crate) fn export_pmm_scene(
     motion_path: &Path,
     output_path: &Path,
 ) -> Result<ExitCode, Box<dyn std::error::Error>> {
-    let model_data = fs::read(model_path)?;
-    let motion_data = fs::read(motion_path)?;
+    let model_data = read_file(model_path)?;
+    let motion_data = read_file(motion_path)?;
     let model = mmd_anim_format::parse_pmx_model(&model_data)?;
     let motion = mmd_anim_format::parse_vmd_animation(&motion_data)?;
     let model_path_text = resolve_pmx_path_for_pmm(model_path)?;
@@ -517,7 +526,7 @@ pub(crate) fn export_pmm_scene(
         &model_path_text,
         &mmd_anim_format::PmmSceneExportOptions::default(),
     );
-    fs::write(output_path, &report.bytes)?;
+    write_file(output_path, &report.bytes)?;
 
     let reparsed = mmd_anim_format::parse_pmm_manifest(&report.bytes)?;
     let document = reparsed
@@ -545,7 +554,7 @@ pub(crate) fn export_json_format(
     input: &Path,
     output: &Path,
 ) -> Result<ExitCode, Box<dyn std::error::Error>> {
-    let json = fs::read_to_string(input)?;
+    let json = read_json_input(input)?;
     let ext = output
         .extension()
         .and_then(|v| v.to_str())
@@ -582,7 +591,7 @@ pub(crate) fn export_json_format(
             .into());
         }
     };
-    fs::write(output, &exported)?;
+    write_file(output, &exported)?;
     println!(
         "{kind_label} export from JSON: ok jsonBytes={} bytesOut={} output={}",
         json.len(),
@@ -590,6 +599,12 @@ pub(crate) fn export_json_format(
         output.display()
     );
     Ok(ExitCode::SUCCESS)
+}
+
+fn read_json_input(input: &Path) -> Result<String, Box<dyn std::error::Error>> {
+    read_text_file(input).map_err(|error| {
+        format!("{error}; --from-json expects UTF-8 JSON text such as inspect --json output").into()
+    })
 }
 
 pub(crate) fn vmd_roundtrip_json(
@@ -976,14 +991,14 @@ pub(crate) fn ensure_vmd_roundtrip(
 ) -> Result<(), Box<dyn std::error::Error>> {
     if left.metadata.model_name != right.metadata.model_name {
         return Err(format!(
-            "VMD metadata.model_name changed: expected={:?} got={:?}",
+            "VMD metadata.modelName changed: expected={:?} got={:?}",
             left.metadata.model_name, right.metadata.model_name
         )
         .into());
     }
     if left.metadata.max_frame != right.metadata.max_frame {
         return Err(format!(
-            "VMD metadata.max_frame changed: expected={} got={}",
+            "VMD metadata.maxFrame changed: expected={} got={}",
             left.metadata.max_frame, right.metadata.max_frame
         )
         .into());
@@ -1009,35 +1024,35 @@ pub(crate) fn ensure_vmd_roundtrip(
     for (i, (l, r)) in left.bone_frames.iter().zip(&right.bone_frames).enumerate() {
         if l.bone_name != r.bone_name {
             return Err(format!(
-                "VMD bone_frames[{i}] bone_name: expected={:?} got={:?}",
+                "VMD boneFrames[{i}] boneName: expected={:?} got={:?}",
                 l.bone_name, r.bone_name
             )
             .into());
         }
         if l.frame != r.frame {
             return Err(format!(
-                "VMD bone_frames[{i}] bone={:?} frame: expected={} got={}",
+                "VMD boneFrames[{i}] bone={:?} frame: expected={} got={}",
                 l.bone_name, l.frame, r.frame
             )
             .into());
         }
         if l.translation != r.translation {
             return Err(format!(
-                "VMD bone_frames[{i}] bone={:?} frame={} translation: expected={:?} got={:?}",
+                "VMD boneFrames[{i}] bone={:?} frame={} translation: expected={:?} got={:?}",
                 l.bone_name, l.frame, l.translation, r.translation
             )
             .into());
         }
         if l.rotation != r.rotation {
             return Err(format!(
-                "VMD bone_frames[{i}] bone={:?} frame={} rotation: expected={:?} got={:?}",
+                "VMD boneFrames[{i}] bone={:?} frame={} rotation: expected={:?} got={:?}",
                 l.bone_name, l.frame, l.rotation, r.rotation
             )
             .into());
         }
         if l.interpolation != r.interpolation {
             return Err(format!(
-                "VMD bone_frames[{i}] bone={:?} frame={} interpolation changed",
+                "VMD boneFrames[{i}] bone={:?} frame={} interpolation changed",
                 l.bone_name, l.frame
             )
             .into());
@@ -1052,21 +1067,21 @@ pub(crate) fn ensure_vmd_roundtrip(
     {
         if l.morph_name != r.morph_name {
             return Err(format!(
-                "VMD morph_frames[{i}] morph_name: expected={:?} got={:?}",
+                "VMD morphFrames[{i}] morphName: expected={:?} got={:?}",
                 l.morph_name, r.morph_name
             )
             .into());
         }
         if l.frame != r.frame {
             return Err(format!(
-                "VMD morph_frames[{i}] morph={:?} frame: expected={} got={}",
+                "VMD morphFrames[{i}] morph={:?} frame: expected={} got={}",
                 l.morph_name, l.frame, r.frame
             )
             .into());
         }
         if l.weight != r.weight {
             return Err(format!(
-                "VMD morph_frames[{i}] morph={:?} frame={} weight: expected={} got={}",
+                "VMD morphFrames[{i}] morph={:?} frame={} weight: expected={} got={}",
                 l.morph_name, l.frame, l.weight, r.weight
             )
             .into());
@@ -1081,49 +1096,49 @@ pub(crate) fn ensure_vmd_roundtrip(
     {
         if l.frame != r.frame {
             return Err(format!(
-                "VMD camera_frames[{i}] frame: expected={} got={}",
+                "VMD cameraFrames[{i}] frame: expected={} got={}",
                 l.frame, r.frame
             )
             .into());
         }
         if l.distance != r.distance {
             return Err(format!(
-                "VMD camera_frames[{i}] frame={} distance: expected={} got={}",
+                "VMD cameraFrames[{i}] frame={} distance: expected={} got={}",
                 l.frame, l.distance, r.distance
             )
             .into());
         }
         if l.position != r.position {
             return Err(format!(
-                "VMD camera_frames[{i}] frame={} position: expected={:?} got={:?}",
+                "VMD cameraFrames[{i}] frame={} position: expected={:?} got={:?}",
                 l.frame, l.position, r.position
             )
             .into());
         }
         if l.rotation != r.rotation {
             return Err(format!(
-                "VMD camera_frames[{i}] frame={} rotation: expected={:?} got={:?}",
+                "VMD cameraFrames[{i}] frame={} rotation: expected={:?} got={:?}",
                 l.frame, l.rotation, r.rotation
             )
             .into());
         }
         if l.interpolation != r.interpolation {
             return Err(format!(
-                "VMD camera_frames[{i}] frame={} interpolation changed",
+                "VMD cameraFrames[{i}] frame={} interpolation changed",
                 l.frame
             )
             .into());
         }
         if l.fov != r.fov {
             return Err(format!(
-                "VMD camera_frames[{i}] frame={} fov: expected={} got={}",
+                "VMD cameraFrames[{i}] frame={} fov: expected={} got={}",
                 l.frame, l.fov, r.fov
             )
             .into());
         }
         if l.perspective != r.perspective {
             return Err(format!(
-                "VMD camera_frames[{i}] frame={} perspective: expected={} got={}",
+                "VMD cameraFrames[{i}] frame={} perspective: expected={} got={}",
                 l.frame, l.perspective, r.perspective
             )
             .into());
@@ -1138,21 +1153,21 @@ pub(crate) fn ensure_vmd_roundtrip(
     {
         if l.frame != r.frame {
             return Err(format!(
-                "VMD light_frames[{i}] frame: expected={} got={}",
+                "VMD lightFrames[{i}] frame: expected={} got={}",
                 l.frame, r.frame
             )
             .into());
         }
         if l.color != r.color {
             return Err(format!(
-                "VMD light_frames[{i}] frame={} color: expected={:?} got={:?}",
+                "VMD lightFrames[{i}] frame={} color: expected={:?} got={:?}",
                 l.frame, l.color, r.color
             )
             .into());
         }
         if l.direction != r.direction {
             return Err(format!(
-                "VMD light_frames[{i}] frame={} direction: expected={:?} got={:?}",
+                "VMD lightFrames[{i}] frame={} direction: expected={:?} got={:?}",
                 l.frame, l.direction, r.direction
             )
             .into());
@@ -1167,21 +1182,21 @@ pub(crate) fn ensure_vmd_roundtrip(
     {
         if l.frame != r.frame {
             return Err(format!(
-                "VMD self_shadow_frames[{i}] frame: expected={} got={}",
+                "VMD selfShadowFrames[{i}] frame: expected={} got={}",
                 l.frame, r.frame
             )
             .into());
         }
         if l.mode != r.mode {
             return Err(format!(
-                "VMD self_shadow_frames[{i}] frame={} mode: expected={} got={}",
+                "VMD selfShadowFrames[{i}] frame={} mode: expected={} got={}",
                 l.frame, l.mode, r.mode
             )
             .into());
         }
         if l.distance != r.distance {
             return Err(format!(
-                "VMD self_shadow_frames[{i}] frame={} distance: expected={} got={}",
+                "VMD selfShadowFrames[{i}] frame={} distance: expected={} got={}",
                 l.frame, l.distance, r.distance
             )
             .into());
@@ -1196,21 +1211,21 @@ pub(crate) fn ensure_vmd_roundtrip(
     {
         if l.frame != r.frame {
             return Err(format!(
-                "VMD property_frames[{i}] frame: expected={} got={}",
+                "VMD propertyFrames[{i}] frame: expected={} got={}",
                 l.frame, r.frame
             )
             .into());
         }
         if l.visible != r.visible {
             return Err(format!(
-                "VMD property_frames[{i}] frame={} visible: expected={} got={}",
+                "VMD propertyFrames[{i}] frame={} visible: expected={} got={}",
                 l.frame, l.visible, r.visible
             )
             .into());
         }
         if l.ik_states.len() != r.ik_states.len() {
             return Err(format!(
-                "VMD property_frames[{i}] frame={} ik_states count: expected={} got={}",
+                "VMD propertyFrames[{i}] frame={} ikStates count: expected={} got={}",
                 l.frame,
                 l.ik_states.len(),
                 r.ik_states.len()
@@ -1220,14 +1235,14 @@ pub(crate) fn ensure_vmd_roundtrip(
         for (j, (lk, rk)) in l.ik_states.iter().zip(&r.ik_states).enumerate() {
             if lk.bone_name != rk.bone_name {
                 return Err(format!(
-                    "VMD property_frames[{i}] frame={} ik_states[{j}] bone_name: expected={:?} got={:?}",
+                    "VMD propertyFrames[{i}] frame={} ikStates[{j}] boneName: expected={:?} got={:?}",
                     l.frame, lk.bone_name, rk.bone_name
                 )
                 .into());
             }
             if lk.enabled != rk.enabled {
                 return Err(format!(
-                    "VMD property_frames[{i}] frame={} ik_states[{j}] bone={:?} enabled: expected={} got={}",
+                    "VMD propertyFrames[{i}] frame={} ikStates[{j}] bone={:?} enabled: expected={} got={}",
                     l.frame, lk.bone_name, lk.enabled, rk.enabled
                 )
                 .into());
@@ -1243,14 +1258,14 @@ pub(crate) fn ensure_vpd_roundtrip(
 ) -> Result<(), Box<dyn std::error::Error>> {
     if left.model_file != right.model_file {
         return Err(format!(
-            "VPD model_file changed: expected={:?} got={:?}",
+            "VPD modelFile changed: expected={:?} got={:?}",
             left.model_file, right.model_file
         )
         .into());
     }
     if left.bone_count != right.bone_count {
         return Err(format!(
-            "VPD bone_count changed: expected={} got={}",
+            "VPD boneCount changed: expected={} got={}",
             left.bone_count, right.bone_count
         )
         .into());

--- a/crates/mmd-anim-cli/src/commands/export.rs
+++ b/crates/mmd-anim-cli/src/commands/export.rs
@@ -2,7 +2,9 @@ use std::{fs, path::Path, process::ExitCode};
 
 use serde_json::json;
 
-pub(crate) fn export_roundtrip_summary(path: &Path) -> Result<ExitCode, Box<dyn std::error::Error>> {
+pub(crate) fn export_roundtrip_summary(
+    path: &Path,
+) -> Result<ExitCode, Box<dyn std::error::Error>> {
     let data = fs::read(path)?;
     match mmd_anim_format::detect_mmd_format(&data, path.file_name().and_then(|v| v.to_str())) {
         mmd_anim_format::MmdFormatKind::Vmd => {
@@ -212,7 +214,9 @@ pub(crate) fn export_roundtrip_json(path: &Path) -> Result<ExitCode, Box<dyn std
     Ok(ExitCode::SUCCESS)
 }
 
-pub(crate) fn export_json_roundtrip_summary(path: &Path) -> Result<ExitCode, Box<dyn std::error::Error>> {
+pub(crate) fn export_json_roundtrip_summary(
+    path: &Path,
+) -> Result<ExitCode, Box<dyn std::error::Error>> {
     let data = fs::read(path)?;
     match mmd_anim_format::detect_mmd_format(&data, path.file_name().and_then(|v| v.to_str())) {
         mmd_anim_format::MmdFormatKind::Vmd => {
@@ -325,7 +329,9 @@ pub(crate) fn export_json_roundtrip_summary(path: &Path) -> Result<ExitCode, Box
     }
 }
 
-pub(crate) fn export_json_roundtrip_json(path: &Path) -> Result<ExitCode, Box<dyn std::error::Error>> {
+pub(crate) fn export_json_roundtrip_json(
+    path: &Path,
+) -> Result<ExitCode, Box<dyn std::error::Error>> {
     let data = fs::read(path)?;
     let result = match mmd_anim_format::detect_mmd_format(
         &data,
@@ -421,7 +427,10 @@ pub(crate) fn export_json_roundtrip_json(path: &Path) -> Result<ExitCode, Box<dy
     Ok(ExitCode::SUCCESS)
 }
 
-pub(crate) fn export_format(input: &Path, output: &Path) -> Result<ExitCode, Box<dyn std::error::Error>> {
+pub(crate) fn export_format(
+    input: &Path,
+    output: &Path,
+) -> Result<ExitCode, Box<dyn std::error::Error>> {
     let data = fs::read(input)?;
     let kind =
         mmd_anim_format::detect_mmd_format(&data, input.file_name().and_then(|v| v.to_str()));
@@ -465,7 +474,9 @@ pub(crate) fn export_format(input: &Path, output: &Path) -> Result<ExitCode, Box
 }
 
 /// Resolves a PMX model path for PMM export to a canonical path string that MMD can open.
-pub(crate) fn resolve_pmx_path_for_pmm(model_path: &Path) -> Result<String, Box<dyn std::error::Error>> {
+pub(crate) fn resolve_pmx_path_for_pmm(
+    model_path: &Path,
+) -> Result<String, Box<dyn std::error::Error>> {
     let canonical = model_path.canonicalize().map_err(|e| {
         format!(
             "failed to canonicalize PMX model path {}: {}",
@@ -530,7 +541,10 @@ pub(crate) fn export_pmm_scene(
     Ok(ExitCode::SUCCESS)
 }
 
-pub(crate) fn export_json_format(input: &Path, output: &Path) -> Result<ExitCode, Box<dyn std::error::Error>> {
+pub(crate) fn export_json_format(
+    input: &Path,
+    output: &Path,
+) -> Result<ExitCode, Box<dyn std::error::Error>> {
     let json = fs::read_to_string(input)?;
     let ext = output
         .extension()

--- a/crates/mmd-anim-cli/src/commands/export.rs
+++ b/crates/mmd-anim-cli/src/commands/export.rs
@@ -812,7 +812,7 @@ pub(crate) fn ensure_pmx_roundtrip(
     let left = serde_json::to_value(left)?;
     let right = serde_json::to_value(right)?;
     if left != right {
-        return Err("PMX parse/export/parse DTO changed".into());
+        return Err("PMX data differs after re-encoding (parse/export/re-parse mismatch)".into());
     }
     Ok(())
 }
@@ -824,7 +824,7 @@ pub(crate) fn ensure_pmd_roundtrip(
     let left = serde_json::to_value(left)?;
     let right = serde_json::to_value(right)?;
     if left != right {
-        return Err("PMD parse/export/parse DTO changed".into());
+        return Err("PMD data differs after re-encoding (parse/export/re-parse mismatch)".into());
     }
     Ok(())
 }
@@ -899,7 +899,7 @@ pub(crate) fn ensure_accessory_json_roundtrip(
         format!("Accessory JSON roundtrip actual serialization failed: {error}")
     })?;
     if expected != actual {
-        return Err("Accessory JSON DTO changed before export".to_owned());
+        return Err("Accessory JSON data differs after re-encoding".to_owned());
     }
     Ok(())
 }

--- a/crates/mmd-anim-cli/src/commands/export.rs
+++ b/crates/mmd-anim-cli/src/commands/export.rs
@@ -562,23 +562,28 @@ pub(crate) fn export_json_format(
         .to_ascii_lowercase();
     let (exported, kind_label): (Vec<u8>, &str) = match ext.as_str() {
         "vmd" => {
-            let dto: mmd_anim_format::VmdParsedAnimation = serde_json::from_str(&json)?;
+            let dto: mmd_anim_format::VmdParsedAnimation =
+                serde_json::from_str(&json).map_err(|e| format_json_deser_error("VMD", e))?;
             (mmd_anim_format::export_vmd_animation(&dto), "VMD")
         }
         "vpd" => {
-            let dto: mmd_anim_format::VpdParsedPose = serde_json::from_str(&json)?;
+            let dto: mmd_anim_format::VpdParsedPose =
+                serde_json::from_str(&json).map_err(|e| format_json_deser_error("VPD", e))?;
             (mmd_anim_format::export_vpd_pose(&dto), "VPD")
         }
         "pmx" => {
-            let dto: mmd_anim_format::PmxParsedModel = serde_json::from_str(&json)?;
+            let dto: mmd_anim_format::PmxParsedModel =
+                serde_json::from_str(&json).map_err(|e| format_json_deser_error("PMX", e))?;
             (mmd_anim_format::export_pmx_model(&dto), "PMX")
         }
         "pmd" => {
-            let dto: mmd_anim_format::PmdParsedModel = serde_json::from_str(&json)?;
+            let dto: mmd_anim_format::PmdParsedModel =
+                serde_json::from_str(&json).map_err(|e| format_json_deser_error("PMD", e))?;
             (mmd_anim_format::export_pmd_model(&dto), "PMD")
         }
         "x" | "vac" => {
-            let dto: mmd_anim_format::AccessoryParsedManifest = serde_json::from_str(&json)?;
+            let dto: mmd_anim_format::AccessoryParsedManifest =
+                serde_json::from_str(&json).map_err(|e| format_json_deser_error("accessory", e))?;
             let label: &'static str = if ext == "vac" { "VAC" } else { "X" };
             (mmd_anim_format::export_accessory_manifest(&dto), label)
         }
@@ -603,8 +608,22 @@ pub(crate) fn export_json_format(
 
 fn read_json_input(input: &Path) -> Result<String, Box<dyn std::error::Error>> {
     read_text_file(input).map_err(|error| {
-        format!("{error}; --from-json expects UTF-8 JSON text such as inspect --json output").into()
+        format!(
+            "{error}; --from-json expects UTF-8 JSON text, typically from `mmd-anim inspect <asset> --json`"
+        )
+        .into()
     })
+}
+
+fn format_json_deser_error(
+    format_label: &str,
+    error: serde_json::Error,
+) -> Box<dyn std::error::Error> {
+    format!(
+        "{format_label} JSON deserialization failed: {error}; \
+         --from-json expects the raw JSON emitted by `mmd-anim inspect <asset> --json`"
+    )
+    .into()
 }
 
 pub(crate) fn vmd_roundtrip_json(

--- a/crates/mmd-anim-cli/src/commands/export.rs
+++ b/crates/mmd-anim-cli/src/commands/export.rs
@@ -1,0 +1,1268 @@
+use std::{fs, path::Path, process::ExitCode};
+
+use serde_json::json;
+
+pub(crate) fn export_roundtrip_summary(path: &Path) -> Result<ExitCode, Box<dyn std::error::Error>> {
+    let data = fs::read(path)?;
+    match mmd_anim_format::detect_mmd_format(&data, path.file_name().and_then(|v| v.to_str())) {
+        mmd_anim_format::MmdFormatKind::Vmd => {
+            let parsed = mmd_anim_format::parse_vmd_animation(&data)?;
+            let exported = mmd_anim_format::export_vmd_animation(&parsed);
+            let reparsed = mmd_anim_format::parse_vmd_animation(&exported)?;
+            ensure_vmd_roundtrip(&parsed, &reparsed)?;
+            println!(
+                "VMD export roundtrip: ok bytesIn={} bytesOut={} boneFrames={} morphFrames={} cameraFrames={} lightFrames={} selfShadowFrames={} propertyFrames={} maxFrame={}",
+                data.len(),
+                exported.len(),
+                parsed.metadata.counts.bones,
+                parsed.metadata.counts.morphs,
+                parsed.metadata.counts.cameras,
+                parsed.metadata.counts.lights,
+                parsed.metadata.counts.self_shadows,
+                parsed.metadata.counts.properties,
+                parsed.metadata.max_frame
+            );
+            Ok(ExitCode::SUCCESS)
+        }
+        mmd_anim_format::MmdFormatKind::Vpd => {
+            let parsed = mmd_anim_format::parse_vpd_pose(&data)?;
+            let exported = mmd_anim_format::export_vpd_pose(&parsed);
+            let reparsed = mmd_anim_format::parse_vpd_pose(&exported)?;
+            ensure_vpd_roundtrip(&parsed, &reparsed)?;
+            println!(
+                "VPD export roundtrip: ok bytesIn={} bytesOut={} bones={}",
+                data.len(),
+                exported.len(),
+                parsed.bone_count
+            );
+            Ok(ExitCode::SUCCESS)
+        }
+        mmd_anim_format::MmdFormatKind::Pmx => {
+            let parsed = mmd_anim_format::parse_pmx_model(&data)?;
+            let exported = mmd_anim_format::export_pmx_model(&parsed);
+            let reparsed = mmd_anim_format::parse_pmx_model(&exported)?;
+            ensure_pmx_roundtrip(&parsed, &reparsed)?;
+            println!(
+                "PMX export roundtrip: ok bytesIn={} bytesOut={} vertices={} faces={} materials={} bones={} morphs={} displayFrames={} rigidBodies={} joints={} softBodies={}",
+                data.len(),
+                exported.len(),
+                parsed.metadata.counts.vertices,
+                parsed.metadata.counts.faces,
+                parsed.metadata.counts.materials,
+                parsed.metadata.counts.bones,
+                parsed.metadata.counts.morphs,
+                parsed.metadata.counts.display_frames,
+                parsed.metadata.counts.rigid_bodies,
+                parsed.metadata.counts.joints,
+                parsed.metadata.counts.soft_bodies
+            );
+            Ok(ExitCode::SUCCESS)
+        }
+        mmd_anim_format::MmdFormatKind::Pmd => {
+            let parsed = mmd_anim_format::parse_pmd_model(&data)?;
+            let exported = mmd_anim_format::export_pmd_model(&parsed);
+            let reparsed = mmd_anim_format::parse_pmd_model(&exported)?;
+            ensure_pmd_roundtrip(&parsed, &reparsed)?;
+            println!(
+                "PMD export roundtrip: ok bytesIn={} bytesOut={} vertices={} faces={} materials={} bones={} ik={} morphs={} displayFrames={} rigidBodies={} joints={}",
+                data.len(),
+                exported.len(),
+                parsed.metadata.counts.vertices,
+                parsed.metadata.counts.faces,
+                parsed.metadata.counts.materials,
+                parsed.metadata.counts.bones,
+                parsed.metadata.counts.ik,
+                parsed.metadata.counts.morphs,
+                parsed.metadata.counts.display_frames,
+                parsed.metadata.counts.rigid_bodies,
+                parsed.metadata.counts.joints
+            );
+            Ok(ExitCode::SUCCESS)
+        }
+        mmd_anim_format::MmdFormatKind::Pmm => {
+            let parsed = mmd_anim_format::parse_pmm_manifest(&data)?;
+            let exported = mmd_anim_format::export_pmm_manifest(&parsed);
+            let _reparsed = mmd_anim_format::parse_pmm_manifest(&exported)?;
+            ensure_pmm_lossless_roundtrip(&data, &exported)?;
+            println!(
+                "PMM export roundtrip: ok bytesIn={} bytesOut={} version={} modelReferences={} assetReferences={} diagnostics={}",
+                data.len(),
+                exported.len(),
+                parsed.version,
+                parsed.model_paths.len(),
+                parsed.asset_summary.reference_count,
+                parsed.diagnostics.len()
+            );
+            Ok(ExitCode::SUCCESS)
+        }
+        mmd_anim_format::MmdFormatKind::X | mmd_anim_format::MmdFormatKind::Vac => {
+            let file_name = path.file_name().and_then(|v| v.to_str());
+            let parsed = mmd_anim_format::parse_accessory_manifest(&data, file_name)?;
+            let exported = mmd_anim_format::export_accessory_manifest(&parsed);
+            let reparsed = mmd_anim_format::parse_accessory_manifest(&exported, file_name)?;
+            ensure_accessory_roundtrip(&parsed, &reparsed)?;
+            println!(
+                "{} export roundtrip: ok bytesIn={} bytesOut={} textures={} diagnostics={}",
+                parsed.format.to_ascii_uppercase(),
+                data.len(),
+                exported.len(),
+                parsed.texture_references.len(),
+                parsed.diagnostics.len()
+            );
+            Ok(ExitCode::SUCCESS)
+        }
+        kind => Err(format!("export roundtrip is not implemented for {kind:?}").into()),
+    }
+}
+
+pub(crate) fn export_roundtrip_json(path: &Path) -> Result<ExitCode, Box<dyn std::error::Error>> {
+    let data = fs::read(path)?;
+    let result = match mmd_anim_format::detect_mmd_format(
+        &data,
+        path.file_name().and_then(|v| v.to_str()),
+    ) {
+        mmd_anim_format::MmdFormatKind::Vmd => {
+            let parsed = mmd_anim_format::parse_vmd_animation(&data)?;
+            let exported = mmd_anim_format::export_vmd_animation(&parsed);
+            let reparsed = mmd_anim_format::parse_vmd_animation(&exported)?;
+            ensure_vmd_roundtrip(&parsed, &reparsed)?;
+            vmd_roundtrip_json(
+                path,
+                "parse-export-parse",
+                data.len(),
+                exported.len(),
+                None,
+                &parsed,
+            )
+        }
+        mmd_anim_format::MmdFormatKind::Vpd => {
+            let parsed = mmd_anim_format::parse_vpd_pose(&data)?;
+            let exported = mmd_anim_format::export_vpd_pose(&parsed);
+            let reparsed = mmd_anim_format::parse_vpd_pose(&exported)?;
+            ensure_vpd_roundtrip(&parsed, &reparsed)?;
+            vpd_roundtrip_json(
+                path,
+                "parse-export-parse",
+                data.len(),
+                exported.len(),
+                None,
+                &parsed,
+            )
+        }
+        mmd_anim_format::MmdFormatKind::Pmx => {
+            let parsed = mmd_anim_format::parse_pmx_model(&data)?;
+            let exported = mmd_anim_format::export_pmx_model(&parsed);
+            let reparsed = mmd_anim_format::parse_pmx_model(&exported)?;
+            ensure_pmx_roundtrip(&parsed, &reparsed)?;
+            pmx_roundtrip_json(
+                path,
+                "parse-export-parse",
+                data.len(),
+                exported.len(),
+                None,
+                &parsed,
+            )
+        }
+        mmd_anim_format::MmdFormatKind::Pmd => {
+            let parsed = mmd_anim_format::parse_pmd_model(&data)?;
+            let exported = mmd_anim_format::export_pmd_model(&parsed);
+            let reparsed = mmd_anim_format::parse_pmd_model(&exported)?;
+            ensure_pmd_roundtrip(&parsed, &reparsed)?;
+            pmd_roundtrip_json(
+                path,
+                "parse-export-parse",
+                data.len(),
+                exported.len(),
+                None,
+                &parsed,
+            )
+        }
+        mmd_anim_format::MmdFormatKind::Pmm => {
+            let parsed = mmd_anim_format::parse_pmm_manifest(&data)?;
+            let exported = mmd_anim_format::export_pmm_manifest(&parsed);
+            let _reparsed = mmd_anim_format::parse_pmm_manifest(&exported)?;
+            ensure_pmm_lossless_roundtrip(&data, &exported)?;
+            pmm_roundtrip_json(
+                path,
+                "parse-export-parse-lossless",
+                data.len(),
+                exported.len(),
+                data == exported,
+                &parsed,
+            )
+        }
+        mmd_anim_format::MmdFormatKind::X | mmd_anim_format::MmdFormatKind::Vac => {
+            let file_name = path.file_name().and_then(|v| v.to_str());
+            let parsed = mmd_anim_format::parse_accessory_manifest(&data, file_name)?;
+            let exported = mmd_anim_format::export_accessory_manifest(&parsed);
+            let reparsed = mmd_anim_format::parse_accessory_manifest(&exported, file_name)?;
+            ensure_accessory_roundtrip(&parsed, &reparsed)?;
+            accessory_roundtrip_json(
+                path,
+                "parse-export-parse",
+                data.len(),
+                exported.len(),
+                None,
+                &parsed,
+            )
+        }
+        kind => return Err(format!("export roundtrip is not implemented for {kind:?}").into()),
+    };
+    println!("{}", serde_json::to_string_pretty(&result)?);
+    Ok(ExitCode::SUCCESS)
+}
+
+pub(crate) fn export_json_roundtrip_summary(path: &Path) -> Result<ExitCode, Box<dyn std::error::Error>> {
+    let data = fs::read(path)?;
+    match mmd_anim_format::detect_mmd_format(&data, path.file_name().and_then(|v| v.to_str())) {
+        mmd_anim_format::MmdFormatKind::Vmd => {
+            let parsed = mmd_anim_format::parse_vmd_animation(&data)?;
+            let json = serde_json::to_string(&parsed)?;
+            let from_json: mmd_anim_format::VmdParsedAnimation = serde_json::from_str(&json)?;
+            let exported = mmd_anim_format::export_vmd_animation(&from_json);
+            let reparsed = mmd_anim_format::parse_vmd_animation(&exported)?;
+            ensure_vmd_roundtrip(&parsed, &reparsed)?;
+            println!(
+                "VMD export JSON roundtrip: ok jsonBytes={} bytesIn={} bytesOut={} boneFrames={} morphFrames={} cameraFrames={} lightFrames={} selfShadowFrames={} propertyFrames={} maxFrame={}",
+                json.len(),
+                data.len(),
+                exported.len(),
+                parsed.metadata.counts.bones,
+                parsed.metadata.counts.morphs,
+                parsed.metadata.counts.cameras,
+                parsed.metadata.counts.lights,
+                parsed.metadata.counts.self_shadows,
+                parsed.metadata.counts.properties,
+                parsed.metadata.max_frame
+            );
+            Ok(ExitCode::SUCCESS)
+        }
+        mmd_anim_format::MmdFormatKind::Vpd => {
+            let parsed = mmd_anim_format::parse_vpd_pose(&data)?;
+            let json = serde_json::to_string(&parsed)?;
+            let from_json: mmd_anim_format::VpdParsedPose = serde_json::from_str(&json)?;
+            let exported = mmd_anim_format::export_vpd_pose(&from_json);
+            let reparsed = mmd_anim_format::parse_vpd_pose(&exported)?;
+            ensure_vpd_roundtrip(&parsed, &reparsed)?;
+            println!(
+                "VPD export JSON roundtrip: ok jsonBytes={} bytesIn={} bytesOut={} bones={}",
+                json.len(),
+                data.len(),
+                exported.len(),
+                parsed.bone_count
+            );
+            Ok(ExitCode::SUCCESS)
+        }
+        mmd_anim_format::MmdFormatKind::Pmx => {
+            let parsed = mmd_anim_format::parse_pmx_model(&data)?;
+            let json = serde_json::to_string(&parsed)?;
+            let from_json: mmd_anim_format::PmxParsedModel = serde_json::from_str(&json)?;
+            let exported = mmd_anim_format::export_pmx_model(&from_json);
+            let reparsed = mmd_anim_format::parse_pmx_model(&exported)?;
+            ensure_pmx_roundtrip(&parsed, &reparsed)?;
+            println!(
+                "PMX export JSON roundtrip: ok jsonBytes={} bytesIn={} bytesOut={} vertices={} faces={} materials={} bones={} morphs={} displayFrames={} rigidBodies={} joints={} softBodies={}",
+                json.len(),
+                data.len(),
+                exported.len(),
+                parsed.metadata.counts.vertices,
+                parsed.metadata.counts.faces,
+                parsed.metadata.counts.materials,
+                parsed.metadata.counts.bones,
+                parsed.metadata.counts.morphs,
+                parsed.metadata.counts.display_frames,
+                parsed.metadata.counts.rigid_bodies,
+                parsed.metadata.counts.joints,
+                parsed.metadata.counts.soft_bodies
+            );
+            Ok(ExitCode::SUCCESS)
+        }
+        mmd_anim_format::MmdFormatKind::Pmd => {
+            let parsed = mmd_anim_format::parse_pmd_model(&data)?;
+            let json = serde_json::to_string(&parsed)?;
+            let from_json: mmd_anim_format::PmdParsedModel = serde_json::from_str(&json)?;
+            let exported = mmd_anim_format::export_pmd_model(&from_json);
+            let reparsed = mmd_anim_format::parse_pmd_model(&exported)?;
+            ensure_pmd_roundtrip(&parsed, &reparsed)?;
+            println!(
+                "PMD export JSON roundtrip: ok jsonBytes={} bytesIn={} bytesOut={} vertices={} faces={} materials={} bones={} ik={} morphs={} displayFrames={} rigidBodies={} joints={}",
+                json.len(),
+                data.len(),
+                exported.len(),
+                parsed.metadata.counts.vertices,
+                parsed.metadata.counts.faces,
+                parsed.metadata.counts.materials,
+                parsed.metadata.counts.bones,
+                parsed.metadata.counts.ik,
+                parsed.metadata.counts.morphs,
+                parsed.metadata.counts.display_frames,
+                parsed.metadata.counts.rigid_bodies,
+                parsed.metadata.counts.joints
+            );
+            Ok(ExitCode::SUCCESS)
+        }
+        mmd_anim_format::MmdFormatKind::X | mmd_anim_format::MmdFormatKind::Vac => {
+            let file_name = path.file_name().and_then(|v| v.to_str());
+            let parsed = mmd_anim_format::parse_accessory_manifest(&data, file_name)?;
+            let json = serde_json::to_string(&parsed)?;
+            let from_json: mmd_anim_format::AccessoryParsedManifest = serde_json::from_str(&json)?;
+            ensure_accessory_json_roundtrip(&parsed, &from_json)?;
+            let exported = mmd_anim_format::export_accessory_manifest(&from_json);
+            let reparsed = mmd_anim_format::parse_accessory_manifest(&exported, file_name)?;
+            ensure_accessory_roundtrip(&parsed, &reparsed)?;
+            println!(
+                "{} export JSON roundtrip: ok jsonBytes={} bytesIn={} bytesOut={} textures={} diagnostics={}",
+                parsed.format.to_ascii_uppercase(),
+                json.len(),
+                data.len(),
+                exported.len(),
+                parsed.texture_references.len(),
+                parsed.diagnostics.len()
+            );
+            Ok(ExitCode::SUCCESS)
+        }
+        kind => Err(format!("export JSON roundtrip is not implemented for {kind:?}").into()),
+    }
+}
+
+pub(crate) fn export_json_roundtrip_json(path: &Path) -> Result<ExitCode, Box<dyn std::error::Error>> {
+    let data = fs::read(path)?;
+    let result = match mmd_anim_format::detect_mmd_format(
+        &data,
+        path.file_name().and_then(|v| v.to_str()),
+    ) {
+        mmd_anim_format::MmdFormatKind::Vmd => {
+            let parsed = mmd_anim_format::parse_vmd_animation(&data)?;
+            let json = serde_json::to_string(&parsed)?;
+            let from_json: mmd_anim_format::VmdParsedAnimation = serde_json::from_str(&json)?;
+            let exported = mmd_anim_format::export_vmd_animation(&from_json);
+            let reparsed = mmd_anim_format::parse_vmd_animation(&exported)?;
+            ensure_vmd_roundtrip(&parsed, &reparsed)?;
+            vmd_roundtrip_json(
+                path,
+                "parse-json-export-parse",
+                data.len(),
+                exported.len(),
+                Some(json.len()),
+                &parsed,
+            )
+        }
+        mmd_anim_format::MmdFormatKind::Vpd => {
+            let parsed = mmd_anim_format::parse_vpd_pose(&data)?;
+            let json = serde_json::to_string(&parsed)?;
+            let from_json: mmd_anim_format::VpdParsedPose = serde_json::from_str(&json)?;
+            let exported = mmd_anim_format::export_vpd_pose(&from_json);
+            let reparsed = mmd_anim_format::parse_vpd_pose(&exported)?;
+            ensure_vpd_roundtrip(&parsed, &reparsed)?;
+            vpd_roundtrip_json(
+                path,
+                "parse-json-export-parse",
+                data.len(),
+                exported.len(),
+                Some(json.len()),
+                &parsed,
+            )
+        }
+        mmd_anim_format::MmdFormatKind::Pmx => {
+            let parsed = mmd_anim_format::parse_pmx_model(&data)?;
+            let json = serde_json::to_string(&parsed)?;
+            let from_json: mmd_anim_format::PmxParsedModel = serde_json::from_str(&json)?;
+            let exported = mmd_anim_format::export_pmx_model(&from_json);
+            let reparsed = mmd_anim_format::parse_pmx_model(&exported)?;
+            ensure_pmx_roundtrip(&parsed, &reparsed)?;
+            pmx_roundtrip_json(
+                path,
+                "parse-json-export-parse",
+                data.len(),
+                exported.len(),
+                Some(json.len()),
+                &parsed,
+            )
+        }
+        mmd_anim_format::MmdFormatKind::Pmd => {
+            let parsed = mmd_anim_format::parse_pmd_model(&data)?;
+            let json = serde_json::to_string(&parsed)?;
+            let from_json: mmd_anim_format::PmdParsedModel = serde_json::from_str(&json)?;
+            let exported = mmd_anim_format::export_pmd_model(&from_json);
+            let reparsed = mmd_anim_format::parse_pmd_model(&exported)?;
+            ensure_pmd_roundtrip(&parsed, &reparsed)?;
+            pmd_roundtrip_json(
+                path,
+                "parse-json-export-parse",
+                data.len(),
+                exported.len(),
+                Some(json.len()),
+                &parsed,
+            )
+        }
+        mmd_anim_format::MmdFormatKind::X | mmd_anim_format::MmdFormatKind::Vac => {
+            let file_name = path.file_name().and_then(|v| v.to_str());
+            let parsed = mmd_anim_format::parse_accessory_manifest(&data, file_name)?;
+            let json = serde_json::to_string(&parsed)?;
+            let from_json: mmd_anim_format::AccessoryParsedManifest = serde_json::from_str(&json)?;
+            ensure_accessory_json_roundtrip(&parsed, &from_json)?;
+            let exported = mmd_anim_format::export_accessory_manifest(&from_json);
+            let reparsed = mmd_anim_format::parse_accessory_manifest(&exported, file_name)?;
+            ensure_accessory_roundtrip(&parsed, &reparsed)?;
+            accessory_roundtrip_json(
+                path,
+                "parse-json-export-parse",
+                data.len(),
+                exported.len(),
+                Some(json.len()),
+                &parsed,
+            )
+        }
+        kind => {
+            return Err(format!("export JSON roundtrip is not implemented for {kind:?}").into());
+        }
+    };
+    println!("{}", serde_json::to_string_pretty(&result)?);
+    Ok(ExitCode::SUCCESS)
+}
+
+pub(crate) fn export_format(input: &Path, output: &Path) -> Result<ExitCode, Box<dyn std::error::Error>> {
+    let data = fs::read(input)?;
+    let kind =
+        mmd_anim_format::detect_mmd_format(&data, input.file_name().and_then(|v| v.to_str()));
+    let (exported, kind_label): (Vec<u8>, &str) = match kind {
+        mmd_anim_format::MmdFormatKind::Vmd => {
+            let parsed = mmd_anim_format::parse_vmd_animation(&data)?;
+            (mmd_anim_format::export_vmd_animation(&parsed), "VMD")
+        }
+        mmd_anim_format::MmdFormatKind::Vpd => {
+            let parsed = mmd_anim_format::parse_vpd_pose(&data)?;
+            (mmd_anim_format::export_vpd_pose(&parsed), "VPD")
+        }
+        mmd_anim_format::MmdFormatKind::Pmx => {
+            let parsed = mmd_anim_format::parse_pmx_model(&data)?;
+            (mmd_anim_format::export_pmx_model(&parsed), "PMX")
+        }
+        mmd_anim_format::MmdFormatKind::Pmd => {
+            let parsed = mmd_anim_format::parse_pmd_model(&data)?;
+            (mmd_anim_format::export_pmd_model(&parsed), "PMD")
+        }
+        mmd_anim_format::MmdFormatKind::Pmm => {
+            let parsed = mmd_anim_format::parse_pmm_manifest(&data)?;
+            (mmd_anim_format::export_pmm_manifest(&parsed), "PMM")
+        }
+        mmd_anim_format::MmdFormatKind::X | mmd_anim_format::MmdFormatKind::Vac => {
+            let file_name = input.file_name().and_then(|v| v.to_str());
+            let parsed = mmd_anim_format::parse_accessory_manifest(&data, file_name)?;
+            let label: &'static str = if parsed.format == "vac" { "VAC" } else { "X" };
+            (mmd_anim_format::export_accessory_manifest(&parsed), label)
+        }
+        kind => return Err(format!("export is not supported for {kind:?}").into()),
+    };
+    fs::write(output, &exported)?;
+    println!(
+        "{kind_label} export: ok bytesIn={} bytesOut={} output={}",
+        data.len(),
+        exported.len(),
+        output.display()
+    );
+    Ok(ExitCode::SUCCESS)
+}
+
+/// Resolves a PMX model path for PMM export to a canonical path string that MMD can open.
+pub(crate) fn resolve_pmx_path_for_pmm(model_path: &Path) -> Result<String, Box<dyn std::error::Error>> {
+    let canonical = model_path.canonicalize().map_err(|e| {
+        format!(
+            "failed to canonicalize PMX model path {}: {}",
+            model_path.display(),
+            e
+        )
+    })?;
+    Ok(pmm_display_path(&canonical))
+}
+
+fn pmm_display_path(path: &Path) -> String {
+    let text = path.display().to_string();
+    #[cfg(windows)]
+    {
+        if let Some(stripped) = text.strip_prefix(r"\\?\UNC\") {
+            return format!(r"\\{stripped}");
+        }
+        if let Some(stripped) = text.strip_prefix(r"\\?\") {
+            return stripped.to_owned();
+        }
+    }
+    text
+}
+
+pub(crate) fn export_pmm_scene(
+    model_path: &Path,
+    motion_path: &Path,
+    output_path: &Path,
+) -> Result<ExitCode, Box<dyn std::error::Error>> {
+    let model_data = fs::read(model_path)?;
+    let motion_data = fs::read(motion_path)?;
+    let model = mmd_anim_format::parse_pmx_model(&model_data)?;
+    let motion = mmd_anim_format::parse_vmd_animation(&motion_data)?;
+    let model_path_text = resolve_pmx_path_for_pmm(model_path)?;
+    let report = mmd_anim_format::export_pmm_scene_from_pmx_vmd(
+        &model,
+        &motion,
+        &model_path_text,
+        &mmd_anim_format::PmmSceneExportOptions::default(),
+    );
+    fs::write(output_path, &report.bytes)?;
+
+    let reparsed = mmd_anim_format::parse_pmm_manifest(&report.bytes)?;
+    let document = reparsed
+        .document_summary
+        .as_ref()
+        .ok_or("generated PMM does not contain a document model block")?;
+    println!(
+        "PMM scene export: ok bytesOut={} bones={} morphs={} boneKeyframes={} morphKeyframes={} frame0Bones={} frame0Morphs={} skippedBones={} skippedMorphs={} maxFrame={} output={}",
+        report.bytes.len(),
+        document.counts.bones,
+        document.counts.morphs,
+        report.bone_keyframes,
+        report.morph_keyframes,
+        report.frame_zero_bone_keyframes,
+        report.frame_zero_morph_keyframes,
+        report.skipped_bone_keyframes,
+        report.skipped_morph_keyframes,
+        report.max_frame,
+        output_path.display()
+    );
+    Ok(ExitCode::SUCCESS)
+}
+
+pub(crate) fn export_json_format(input: &Path, output: &Path) -> Result<ExitCode, Box<dyn std::error::Error>> {
+    let json = fs::read_to_string(input)?;
+    let ext = output
+        .extension()
+        .and_then(|v| v.to_str())
+        .unwrap_or("")
+        .to_ascii_lowercase();
+    let (exported, kind_label): (Vec<u8>, &str) = match ext.as_str() {
+        "vmd" => {
+            let dto: mmd_anim_format::VmdParsedAnimation = serde_json::from_str(&json)?;
+            (mmd_anim_format::export_vmd_animation(&dto), "VMD")
+        }
+        "vpd" => {
+            let dto: mmd_anim_format::VpdParsedPose = serde_json::from_str(&json)?;
+            (mmd_anim_format::export_vpd_pose(&dto), "VPD")
+        }
+        "pmx" => {
+            let dto: mmd_anim_format::PmxParsedModel = serde_json::from_str(&json)?;
+            (mmd_anim_format::export_pmx_model(&dto), "PMX")
+        }
+        "pmd" => {
+            let dto: mmd_anim_format::PmdParsedModel = serde_json::from_str(&json)?;
+            (mmd_anim_format::export_pmd_model(&dto), "PMD")
+        }
+        "x" | "vac" => {
+            let dto: mmd_anim_format::AccessoryParsedManifest = serde_json::from_str(&json)?;
+            let label: &'static str = if ext == "vac" { "VAC" } else { "X" };
+            (mmd_anim_format::export_accessory_manifest(&dto), label)
+        }
+        _ => {
+            return Err(format!(
+                "cannot determine export format from output extension {:?}; \
+                 supported: vmd, vpd, pmx, pmd, x, vac",
+                ext
+            )
+            .into());
+        }
+    };
+    fs::write(output, &exported)?;
+    println!(
+        "{kind_label} export from JSON: ok jsonBytes={} bytesOut={} output={}",
+        json.len(),
+        exported.len(),
+        output.display()
+    );
+    Ok(ExitCode::SUCCESS)
+}
+
+pub(crate) fn vmd_roundtrip_json(
+    path: &Path,
+    mode: &str,
+    bytes_in: usize,
+    bytes_out: usize,
+    json_bytes: Option<usize>,
+    parsed: &mmd_anim_format::VmdParsedAnimation,
+) -> serde_json::Value {
+    serde_json::json!({
+        "status": "ok",
+        "mode": mode,
+        "format": "vmd",
+        "path": path.display().to_string(),
+        "bytesIn": bytes_in,
+        "bytesOut": bytes_out,
+        "jsonBytes": json_bytes,
+        "counts": {
+            "boneFrames": parsed.metadata.counts.bones,
+            "morphFrames": parsed.metadata.counts.morphs,
+            "cameraFrames": parsed.metadata.counts.cameras,
+            "lightFrames": parsed.metadata.counts.lights,
+            "selfShadowFrames": parsed.metadata.counts.self_shadows,
+            "propertyFrames": parsed.metadata.counts.properties,
+        },
+        "maxFrame": parsed.metadata.max_frame,
+    })
+}
+
+pub(crate) fn vpd_roundtrip_json(
+    path: &Path,
+    mode: &str,
+    bytes_in: usize,
+    bytes_out: usize,
+    json_bytes: Option<usize>,
+    parsed: &mmd_anim_format::VpdParsedPose,
+) -> serde_json::Value {
+    serde_json::json!({
+        "status": "ok",
+        "mode": mode,
+        "format": "vpd",
+        "path": path.display().to_string(),
+        "bytesIn": bytes_in,
+        "bytesOut": bytes_out,
+        "jsonBytes": json_bytes,
+        "counts": {
+            "bones": parsed.bone_count,
+        },
+    })
+}
+
+pub(crate) fn pmd_roundtrip_json(
+    path: &Path,
+    mode: &str,
+    bytes_in: usize,
+    bytes_out: usize,
+    json_bytes: Option<usize>,
+    parsed: &mmd_anim_format::PmdParsedModel,
+) -> serde_json::Value {
+    serde_json::json!({
+        "status": "ok",
+        "mode": mode,
+        "format": "pmd",
+        "path": path.display().to_string(),
+        "bytesIn": bytes_in,
+        "bytesOut": bytes_out,
+        "jsonBytes": json_bytes,
+        "counts": {
+            "vertices": parsed.metadata.counts.vertices,
+            "faces": parsed.metadata.counts.faces,
+            "materials": parsed.metadata.counts.materials,
+            "bones": parsed.metadata.counts.bones,
+            "ik": parsed.metadata.counts.ik,
+            "morphs": parsed.metadata.counts.morphs,
+            "displayFrames": parsed.metadata.counts.display_frames,
+            "rigidBodies": parsed.metadata.counts.rigid_bodies,
+            "joints": parsed.metadata.counts.joints,
+        },
+    })
+}
+
+pub(crate) fn pmx_roundtrip_json(
+    path: &Path,
+    mode: &str,
+    bytes_in: usize,
+    bytes_out: usize,
+    json_bytes: Option<usize>,
+    parsed: &mmd_anim_format::PmxParsedModel,
+) -> serde_json::Value {
+    serde_json::json!({
+        "status": "ok",
+        "mode": mode,
+        "format": "pmx",
+        "path": path.display().to_string(),
+        "bytesIn": bytes_in,
+        "bytesOut": bytes_out,
+        "jsonBytes": json_bytes,
+        "metadata": {
+            "version": parsed.metadata.version,
+            "encoding": parsed.metadata.encoding,
+            "additionalUvCount": parsed.metadata.additional_uv_count,
+            "indexSizes": {
+                "vertex": parsed.metadata.index_sizes.vertex,
+                "texture": parsed.metadata.index_sizes.texture,
+                "material": parsed.metadata.index_sizes.material,
+                "bone": parsed.metadata.index_sizes.bone,
+                "morph": parsed.metadata.index_sizes.morph,
+                "rigidBody": parsed.metadata.index_sizes.rigid_body,
+            },
+        },
+        "counts": {
+            "vertices": parsed.metadata.counts.vertices,
+            "faces": parsed.metadata.counts.faces,
+            "materials": parsed.metadata.counts.materials,
+            "bones": parsed.metadata.counts.bones,
+            "morphs": parsed.metadata.counts.morphs,
+            "displayFrames": parsed.metadata.counts.display_frames,
+            "rigidBodies": parsed.metadata.counts.rigid_bodies,
+            "joints": parsed.metadata.counts.joints,
+            "softBodies": parsed.metadata.counts.soft_bodies,
+        },
+    })
+}
+
+pub(crate) fn accessory_roundtrip_json(
+    path: &Path,
+    mode: &str,
+    bytes_in: usize,
+    bytes_out: usize,
+    json_bytes: Option<usize>,
+    parsed: &mmd_anim_format::AccessoryParsedManifest,
+) -> serde_json::Value {
+    let mesh_material_reemitted = !parsed.mesh_summaries.is_empty();
+    let preserved_fields = if mesh_material_reemitted {
+        serde_json::json!([
+            "format",
+            "header",
+            "textureReferences",
+            "meshSummaries",
+            "materials"
+        ])
+    } else if parsed.format == "vac" {
+        serde_json::json!(["format", "header", "textureReferences", "vacSettings"])
+    } else {
+        serde_json::json!(["format", "header", "textureReferences"])
+    };
+    json!({
+        "status": "ok",
+        "mode": mode,
+        "format": parsed.format,
+        "path": path.to_string_lossy(),
+        "bytesIn": bytes_in,
+        "bytesOut": bytes_out,
+        "jsonBytes": json_bytes,
+        "counts": {
+            "meshes": parsed.mesh_count,
+            "materials": parsed.material_count,
+            "meshVertices": parsed.mesh_summaries.iter().map(|mesh| mesh.vertex_count).sum::<usize>(),
+            "meshFaces": parsed.mesh_summaries.iter().map(|mesh| mesh.face_count).sum::<usize>(),
+            "meshNormals": parsed.mesh_summaries.iter().map(|mesh| mesh.normals.len()).sum::<usize>(),
+            "meshTextureCoordinates": parsed.mesh_summaries.iter().map(|mesh| mesh.texture_coordinates.len()).sum::<usize>(),
+            "meshVertexColors": parsed.mesh_summaries.iter().map(|mesh| mesh.vertex_colors.len()).sum::<usize>(),
+            "meshMaterialIndices": parsed.mesh_summaries.iter().map(|mesh| mesh.material_indices.len()).sum::<usize>(),
+            "textureReferences": parsed.texture_references.len(),
+            "diagnostics": parsed.diagnostics.len()
+        },
+        "metadata": {
+            "text": parsed.text,
+            "header": parsed.header,
+            "exportScope": if mesh_material_reemitted { "text-mesh-material-attributes" } else { "manifest" },
+            "meshMaterialReemitted": mesh_material_reemitted,
+            "preservedFields": preserved_fields
+        }
+    })
+}
+
+pub(crate) fn pmm_roundtrip_json(
+    path: &Path,
+    mode: &str,
+    bytes_in: usize,
+    bytes_out: usize,
+    byte_for_byte: bool,
+    parsed: &mmd_anim_format::PmmParsedManifest,
+) -> serde_json::Value {
+    serde_json::json!({
+        "status": "ok",
+        "mode": mode,
+        "format": "pmm",
+        "path": path.display().to_string(),
+        "bytesIn": bytes_in,
+        "bytesOut": bytes_out,
+        "version": parsed.version,
+        "modelReferences": parsed.model_paths.len(),
+        "assetReferences": parsed.asset_summary.reference_count,
+        "diagnostics": parsed.diagnostics.len(),
+        "byteForByte": byte_for_byte,
+    })
+}
+
+pub(crate) fn ensure_pmx_roundtrip(
+    left: &mmd_anim_format::PmxParsedModel,
+    right: &mmd_anim_format::PmxParsedModel,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let left = serde_json::to_value(left)?;
+    let right = serde_json::to_value(right)?;
+    if left != right {
+        return Err("PMX parse/export/parse DTO changed".into());
+    }
+    Ok(())
+}
+
+pub(crate) fn ensure_pmd_roundtrip(
+    left: &mmd_anim_format::PmdParsedModel,
+    right: &mmd_anim_format::PmdParsedModel,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let left = serde_json::to_value(left)?;
+    let right = serde_json::to_value(right)?;
+    if left != right {
+        return Err("PMD parse/export/parse DTO changed".into());
+    }
+    Ok(())
+}
+
+pub(crate) fn ensure_pmm_lossless_roundtrip(
+    original: &[u8],
+    exported: &[u8],
+) -> Result<(), Box<dyn std::error::Error>> {
+    if original != exported {
+        return Err(
+            "PMM parse/export/parse did not preserve source bytes (lossless path failed)".into(),
+        );
+    }
+    Ok(())
+}
+
+pub(crate) fn ensure_accessory_roundtrip(
+    expected: &mmd_anim_format::AccessoryParsedManifest,
+    actual: &mmd_anim_format::AccessoryParsedManifest,
+) -> Result<(), String> {
+    if expected.format != actual.format {
+        return Err(format!(
+            "Accessory roundtrip format changed: expected {}, got {}",
+            expected.format, actual.format
+        ));
+    }
+    if expected.header != actual.header {
+        return Err(format!(
+            "Accessory roundtrip header changed: expected {:?}, got {:?}",
+            expected.header, actual.header
+        ));
+    }
+    if expected.text != actual.text {
+        return Err(format!(
+            "Accessory roundtrip text flag changed: expected {}, got {}",
+            expected.text, actual.text
+        ));
+    }
+    if expected.texture_references != actual.texture_references {
+        return Err(format!(
+            "Accessory roundtrip textureReferences changed: expected {:?}, got {:?}",
+            expected.texture_references, actual.texture_references
+        ));
+    }
+    if !expected.mesh_summaries.is_empty() && expected.mesh_summaries != actual.mesh_summaries {
+        return Err(format!(
+            "Accessory roundtrip meshSummaries changed: {}",
+            describe_accessory_mesh_diff(expected, actual)
+        ));
+    }
+    if expected.materials != actual.materials {
+        return Err(format!(
+            "Accessory roundtrip materials changed: expected {} entries, got {} entries",
+            expected.materials.len(),
+            actual.materials.len()
+        ));
+    }
+    if expected.vac_settings != actual.vac_settings {
+        return Err("Accessory roundtrip vacSettings changed".to_owned());
+    }
+    Ok(())
+}
+
+pub(crate) fn ensure_accessory_json_roundtrip(
+    expected: &mmd_anim_format::AccessoryParsedManifest,
+    actual: &mmd_anim_format::AccessoryParsedManifest,
+) -> Result<(), String> {
+    let expected = serde_json::to_value(expected).map_err(|error| {
+        format!("Accessory JSON roundtrip expected serialization failed: {error}")
+    })?;
+    let actual = serde_json::to_value(actual).map_err(|error| {
+        format!("Accessory JSON roundtrip actual serialization failed: {error}")
+    })?;
+    if expected != actual {
+        return Err("Accessory JSON DTO changed before export".to_owned());
+    }
+    Ok(())
+}
+
+fn describe_accessory_mesh_diff(
+    expected: &mmd_anim_format::AccessoryParsedManifest,
+    actual: &mmd_anim_format::AccessoryParsedManifest,
+) -> String {
+    if expected.mesh_summaries.len() != actual.mesh_summaries.len() {
+        return format!(
+            "expected {} entries, got {} entries",
+            expected.mesh_summaries.len(),
+            actual.mesh_summaries.len()
+        );
+    }
+    for (index, (expected_mesh, actual_mesh)) in expected
+        .mesh_summaries
+        .iter()
+        .zip(actual.mesh_summaries.iter())
+        .enumerate()
+    {
+        if expected_mesh.vertex_count != actual_mesh.vertex_count {
+            return format!(
+                "mesh {index} vertexCount expected {}, got {}",
+                expected_mesh.vertex_count, actual_mesh.vertex_count
+            );
+        }
+        if expected_mesh.face_count != actual_mesh.face_count {
+            return format!(
+                "mesh {index} faceCount expected {}, got {}",
+                expected_mesh.face_count, actual_mesh.face_count
+            );
+        }
+        if expected_mesh.positions != actual_mesh.positions {
+            return format!(
+                "mesh {index} positions expected {} entries, got {} entries",
+                expected_mesh.positions.len(),
+                actual_mesh.positions.len()
+            );
+        }
+        if expected_mesh.face_indices != actual_mesh.face_indices {
+            return format!(
+                "mesh {index} faceIndices expected {} entries, got {} entries",
+                expected_mesh.face_indices.len(),
+                actual_mesh.face_indices.len()
+            );
+        }
+        if expected_mesh.normals != actual_mesh.normals {
+            return format!(
+                "mesh {index} normals expected {} entries, got {} entries",
+                expected_mesh.normals.len(),
+                actual_mesh.normals.len()
+            );
+        }
+        if expected_mesh.normal_face_indices != actual_mesh.normal_face_indices {
+            return format!(
+                "mesh {index} normalFaceIndices expected {} entries, got {} entries",
+                expected_mesh.normal_face_indices.len(),
+                actual_mesh.normal_face_indices.len()
+            );
+        }
+        if expected_mesh.texture_coordinates != actual_mesh.texture_coordinates {
+            return format!(
+                "mesh {index} textureCoordinates expected {} entries, got {} entries",
+                expected_mesh.texture_coordinates.len(),
+                actual_mesh.texture_coordinates.len()
+            );
+        }
+        if expected_mesh.vertex_colors != actual_mesh.vertex_colors {
+            return format!(
+                "mesh {index} vertexColors expected {} entries, got {} entries",
+                expected_mesh.vertex_colors.len(),
+                actual_mesh.vertex_colors.len()
+            );
+        }
+        if expected_mesh.material_indices != actual_mesh.material_indices {
+            return format!(
+                "mesh {index} materialIndices expected {:?}, got {:?}",
+                expected_mesh.material_indices, actual_mesh.material_indices
+            );
+        }
+    }
+    "unknown mesh summary delta".to_owned()
+}
+
+pub(crate) fn ensure_vmd_roundtrip(
+    left: &mmd_anim_format::VmdParsedAnimation,
+    right: &mmd_anim_format::VmdParsedAnimation,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if left.metadata.model_name != right.metadata.model_name {
+        return Err(format!(
+            "VMD metadata.model_name changed: expected={:?} got={:?}",
+            left.metadata.model_name, right.metadata.model_name
+        )
+        .into());
+    }
+    if left.metadata.max_frame != right.metadata.max_frame {
+        return Err(format!(
+            "VMD metadata.max_frame changed: expected={} got={}",
+            left.metadata.max_frame, right.metadata.max_frame
+        )
+        .into());
+    }
+    macro_rules! check_count {
+        ($field:ident, $label:expr) => {
+            if left.metadata.counts.$field != right.metadata.counts.$field {
+                return Err(format!(
+                    "VMD metadata.counts.{} changed: expected={} got={}",
+                    $label, left.metadata.counts.$field, right.metadata.counts.$field
+                )
+                .into());
+            }
+        };
+    }
+    check_count!(bones, "bones");
+    check_count!(morphs, "morphs");
+    check_count!(cameras, "cameras");
+    check_count!(lights, "lights");
+    check_count!(self_shadows, "selfShadows");
+    check_count!(properties, "properties");
+
+    for (i, (l, r)) in left.bone_frames.iter().zip(&right.bone_frames).enumerate() {
+        if l.bone_name != r.bone_name {
+            return Err(format!(
+                "VMD bone_frames[{i}] bone_name: expected={:?} got={:?}",
+                l.bone_name, r.bone_name
+            )
+            .into());
+        }
+        if l.frame != r.frame {
+            return Err(format!(
+                "VMD bone_frames[{i}] bone={:?} frame: expected={} got={}",
+                l.bone_name, l.frame, r.frame
+            )
+            .into());
+        }
+        if l.translation != r.translation {
+            return Err(format!(
+                "VMD bone_frames[{i}] bone={:?} frame={} translation: expected={:?} got={:?}",
+                l.bone_name, l.frame, l.translation, r.translation
+            )
+            .into());
+        }
+        if l.rotation != r.rotation {
+            return Err(format!(
+                "VMD bone_frames[{i}] bone={:?} frame={} rotation: expected={:?} got={:?}",
+                l.bone_name, l.frame, l.rotation, r.rotation
+            )
+            .into());
+        }
+        if l.interpolation != r.interpolation {
+            return Err(format!(
+                "VMD bone_frames[{i}] bone={:?} frame={} interpolation changed",
+                l.bone_name, l.frame
+            )
+            .into());
+        }
+    }
+
+    for (i, (l, r)) in left
+        .morph_frames
+        .iter()
+        .zip(&right.morph_frames)
+        .enumerate()
+    {
+        if l.morph_name != r.morph_name {
+            return Err(format!(
+                "VMD morph_frames[{i}] morph_name: expected={:?} got={:?}",
+                l.morph_name, r.morph_name
+            )
+            .into());
+        }
+        if l.frame != r.frame {
+            return Err(format!(
+                "VMD morph_frames[{i}] morph={:?} frame: expected={} got={}",
+                l.morph_name, l.frame, r.frame
+            )
+            .into());
+        }
+        if l.weight != r.weight {
+            return Err(format!(
+                "VMD morph_frames[{i}] morph={:?} frame={} weight: expected={} got={}",
+                l.morph_name, l.frame, l.weight, r.weight
+            )
+            .into());
+        }
+    }
+
+    for (i, (l, r)) in left
+        .camera_frames
+        .iter()
+        .zip(&right.camera_frames)
+        .enumerate()
+    {
+        if l.frame != r.frame {
+            return Err(format!(
+                "VMD camera_frames[{i}] frame: expected={} got={}",
+                l.frame, r.frame
+            )
+            .into());
+        }
+        if l.distance != r.distance {
+            return Err(format!(
+                "VMD camera_frames[{i}] frame={} distance: expected={} got={}",
+                l.frame, l.distance, r.distance
+            )
+            .into());
+        }
+        if l.position != r.position {
+            return Err(format!(
+                "VMD camera_frames[{i}] frame={} position: expected={:?} got={:?}",
+                l.frame, l.position, r.position
+            )
+            .into());
+        }
+        if l.rotation != r.rotation {
+            return Err(format!(
+                "VMD camera_frames[{i}] frame={} rotation: expected={:?} got={:?}",
+                l.frame, l.rotation, r.rotation
+            )
+            .into());
+        }
+        if l.interpolation != r.interpolation {
+            return Err(format!(
+                "VMD camera_frames[{i}] frame={} interpolation changed",
+                l.frame
+            )
+            .into());
+        }
+        if l.fov != r.fov {
+            return Err(format!(
+                "VMD camera_frames[{i}] frame={} fov: expected={} got={}",
+                l.frame, l.fov, r.fov
+            )
+            .into());
+        }
+        if l.perspective != r.perspective {
+            return Err(format!(
+                "VMD camera_frames[{i}] frame={} perspective: expected={} got={}",
+                l.frame, l.perspective, r.perspective
+            )
+            .into());
+        }
+    }
+
+    for (i, (l, r)) in left
+        .light_frames
+        .iter()
+        .zip(&right.light_frames)
+        .enumerate()
+    {
+        if l.frame != r.frame {
+            return Err(format!(
+                "VMD light_frames[{i}] frame: expected={} got={}",
+                l.frame, r.frame
+            )
+            .into());
+        }
+        if l.color != r.color {
+            return Err(format!(
+                "VMD light_frames[{i}] frame={} color: expected={:?} got={:?}",
+                l.frame, l.color, r.color
+            )
+            .into());
+        }
+        if l.direction != r.direction {
+            return Err(format!(
+                "VMD light_frames[{i}] frame={} direction: expected={:?} got={:?}",
+                l.frame, l.direction, r.direction
+            )
+            .into());
+        }
+    }
+
+    for (i, (l, r)) in left
+        .self_shadow_frames
+        .iter()
+        .zip(&right.self_shadow_frames)
+        .enumerate()
+    {
+        if l.frame != r.frame {
+            return Err(format!(
+                "VMD self_shadow_frames[{i}] frame: expected={} got={}",
+                l.frame, r.frame
+            )
+            .into());
+        }
+        if l.mode != r.mode {
+            return Err(format!(
+                "VMD self_shadow_frames[{i}] frame={} mode: expected={} got={}",
+                l.frame, l.mode, r.mode
+            )
+            .into());
+        }
+        if l.distance != r.distance {
+            return Err(format!(
+                "VMD self_shadow_frames[{i}] frame={} distance: expected={} got={}",
+                l.frame, l.distance, r.distance
+            )
+            .into());
+        }
+    }
+
+    for (i, (l, r)) in left
+        .property_frames
+        .iter()
+        .zip(&right.property_frames)
+        .enumerate()
+    {
+        if l.frame != r.frame {
+            return Err(format!(
+                "VMD property_frames[{i}] frame: expected={} got={}",
+                l.frame, r.frame
+            )
+            .into());
+        }
+        if l.visible != r.visible {
+            return Err(format!(
+                "VMD property_frames[{i}] frame={} visible: expected={} got={}",
+                l.frame, l.visible, r.visible
+            )
+            .into());
+        }
+        if l.ik_states.len() != r.ik_states.len() {
+            return Err(format!(
+                "VMD property_frames[{i}] frame={} ik_states count: expected={} got={}",
+                l.frame,
+                l.ik_states.len(),
+                r.ik_states.len()
+            )
+            .into());
+        }
+        for (j, (lk, rk)) in l.ik_states.iter().zip(&r.ik_states).enumerate() {
+            if lk.bone_name != rk.bone_name {
+                return Err(format!(
+                    "VMD property_frames[{i}] frame={} ik_states[{j}] bone_name: expected={:?} got={:?}",
+                    l.frame, lk.bone_name, rk.bone_name
+                )
+                .into());
+            }
+            if lk.enabled != rk.enabled {
+                return Err(format!(
+                    "VMD property_frames[{i}] frame={} ik_states[{j}] bone={:?} enabled: expected={} got={}",
+                    l.frame, lk.bone_name, lk.enabled, rk.enabled
+                )
+                .into());
+            }
+        }
+    }
+    Ok(())
+}
+
+pub(crate) fn ensure_vpd_roundtrip(
+    left: &mmd_anim_format::VpdParsedPose,
+    right: &mmd_anim_format::VpdParsedPose,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if left.model_file != right.model_file {
+        return Err(format!(
+            "VPD model_file changed: expected={:?} got={:?}",
+            left.model_file, right.model_file
+        )
+        .into());
+    }
+    if left.bone_count != right.bone_count {
+        return Err(format!(
+            "VPD bone_count changed: expected={} got={}",
+            left.bone_count, right.bone_count
+        )
+        .into());
+    }
+    for (i, (l, r)) in left.bones.iter().zip(&right.bones).enumerate() {
+        if l.name != r.name {
+            return Err(format!(
+                "VPD bones[{i}] name: expected={:?} got={:?}",
+                l.name, r.name
+            )
+            .into());
+        }
+        if l.translation != r.translation {
+            return Err(format!(
+                "VPD bones[{i}] bone={:?} translation: expected={:?} got={:?}",
+                l.name, l.translation, r.translation
+            )
+            .into());
+        }
+        if l.rotation != r.rotation {
+            return Err(format!(
+                "VPD bones[{i}] bone={:?} rotation: expected={:?} got={:?}",
+                l.name, l.rotation, r.rotation
+            )
+            .into());
+        }
+    }
+    Ok(())
+}

--- a/crates/mmd-anim-cli/src/commands/golden.rs
+++ b/crates/mmd-anim-cli/src/commands/golden.rs
@@ -4,8 +4,8 @@ use glam::Vec3A;
 use mmd_anim_format::VmdClipBuildOptions;
 use mmd_anim_runtime::{BoneIndex, IkSolver, ModelArena, MorphIndex, RuntimeInstance};
 use mmd_anim_schema::{
-    GoldenIkBatchManifest, GoldenIkFixture, MmdDumperOracleDump, MmdDumperOracleModel,
-    DEFAULT_FOCUSED_IK_BONE_NAMES,
+    DEFAULT_FOCUSED_IK_BONE_NAMES, GoldenIkBatchManifest, GoldenIkFixture, MmdDumperOracleDump,
+    MmdDumperOracleModel,
 };
 use serde_json::json;
 

--- a/crates/mmd-anim-cli/src/commands/golden.rs
+++ b/crates/mmd-anim-cli/src/commands/golden.rs
@@ -515,7 +515,7 @@ pub(crate) fn golden_ik_compare(
         }
 
         let fixture = GoldenIkFixture::from_json_str(&fs::read_to_string(&fixture_path)?)?;
-        let oracle_path = super::resolve_maybe_absolute(&case_root, &fixture.output);
+        let oracle_path = crate::resolve_maybe_absolute(&case_root, &fixture.output);
         if !oracle_path.exists() {
             missing += 1;
             eprintln!("missing: {}", oracle_path.display());
@@ -899,7 +899,7 @@ pub(crate) fn golden_ik_diagnose(
     }
 
     let fixture = GoldenIkFixture::from_json_str(&fs::read_to_string(&fixture_path)?)?;
-    let oracle_path = super::resolve_maybe_absolute(&case_root, &fixture.output);
+    let oracle_path = crate::resolve_maybe_absolute(&case_root, &fixture.output);
     if !oracle_path.exists() {
         return Err("oracle file not found".into());
     }

--- a/crates/mmd-anim-cli/src/commands/golden.rs
+++ b/crates/mmd-anim-cli/src/commands/golden.rs
@@ -4,8 +4,8 @@ use glam::Vec3A;
 use mmd_anim_format::VmdClipBuildOptions;
 use mmd_anim_runtime::{BoneIndex, IkSolver, ModelArena, MorphIndex, RuntimeInstance};
 use mmd_anim_schema::{
-    DEFAULT_FOCUSED_IK_BONE_NAMES, GoldenIkBatchManifest, GoldenIkFixture, MmdDumperOracleDump,
-    MmdDumperOracleModel,
+    GoldenIkBatchManifest, GoldenIkFixture, MmdDumperOracleDump, MmdDumperOracleModel,
+    DEFAULT_FOCUSED_IK_BONE_NAMES,
 };
 use serde_json::json;
 

--- a/crates/mmd-anim-cli/src/commands/import.rs
+++ b/crates/mmd-anim-cli/src/commands/import.rs
@@ -1,12 +1,12 @@
-use std::{collections::BTreeMap, fs, path::Path, process::ExitCode, sync::Arc};
+use std::{collections::BTreeMap, path::Path, process::ExitCode, sync::Arc};
 
 use glam::Vec3A;
 use mmd_anim_runtime::RuntimeInstance;
 
-use crate::{f32_checksum, translation_checksum};
+use crate::{diagnostics_suffix, f32_checksum, read_file, translation_checksum};
 
 pub(crate) fn import_pmx_summary(path: &Path) -> Result<ExitCode, Box<dyn std::error::Error>> {
-    let data = fs::read(path)?;
+    let data = read_file(path)?;
     let imported = mmd_anim_format::import_pmx_runtime(&data)?;
     println!(
         "PMX runtime import: bones={} append={} fixedAxis={} ik={} boneNames={} morphNames={} ikNameMap={}",
@@ -22,7 +22,7 @@ pub(crate) fn import_pmx_summary(path: &Path) -> Result<ExitCode, Box<dyn std::e
 }
 
 pub(crate) fn import_pmx_ik_summary(path: &Path) -> Result<ExitCode, Box<dyn std::error::Error>> {
-    let data = fs::read(path)?;
+    let data = read_file(path)?;
     let imported = mmd_anim_format::import_pmx_runtime(&data)?;
     let solvers = imported.model.ik_solvers();
     let max_iterations = solvers
@@ -70,10 +70,10 @@ pub(crate) fn import_pmx_ik_summary(path: &Path) -> Result<ExitCode, Box<dyn std
 }
 
 pub(crate) fn import_pmd_summary(path: &Path) -> Result<ExitCode, Box<dyn std::error::Error>> {
-    let data = fs::read(path)?;
+    let data = read_file(path)?;
     let imported = mmd_anim_format::import_pmd_runtime(&data)?;
     println!(
-        "PMD runtime import: bones={} ik={} morphSlots={} vertexMorphOffsets={} boneNames={} morphNames={} ikNameMap={} diagnostics={}",
+        "PMD runtime import: bones={} ik={} morphSlots={} vertexMorphOffsets={} boneNames={} morphNames={} ikNameMap={}{}",
         imported.model.bone_count(),
         imported.model.ik_count(),
         imported.model.morph_count(),
@@ -81,13 +81,13 @@ pub(crate) fn import_pmd_summary(path: &Path) -> Result<ExitCode, Box<dyn std::e
         imported.bone_name_to_index.len(),
         imported.morph_name_to_index.len(),
         imported.ik_solver_bone_name_to_index.len(),
-        imported.diagnostics.len()
+        diagnostics_suffix(imported.diagnostics.len())
     );
     Ok(ExitCode::SUCCESS)
 }
 
 pub(crate) fn import_vmd_summary(path: &Path) -> Result<ExitCode, Box<dyn std::error::Error>> {
-    let data = fs::read(path)?;
+    let data = read_file(path)?;
     let imported = mmd_anim_format::import_vmd_motion(&data)?;
     let property_ik_entries: usize = imported
         .property_ik_frames
@@ -108,8 +108,8 @@ pub(crate) fn import_pair_summary(
     pmx_path: &Path,
     vmd_path: &Path,
 ) -> Result<ExitCode, Box<dyn std::error::Error>> {
-    let pmx = mmd_anim_format::import_pmx_runtime(&fs::read(pmx_path)?)?;
-    let vmd = mmd_anim_format::import_vmd_motion(&fs::read(vmd_path)?)?;
+    let pmx = mmd_anim_format::import_pmx_runtime(&read_file(pmx_path)?)?;
+    let vmd = mmd_anim_format::import_vmd_motion(&read_file(vmd_path)?)?;
 
     let matched_bone_keys = vmd
         .bone_keyframes
@@ -163,8 +163,8 @@ pub(crate) fn import_pair_clip_summary(
     pmx_path: &Path,
     vmd_path: &Path,
 ) -> Result<ExitCode, Box<dyn std::error::Error>> {
-    let pmx = mmd_anim_format::import_pmx_runtime(&fs::read(pmx_path)?)?;
-    let vmd = mmd_anim_format::import_vmd_motion(&fs::read(vmd_path)?)?;
+    let pmx = mmd_anim_format::import_pmx_runtime(&read_file(pmx_path)?)?;
+    let vmd = mmd_anim_format::import_vmd_motion(&read_file(vmd_path)?)?;
 
     let solver_count = pmx.model.ik_count();
     let clip = mmd_anim_format::build_pair_clip(
@@ -199,8 +199,8 @@ pub(crate) fn import_pair_frame_summary(
     vmd_path: &Path,
     frame: f32,
 ) -> Result<ExitCode, Box<dyn std::error::Error>> {
-    let pmx = mmd_anim_format::import_pmx_runtime(&fs::read(pmx_path)?)?;
-    let vmd = mmd_anim_format::import_vmd_motion(&fs::read(vmd_path)?)?;
+    let pmx = mmd_anim_format::import_pmx_runtime(&read_file(pmx_path)?)?;
+    let vmd = mmd_anim_format::import_vmd_motion(&read_file(vmd_path)?)?;
 
     let bone_count = pmx.model.bone_count();
     let solver_count = pmx.model.ik_count();

--- a/crates/mmd-anim-cli/src/commands/import.rs
+++ b/crates/mmd-anim-cli/src/commands/import.rs
@@ -142,19 +142,38 @@ pub(crate) fn import_pair_summary(
         })
         .count();
 
+    let bone_match_pct = if vmd.bone_keyframes.is_empty() {
+        100.0
+    } else {
+        matched_bone_keys as f64 / vmd.bone_keyframes.len() as f64 * 100.0
+    };
+    let morph_match_pct = if vmd.morph_keyframes.is_empty() {
+        100.0
+    } else {
+        matched_morph_keys as f64 / vmd.morph_keyframes.len() as f64 * 100.0
+    };
+    println!("PMX/VMD runtime import:");
     println!(
-        "PMX/VMD runtime import: bones={} append={} fixedAxis={} ik={} vmdBoneKeys={} matchedBoneKeys={} vmdMorphKeys={} matchedMorphKeys={} propertyFrames={} propertyIkEntries={} matchedPropertyIkEntries={}",
+        "  model:    bones={} append={} fixedAxis={} ik={}",
         pmx.model.bone_count(),
         pmx.model.append_transforms().len(),
         pmx.model.fixed_axis_count(),
         pmx.model.ik_count(),
+    );
+    println!(
+        "  motion:   vmdBoneKeys={} matchedBoneKeys={} ({:.1}%) vmdMorphKeys={} matchedMorphKeys={} ({:.1}%)",
         vmd.bone_keyframes.len(),
         matched_bone_keys,
+        bone_match_pct,
         vmd.morph_keyframes.len(),
         matched_morph_keys,
+        morph_match_pct,
+    );
+    println!(
+        "  property: propertyFrames={} propertyIkEntries={} matchedPropertyIkEntries={}",
         vmd.property_ik_frames.len(),
         property_ik_entries,
-        matched_property_ik_entries
+        matched_property_ik_entries,
     );
     Ok(ExitCode::SUCCESS)
 }

--- a/crates/mmd-anim-cli/src/commands/import.rs
+++ b/crates/mmd-anim-cli/src/commands/import.rs
@@ -1,0 +1,266 @@
+use std::{
+    collections::BTreeMap,
+    fs,
+    path::Path,
+    process::ExitCode,
+    sync::Arc,
+};
+
+use glam::Vec3A;
+use mmd_anim_runtime::RuntimeInstance;
+
+use crate::{f32_checksum, translation_checksum};
+
+pub(crate) fn import_pmx_summary(path: &Path) -> Result<ExitCode, Box<dyn std::error::Error>> {
+    let data = fs::read(path)?;
+    let imported = mmd_anim_format::import_pmx_runtime(&data)?;
+    println!(
+        "PMX runtime import: bones={} append={} fixedAxis={} ik={} boneNames={} morphNames={} ikNameMap={}",
+        imported.model.bone_count(),
+        imported.model.append_transforms().len(),
+        imported.model.fixed_axis_count(),
+        imported.model.ik_count(),
+        imported.bone_name_to_index.len(),
+        imported.morph_name_to_index.len(),
+        imported.ik_solver_bone_name_to_index.len()
+    );
+    Ok(ExitCode::SUCCESS)
+}
+
+pub(crate) fn import_pmx_ik_summary(path: &Path) -> Result<ExitCode, Box<dyn std::error::Error>> {
+    let data = fs::read(path)?;
+    let imported = mmd_anim_format::import_pmx_runtime(&data)?;
+    let solvers = imported.model.ik_solvers();
+    let max_iterations = solvers
+        .iter()
+        .map(|solver| solver.iteration_count)
+        .max()
+        .unwrap_or(0);
+    let mut distribution = BTreeMap::<u32, usize>::new();
+    for solver in solvers {
+        *distribution.entry(solver.iteration_count).or_default() += 1;
+    }
+    let distribution = distribution
+        .iter()
+        .map(|(iterations, count)| format!("{iterations}:{count}"))
+        .collect::<Vec<_>>()
+        .join(",");
+
+    println!(
+        "PMX IK summary: bones={} ik={} maxIterations={} distribution={}",
+        imported.model.bone_count(),
+        solvers.len(),
+        max_iterations,
+        distribution
+    );
+    for (solver_index, solver) in solvers.iter().enumerate() {
+        if solver.iteration_count == max_iterations {
+            let name = imported
+                .bone_names
+                .get(solver.ik_bone.as_usize())
+                .map(String::as_str)
+                .unwrap_or("<unknown>");
+            println!(
+                "max IK: solver={} bone={} name={} target={} iterations={} limitAngle={:.6} links={}",
+                solver_index,
+                solver.ik_bone.as_usize(),
+                name,
+                solver.target_bone.as_usize(),
+                solver.iteration_count,
+                solver.limit_angle,
+                solver.links.len()
+            );
+        }
+    }
+    Ok(ExitCode::SUCCESS)
+}
+
+pub(crate) fn import_pmd_summary(path: &Path) -> Result<ExitCode, Box<dyn std::error::Error>> {
+    let data = fs::read(path)?;
+    let imported = mmd_anim_format::import_pmd_runtime(&data)?;
+    println!(
+        "PMD runtime import: bones={} ik={} morphSlots={} vertexMorphOffsets={} boneNames={} morphNames={} ikNameMap={} diagnostics={}",
+        imported.model.bone_count(),
+        imported.model.ik_count(),
+        imported.model.morph_count(),
+        imported.model.vertex_morph_offsets().len(),
+        imported.bone_name_to_index.len(),
+        imported.morph_name_to_index.len(),
+        imported.ik_solver_bone_name_to_index.len(),
+        imported.diagnostics.len()
+    );
+    Ok(ExitCode::SUCCESS)
+}
+
+pub(crate) fn import_vmd_summary(path: &Path) -> Result<ExitCode, Box<dyn std::error::Error>> {
+    let data = fs::read(path)?;
+    let imported = mmd_anim_format::import_vmd_motion(&data)?;
+    let property_ik_entries: usize = imported
+        .property_ik_frames
+        .iter()
+        .map(|frame| frame.entries.len())
+        .sum();
+    println!(
+        "VMD runtime import: boneKeys={} morphKeys={} propertyFrames={} propertyIkEntries={}",
+        imported.bone_keyframes.len(),
+        imported.morph_keyframes.len(),
+        imported.property_ik_frames.len(),
+        property_ik_entries
+    );
+    Ok(ExitCode::SUCCESS)
+}
+
+pub(crate) fn import_pair_summary(
+    pmx_path: &Path,
+    vmd_path: &Path,
+) -> Result<ExitCode, Box<dyn std::error::Error>> {
+    let pmx = mmd_anim_format::import_pmx_runtime(&fs::read(pmx_path)?)?;
+    let vmd = mmd_anim_format::import_vmd_motion(&fs::read(vmd_path)?)?;
+
+    let matched_bone_keys = vmd
+        .bone_keyframes
+        .iter()
+        .filter(|keyframe| {
+            pmx.bone_name_to_index
+                .contains_key(&keyframe.bone_name_normalized)
+        })
+        .count();
+    let matched_morph_keys = vmd
+        .morph_keyframes
+        .iter()
+        .filter(|(name, _, _)| {
+            let normalized = mmd_anim_format::normalize_vmd_name(name);
+            pmx.morph_name_to_index.contains_key(&normalized)
+        })
+        .count();
+    let property_ik_entries: usize = vmd
+        .property_ik_frames
+        .iter()
+        .map(|frame| frame.entries.len())
+        .sum();
+    let matched_property_ik_entries = vmd
+        .property_ik_frames
+        .iter()
+        .flat_map(|frame| frame.entries.iter())
+        .filter(|entry| {
+            pmx.ik_solver_bone_name_to_index
+                .contains_key(&entry.name_normalized)
+        })
+        .count();
+
+    println!(
+        "PMX/VMD runtime import: bones={} append={} fixedAxis={} ik={} vmdBoneKeys={} matchedBoneKeys={} vmdMorphKeys={} matchedMorphKeys={} propertyFrames={} propertyIkEntries={} matchedPropertyIkEntries={}",
+        pmx.model.bone_count(),
+        pmx.model.append_transforms().len(),
+        pmx.model.fixed_axis_count(),
+        pmx.model.ik_count(),
+        vmd.bone_keyframes.len(),
+        matched_bone_keys,
+        vmd.morph_keyframes.len(),
+        matched_morph_keys,
+        vmd.property_ik_frames.len(),
+        property_ik_entries,
+        matched_property_ik_entries
+    );
+    Ok(ExitCode::SUCCESS)
+}
+
+pub(crate) fn import_pair_clip_summary(
+    pmx_path: &Path,
+    vmd_path: &Path,
+) -> Result<ExitCode, Box<dyn std::error::Error>> {
+    let pmx = mmd_anim_format::import_pmx_runtime(&fs::read(pmx_path)?)?;
+    let vmd = mmd_anim_format::import_vmd_motion(&fs::read(vmd_path)?)?;
+
+    let solver_count = pmx.model.ik_count();
+    let clip = mmd_anim_format::build_pair_clip(
+        &vmd,
+        &pmx.bone_name_to_index,
+        &pmx.morph_name_to_index,
+        &pmx.ik_solver_bone_name_to_index,
+        solver_count,
+    );
+
+    let frame_range = clip
+        .frame_range()
+        .map(|(first, last)| format!("{first}..{last}"))
+        .unwrap_or_else(|| "none".to_owned());
+
+    println!(
+        "Pair clip built: bones={} append={} fixedAxis={} ik={} clipBoneTracks={} clipMorphTracks={} propertyTrack={} frameRange={}",
+        pmx.model.bone_count(),
+        pmx.model.append_transforms().len(),
+        pmx.model.fixed_axis_count(),
+        pmx.model.ik_count(),
+        clip.bone_track_count(),
+        clip.morph_track_count(),
+        clip.has_property_track(),
+        frame_range
+    );
+    Ok(ExitCode::SUCCESS)
+}
+
+pub(crate) fn import_pair_frame_summary(
+    pmx_path: &Path,
+    vmd_path: &Path,
+    frame: f32,
+) -> Result<ExitCode, Box<dyn std::error::Error>> {
+    let pmx = mmd_anim_format::import_pmx_runtime(&fs::read(pmx_path)?)?;
+    let vmd = mmd_anim_format::import_vmd_motion(&fs::read(vmd_path)?)?;
+
+    let bone_count = pmx.model.bone_count();
+    let solver_count = pmx.model.ik_count();
+    let morph_count = pmx
+        .morph_name_to_index
+        .values()
+        .map(|index| index.as_usize() + 1)
+        .max()
+        .unwrap_or(0);
+
+    let clip = mmd_anim_format::build_pair_clip(
+        &vmd,
+        &pmx.bone_name_to_index,
+        &pmx.morph_name_to_index,
+        &pmx.ik_solver_bone_name_to_index,
+        solver_count,
+    );
+
+    let model = Arc::new(pmx.model);
+    let mut runtime = RuntimeInstance::new_with_counts(model, morph_count, solver_count);
+
+    runtime.evaluate_clip_frame(&clip, frame);
+
+    let world_matrices = runtime.world_matrices();
+
+    let first_translation = if let Some(m) = world_matrices.first() {
+        Vec3A::new(m.w_axis.x, m.w_axis.y, m.w_axis.z)
+    } else {
+        Vec3A::ZERO
+    };
+
+    let checksum = translation_checksum(world_matrices);
+    let morph_weights = runtime.morph_weights();
+    let nonzero_morphs = morph_weights
+        .iter()
+        .filter(|weight| weight.abs() > f32::EPSILON)
+        .count();
+    let morph_checksum = f32_checksum(morph_weights);
+
+    println!(
+        "PMX/VMD frame {:.3}: bones={} ik={} clipBoneTracks={} clipMorphTracks={} worldMatrices={} firstTranslation=({:.6},{:.6},{:.6}) translationChecksum={:08x} nonzeroMorphs={} morphChecksum={:08x}",
+        frame,
+        bone_count,
+        solver_count,
+        clip.bone_track_count(),
+        clip.morph_track_count(),
+        world_matrices.len(),
+        first_translation.x,
+        first_translation.y,
+        first_translation.z,
+        checksum,
+        nonzero_morphs,
+        morph_checksum,
+    );
+
+    Ok(ExitCode::SUCCESS)
+}

--- a/crates/mmd-anim-cli/src/commands/import.rs
+++ b/crates/mmd-anim-cli/src/commands/import.rs
@@ -1,10 +1,4 @@
-use std::{
-    collections::BTreeMap,
-    fs,
-    path::Path,
-    process::ExitCode,
-    sync::Arc,
-};
+use std::{collections::BTreeMap, fs, path::Path, process::ExitCode, sync::Arc};
 
 use glam::Vec3A;
 use mmd_anim_runtime::RuntimeInstance;

--- a/crates/mmd-anim-cli/src/commands/mod.rs
+++ b/crates/mmd-anim-cli/src/commands/mod.rs
@@ -6,3 +6,4 @@ pub(crate) mod import;
 pub(crate) mod oracle;
 pub(crate) mod parse;
 pub(crate) mod patch;
+pub(crate) mod rig;

--- a/crates/mmd-anim-cli/src/commands/mod.rs
+++ b/crates/mmd-anim-cli/src/commands/mod.rs
@@ -1,0 +1,8 @@
+pub(crate) mod bench;
+pub(crate) mod compare;
+pub(crate) mod export;
+pub(crate) mod golden;
+pub(crate) mod import;
+pub(crate) mod oracle;
+pub(crate) mod parse;
+pub(crate) mod patch;

--- a/crates/mmd-anim-cli/src/commands/oracle.rs
+++ b/crates/mmd-anim-cli/src/commands/oracle.rs
@@ -1,0 +1,37 @@
+use std::{fs, process::ExitCode};
+
+use mmd_anim_schema::MmdDumperOracleDump;
+
+pub(crate) fn oracle_summary(path: &str) -> Result<ExitCode, Box<dyn std::error::Error>> {
+    let content = fs::read_to_string(path)?;
+    let dump = MmdDumperOracleDump::from_jsonl_str(&content, None)?;
+    let model_count = dump
+        .frames
+        .iter()
+        .map(|frame| frame.models.len())
+        .max()
+        .unwrap_or(0);
+    let bone_count = dump
+        .frames
+        .first()
+        .and_then(|frame| frame.models.first())
+        .map(|model| model.bones.len())
+        .unwrap_or(0);
+    let morph_count = dump
+        .frames
+        .first()
+        .and_then(|frame| frame.models.first())
+        .map(|model| model.morphs.len())
+        .unwrap_or(0);
+
+    println!(
+        "MMDDumper oracle: frames={} models={} firstModelBones={} firstModelMorphs={} mmd={} dumper={}",
+        dump.frames.len(),
+        model_count,
+        bone_count,
+        morph_count,
+        dump.source.mmd_version,
+        dump.source.dumper_version
+    );
+    Ok(ExitCode::SUCCESS)
+}

--- a/crates/mmd-anim-cli/src/commands/parse.rs
+++ b/crates/mmd-anim-cli/src/commands/parse.rs
@@ -1,0 +1,353 @@
+use std::{fs, path::Path, process::ExitCode};
+
+pub(crate) fn parse_pmx_summary(path: &Path) -> Result<ExitCode, Box<dyn std::error::Error>> {
+    let data = fs::read(path)?;
+    let parsed = mmd_anim_format::parse_pmx_model(&data)?;
+    println!(
+        "PMX parser: vertices={} faces={} materials={} bones={} morphs={} displayFrames={} rigidBodies={} joints={} softBodies={} diagnostics={}",
+        parsed.metadata.counts.vertices,
+        parsed.metadata.counts.faces,
+        parsed.metadata.counts.materials,
+        parsed.metadata.counts.bones,
+        parsed.metadata.counts.morphs,
+        parsed.metadata.counts.display_frames,
+        parsed.metadata.counts.rigid_bodies,
+        parsed.metadata.counts.joints,
+        parsed.metadata.counts.soft_bodies,
+        parsed.diagnostics.len()
+    );
+    Ok(ExitCode::SUCCESS)
+}
+
+pub(crate) fn parse_format_summary(path: &Path) -> Result<ExitCode, Box<dyn std::error::Error>> {
+    let data = fs::read(path)?;
+    match mmd_anim_format::detect_mmd_format(&data, path.file_name().and_then(|v| v.to_str())) {
+        mmd_anim_format::MmdFormatKind::Pmx => parse_pmx_summary(path),
+        mmd_anim_format::MmdFormatKind::Pmd => {
+            let parsed = mmd_anim_format::parse_pmd_model(&data)?;
+            println!(
+                "PMD parser: vertices={} faces={} materials={} bones={} ik={} morphs={} displayFrames={} rigidBodies={} joints={}",
+                parsed.metadata.counts.vertices,
+                parsed.metadata.counts.faces,
+                parsed.metadata.counts.materials,
+                parsed.metadata.counts.bones,
+                parsed.metadata.counts.ik,
+                parsed.metadata.counts.morphs,
+                parsed.metadata.counts.display_frames,
+                parsed.metadata.counts.rigid_bodies,
+                parsed.metadata.counts.joints
+            );
+            Ok(ExitCode::SUCCESS)
+        }
+        mmd_anim_format::MmdFormatKind::Vmd => {
+            let parsed = mmd_anim_format::parse_vmd_animation(&data)?;
+            println!(
+                "VMD parser: boneFrames={} morphFrames={} cameraFrames={} lightFrames={} selfShadowFrames={} propertyFrames={} maxFrame={}",
+                parsed.metadata.counts.bones,
+                parsed.metadata.counts.morphs,
+                parsed.metadata.counts.cameras,
+                parsed.metadata.counts.lights,
+                parsed.metadata.counts.self_shadows,
+                parsed.metadata.counts.properties,
+                parsed.metadata.max_frame
+            );
+            Ok(ExitCode::SUCCESS)
+        }
+        mmd_anim_format::MmdFormatKind::Vpd => {
+            let parsed = mmd_anim_format::parse_vpd_pose(&data)?;
+            println!(
+                "VPD parser: bones={} diagnostics={}",
+                parsed.bone_count,
+                parsed.diagnostics.len()
+            );
+            Ok(ExitCode::SUCCESS)
+        }
+        mmd_anim_format::MmdFormatKind::Pmm => {
+            let parsed = mmd_anim_format::parse_pmm_manifest(&data)?;
+            let model_slot_flag_counts = parsed
+                .display_state
+                .model_slot_flag_counts
+                .iter()
+                .map(|(flag, count)| format!("{flag}:{count}"))
+                .collect::<Vec<_>>()
+                .join(",");
+            let asset_kind_counts = parsed
+                .asset_summary
+                .kind_counts
+                .iter()
+                .map(|(kind, count)| format!("{kind}:{count}"))
+                .collect::<Vec<_>>()
+                .join(",");
+            let asset_extension_counts = parsed
+                .asset_summary
+                .extension_counts
+                .iter()
+                .map(|(extension, count)| format!("{extension}:{count}"))
+                .collect::<Vec<_>>()
+                .join(",");
+            let first_model_slot_padding = parsed
+                .model_slots
+                .first()
+                .map(|slot| slot.trailing_zero_padding_bytes.to_string())
+                .unwrap_or_else(|| "unknown".to_owned());
+            let first_model_slot_next_non_zero = parsed
+                .model_slots
+                .first()
+                .and_then(|slot| slot.next_non_zero_offset)
+                .map(|offset| offset.to_string())
+                .unwrap_or_else(|| "unknown".to_owned());
+            let document_models = parsed
+                .document_summary
+                .as_ref()
+                .map(|document| document.counts.models.to_string())
+                .unwrap_or_else(|| "unknown".to_owned());
+            let document_bone_keyframes = parsed
+                .document_summary
+                .as_ref()
+                .map(|document| document.counts.bone_keyframes.to_string())
+                .unwrap_or_else(|| "unknown".to_owned());
+            let document_morph_keyframes = parsed
+                .document_summary
+                .as_ref()
+                .map(|document| document.counts.morph_keyframes.to_string())
+                .unwrap_or_else(|| "unknown".to_owned());
+            let global_camera_keyframes = parsed
+                .document_global_summary
+                .as_ref()
+                .map(|g| (g.camera.initial_keyframes + g.camera.keyframes).to_string())
+                .unwrap_or_else(|| "unknown".to_owned());
+            let global_light_keyframes = parsed
+                .document_global_summary
+                .as_ref()
+                .map(|g| (g.light.initial_keyframes + g.light.keyframes).to_string())
+                .unwrap_or_else(|| "unknown".to_owned());
+            let global_accessory_count = parsed
+                .document_global_summary
+                .as_ref()
+                .map(|g| g.accessories.accessory_count.to_string())
+                .unwrap_or_else(|| "unknown".to_owned());
+            let global_accessory_keyframes = parsed
+                .document_global_summary
+                .as_ref()
+                .map(|g| g.accessories.keyframes.to_string())
+                .unwrap_or_else(|| "unknown".to_owned());
+            let global_gravity_keyframes = parsed
+                .document_global_summary
+                .as_ref()
+                .map(|g| (g.gravity.initial_keyframes + g.gravity.keyframes).to_string())
+                .unwrap_or_else(|| "unknown".to_owned());
+            let global_self_shadow_keyframes = parsed
+                .document_global_summary
+                .as_ref()
+                .map(|g| (g.self_shadow.initial_keyframes + g.self_shadow.keyframes).to_string())
+                .unwrap_or_else(|| "unknown".to_owned());
+            let global_audio_path = parsed
+                .document_global_summary
+                .as_ref()
+                .map(|g| (!g.settings.audio_path.is_empty()).to_string())
+                .unwrap_or_else(|| "unknown".to_owned());
+            let global_bg_video_path = parsed
+                .document_global_summary
+                .as_ref()
+                .map(|g| (!g.settings.background_video_path.is_empty()).to_string())
+                .unwrap_or_else(|| "unknown".to_owned());
+            let global_bg_image_path = parsed
+                .document_global_summary
+                .as_ref()
+                .map(|g| (!g.settings.background_image_path.is_empty()).to_string())
+                .unwrap_or_else(|| "unknown".to_owned());
+            println!(
+                "PMM parser: references={} version={} parsedVersion={} models={} accessories={} motions={} audio={} images={} videos={} modelAssets={} modelSlots={} firstModelSlotPadding={} firstModelSlotNextNonZeroOffset={} documentModels={} documentBoneKeyframes={} documentMorphKeyframes={} headerTextEntries={} audioAssets={} assetConfidence=high:{} medium:{} low:{} assetKindCounts={} assetExtensionCounts={} screen={}x{} timelineFrames={} timelineRange={}..{} frameRate={} durationSeconds={} displayLayout={} selectedModelIndex={} documentModelCount={} declaredModelSlotCount={} modelSlotCount={} nonZeroModelSlotCount={} modelSlotFlags={} activeModelSlotIndices={} emptyModelSlotIndices={} modelSlotFlagCounts={} accessorySlotCount={} globalCameraKeyframes={} globalLightKeyframes={} globalAccessoryCount={} globalAccessoryKeyframes={} globalGravityKeyframes={} globalSelfShadowKeyframes={} globalAudioPath={} globalBgVideoPath={} globalBgImagePath={} diagnostics={}",
+                parsed.asset_summary.reference_count,
+                parsed.version,
+                parsed
+                    .parsed_version
+                    .map(|value| value.to_string())
+                    .unwrap_or_else(|| "unknown".to_owned()),
+                parsed.model_paths.len(),
+                parsed.accessory_paths.len(),
+                parsed.motion_paths.len(),
+                parsed.audio_paths.len(),
+                parsed.image_paths.len(),
+                parsed.video_paths.len(),
+                parsed.model_assets.len(),
+                parsed.model_slots.len(),
+                first_model_slot_padding,
+                first_model_slot_next_non_zero,
+                document_models,
+                document_bone_keyframes,
+                document_morph_keyframes,
+                parsed.header_text_entries.len(),
+                parsed.audio_assets.len(),
+                parsed.asset_summary.high_confidence_count,
+                parsed.asset_summary.medium_confidence_count,
+                parsed.asset_summary.low_confidence_count,
+                asset_kind_counts,
+                asset_extension_counts,
+                parsed
+                    .project_settings
+                    .screen_width
+                    .map(|value| value.to_string())
+                    .unwrap_or_else(|| "unknown".to_owned()),
+                parsed
+                    .project_settings
+                    .screen_height
+                    .map(|value| value.to_string())
+                    .unwrap_or_else(|| "unknown".to_owned()),
+                parsed
+                    .project_settings
+                    .timeline_frame_count
+                    .map(|value| value.to_string())
+                    .unwrap_or_else(|| "unknown".to_owned()),
+                parsed
+                    .timeline
+                    .start_frame
+                    .map(|value| value.to_string())
+                    .unwrap_or_else(|| "unknown".to_owned()),
+                parsed
+                    .timeline
+                    .end_frame_exclusive
+                    .map(|value| value.to_string())
+                    .unwrap_or_else(|| "unknown".to_owned()),
+                parsed
+                    .project_settings
+                    .frame_rate
+                    .map(|value| value.to_string())
+                    .unwrap_or_else(|| "unknown".to_owned()),
+                parsed
+                    .timeline
+                    .duration_seconds
+                    .map(|value| value.to_string())
+                    .unwrap_or_else(|| "unknown".to_owned()),
+                parsed.display_state.layout,
+                parsed
+                    .display_state
+                    .selected_model_index
+                    .map(|value| value.to_string())
+                    .unwrap_or_else(|| "unknown".to_owned()),
+                parsed
+                    .display_state
+                    .document_model_count
+                    .map(|value| value.to_string())
+                    .unwrap_or_else(|| "unknown".to_owned()),
+                parsed
+                    .display_state
+                    .declared_model_slot_count
+                    .map(|value| value.to_string())
+                    .unwrap_or_else(|| "unknown".to_owned()),
+                parsed.display_state.model_slot_count,
+                parsed.display_state.non_zero_model_slot_count,
+                parsed
+                    .display_state
+                    .model_slot_flags
+                    .iter()
+                    .map(|flag| flag.to_string())
+                    .collect::<Vec<_>>()
+                    .join(","),
+                parsed
+                    .display_state
+                    .active_model_slot_indices
+                    .iter()
+                    .map(|index| index.to_string())
+                    .collect::<Vec<_>>()
+                    .join(","),
+                parsed
+                    .display_state
+                    .empty_model_slot_indices
+                    .iter()
+                    .map(|index| index.to_string())
+                    .collect::<Vec<_>>()
+                    .join(","),
+                model_slot_flag_counts,
+                parsed
+                    .display_state
+                    .accessory_slot_count
+                    .map(|value| value.to_string())
+                    .unwrap_or_else(|| "unknown".to_owned()),
+                global_camera_keyframes,
+                global_light_keyframes,
+                global_accessory_count,
+                global_accessory_keyframes,
+                global_gravity_keyframes,
+                global_self_shadow_keyframes,
+                global_audio_path,
+                global_bg_video_path,
+                global_bg_image_path,
+                parsed.diagnostics.len()
+            );
+            Ok(ExitCode::SUCCESS)
+        }
+        mmd_anim_format::MmdFormatKind::X | mmd_anim_format::MmdFormatKind::Vac => {
+            let parsed = mmd_anim_format::parse_accessory_manifest(
+                &data,
+                path.file_name().and_then(|v| v.to_str()),
+            )?;
+            println!(
+                "{} parser: byteLength={} meshes={} materials={} textures={} diagnostics={}",
+                parsed.format.to_uppercase(),
+                parsed.byte_length,
+                parsed.mesh_count,
+                parsed.material_count,
+                parsed.texture_references.len(),
+                parsed.diagnostics.len()
+            );
+            Ok(ExitCode::SUCCESS)
+        }
+        mmd_anim_format::MmdFormatKind::Nmd => {
+            let parsed = mmd_anim_format::parse_nmd_manifest(&data)?;
+            println!(
+                "NMD parser: byteLength={} annotations={} globalTracks={} bundles={{accessory:{}, bone:{}, camera:{}, light:{}, model:{}, morph:{}, selfShadow:{}, unknown:{}}} diagnostics={}",
+                parsed.byte_length,
+                parsed.metadata.annotation_count,
+                parsed.global_track_count,
+                parsed.keyframe_bundles.accessory,
+                parsed.keyframe_bundles.bone,
+                parsed.keyframe_bundles.camera,
+                parsed.keyframe_bundles.light,
+                parsed.keyframe_bundles.model,
+                parsed.keyframe_bundles.morph,
+                parsed.keyframe_bundles.self_shadow,
+                parsed.keyframe_bundles.unknown,
+                parsed.diagnostics.len()
+            );
+            Ok(ExitCode::SUCCESS)
+        }
+        mmd_anim_format::MmdFormatKind::Unknown => Err("unknown MMD format".into()),
+    }
+}
+
+pub(crate) fn parse_format_json(path: &Path) -> Result<ExitCode, Box<dyn std::error::Error>> {
+    let data = fs::read(path)?;
+    let value = match mmd_anim_format::detect_mmd_format(
+        &data,
+        path.file_name().and_then(|v| v.to_str()),
+    ) {
+        mmd_anim_format::MmdFormatKind::Pmx => {
+            serde_json::to_value(mmd_anim_format::parse_pmx_model(&data)?)?
+        }
+        mmd_anim_format::MmdFormatKind::Pmd => {
+            serde_json::to_value(mmd_anim_format::parse_pmd_model(&data)?)?
+        }
+        mmd_anim_format::MmdFormatKind::Vmd => {
+            serde_json::to_value(mmd_anim_format::parse_vmd_animation(&data)?)?
+        }
+        mmd_anim_format::MmdFormatKind::Vpd => {
+            serde_json::to_value(mmd_anim_format::parse_vpd_pose(&data)?)?
+        }
+        mmd_anim_format::MmdFormatKind::Pmm => {
+            serde_json::to_value(mmd_anim_format::parse_pmm_manifest(&data)?)?
+        }
+        mmd_anim_format::MmdFormatKind::X | mmd_anim_format::MmdFormatKind::Vac => {
+            serde_json::to_value(mmd_anim_format::parse_accessory_manifest(
+                &data,
+                path.file_name().and_then(|v| v.to_str()),
+            )?)?
+        }
+        mmd_anim_format::MmdFormatKind::Nmd => {
+            serde_json::to_value(mmd_anim_format::parse_nmd_manifest(&data)?)?
+        }
+        mmd_anim_format::MmdFormatKind::Unknown => return Err("unknown MMD format".into()),
+    };
+    println!("{}", serde_json::to_string_pretty(&value)?);
+    Ok(ExitCode::SUCCESS)
+}

--- a/crates/mmd-anim-cli/src/commands/parse.rs
+++ b/crates/mmd-anim-cli/src/commands/parse.rs
@@ -1,10 +1,12 @@
-use std::{fs, path::Path, process::ExitCode};
+use std::{path::Path, process::ExitCode};
+
+use crate::{diagnostics_suffix, read_file, unsupported_format_error, write_file};
 
 pub(crate) fn parse_pmx_summary(path: &Path) -> Result<ExitCode, Box<dyn std::error::Error>> {
-    let data = fs::read(path)?;
+    let data = read_file(path)?;
     let parsed = mmd_anim_format::parse_pmx_model(&data)?;
     println!(
-        "PMX parser: vertices={} faces={} materials={} bones={} morphs={} displayFrames={} rigidBodies={} joints={} softBodies={} diagnostics={}",
+        "PMX parser: vertices={} faces={} materials={} bones={} morphs={} displayFrames={} rigidBodies={} joints={} softBodies={}{}",
         parsed.metadata.counts.vertices,
         parsed.metadata.counts.faces,
         parsed.metadata.counts.materials,
@@ -14,13 +16,13 @@ pub(crate) fn parse_pmx_summary(path: &Path) -> Result<ExitCode, Box<dyn std::er
         parsed.metadata.counts.rigid_bodies,
         parsed.metadata.counts.joints,
         parsed.metadata.counts.soft_bodies,
-        parsed.diagnostics.len()
+        diagnostics_suffix(parsed.diagnostics.len())
     );
     Ok(ExitCode::SUCCESS)
 }
 
 pub(crate) fn parse_format_summary(path: &Path) -> Result<ExitCode, Box<dyn std::error::Error>> {
-    let data = fs::read(path)?;
+    let data = read_file(path)?;
     match mmd_anim_format::detect_mmd_format(&data, path.file_name().and_then(|v| v.to_str())) {
         mmd_anim_format::MmdFormatKind::Pmx => parse_pmx_summary(path),
         mmd_anim_format::MmdFormatKind::Pmd => {
@@ -56,9 +58,9 @@ pub(crate) fn parse_format_summary(path: &Path) -> Result<ExitCode, Box<dyn std:
         mmd_anim_format::MmdFormatKind::Vpd => {
             let parsed = mmd_anim_format::parse_vpd_pose(&data)?;
             println!(
-                "VPD parser: bones={} diagnostics={}",
+                "VPD parser: bones={}{}",
                 parsed.bone_count,
-                parsed.diagnostics.len()
+                diagnostics_suffix(parsed.diagnostics.len())
             );
             Ok(ExitCode::SUCCESS)
         }
@@ -157,7 +159,7 @@ pub(crate) fn parse_format_summary(path: &Path) -> Result<ExitCode, Box<dyn std:
                 .map(|g| (!g.settings.background_image_path.is_empty()).to_string())
                 .unwrap_or_else(|| "unknown".to_owned());
             println!(
-                "PMM parser: references={} version={} parsedVersion={} models={} accessories={} motions={} audio={} images={} videos={} modelAssets={} modelSlots={} firstModelSlotPadding={} firstModelSlotNextNonZeroOffset={} documentModels={} documentBoneKeyframes={} documentMorphKeyframes={} headerTextEntries={} audioAssets={} assetConfidence=high:{} medium:{} low:{} assetKindCounts={} assetExtensionCounts={} screen={}x{} timelineFrames={} timelineRange={}..{} frameRate={} durationSeconds={} displayLayout={} selectedModelIndex={} documentModelCount={} declaredModelSlotCount={} modelSlotCount={} nonZeroModelSlotCount={} modelSlotFlags={} activeModelSlotIndices={} emptyModelSlotIndices={} modelSlotFlagCounts={} accessorySlotCount={} globalCameraKeyframes={} globalLightKeyframes={} globalAccessoryCount={} globalAccessoryKeyframes={} globalGravityKeyframes={} globalSelfShadowKeyframes={} globalAudioPath={} globalBgVideoPath={} globalBgImagePath={} diagnostics={}",
+                "PMM parser: references={} version={} parsedVersion={} models={} accessories={} motions={} audio={} images={} videos={} modelAssets={} modelSlots={} firstModelSlotPadding={} firstModelSlotNextNonZeroOffset={} documentModels={} documentBoneKeyframes={} documentMorphKeyframes={} headerTextEntries={} audioAssets={} assetConfidence=high:{} medium:{} low:{} assetKindCounts={} assetExtensionCounts={} screen={}x{} timelineFrames={} timelineRange={}..{} frameRate={} durationSeconds={} displayLayout={} selectedModelIndex={} documentModelCount={} declaredModelSlotCount={} modelSlotCount={} nonZeroModelSlotCount={} modelSlotFlags={} activeModelSlotIndices={} emptyModelSlotIndices={} modelSlotFlagCounts={} accessorySlotCount={} globalCameraKeyframes={} globalLightKeyframes={} globalAccessoryCount={} globalAccessoryKeyframes={} globalGravityKeyframes={} globalSelfShadowKeyframes={} globalAudioPath={} globalBgVideoPath={} globalBgImagePath={}{}",
                 parsed.asset_summary.reference_count,
                 parsed.version,
                 parsed
@@ -273,7 +275,7 @@ pub(crate) fn parse_format_summary(path: &Path) -> Result<ExitCode, Box<dyn std:
                 global_audio_path,
                 global_bg_video_path,
                 global_bg_image_path,
-                parsed.diagnostics.len()
+                diagnostics_suffix(parsed.diagnostics.len())
             );
             Ok(ExitCode::SUCCESS)
         }
@@ -283,20 +285,20 @@ pub(crate) fn parse_format_summary(path: &Path) -> Result<ExitCode, Box<dyn std:
                 path.file_name().and_then(|v| v.to_str()),
             )?;
             println!(
-                "{} parser: byteLength={} meshes={} materials={} textures={} diagnostics={}",
+                "{} parser: byteLength={} meshes={} materials={} textures={}{}",
                 parsed.format.to_uppercase(),
                 parsed.byte_length,
                 parsed.mesh_count,
                 parsed.material_count,
                 parsed.texture_references.len(),
-                parsed.diagnostics.len()
+                diagnostics_suffix(parsed.diagnostics.len())
             );
             Ok(ExitCode::SUCCESS)
         }
         mmd_anim_format::MmdFormatKind::Nmd => {
             let parsed = mmd_anim_format::parse_nmd_manifest(&data)?;
             println!(
-                "NMD parser: byteLength={} annotations={} globalTracks={} bundles={{accessory:{}, bone:{}, camera:{}, light:{}, model:{}, morph:{}, selfShadow:{}, unknown:{}}} diagnostics={}",
+                "NMD parser: byteLength={} annotations={} globalTracks={} bundles={{accessory:{}, bone:{}, camera:{}, light:{}, model:{}, morph:{}, selfShadow:{}, unknown:{}}}{}",
                 parsed.byte_length,
                 parsed.metadata.annotation_count,
                 parsed.global_track_count,
@@ -308,16 +310,36 @@ pub(crate) fn parse_format_summary(path: &Path) -> Result<ExitCode, Box<dyn std:
                 parsed.keyframe_bundles.morph,
                 parsed.keyframe_bundles.self_shadow,
                 parsed.keyframe_bundles.unknown,
-                parsed.diagnostics.len()
+                diagnostics_suffix(parsed.diagnostics.len())
             );
             Ok(ExitCode::SUCCESS)
         }
-        mmd_anim_format::MmdFormatKind::Unknown => Err("unknown MMD format".into()),
+        mmd_anim_format::MmdFormatKind::Unknown => Err(unsupported_format_error(path)),
     }
 }
 
 pub(crate) fn parse_format_json(path: &Path) -> Result<ExitCode, Box<dyn std::error::Error>> {
-    let data = fs::read(path)?;
+    let text = parse_format_json_text(path)?;
+    println!("{text}");
+    Ok(ExitCode::SUCCESS)
+}
+
+pub(crate) fn parse_format_json_to_file(
+    path: &Path,
+    output: &Path,
+) -> Result<ExitCode, Box<dyn std::error::Error>> {
+    let text = parse_format_json_text(path)?;
+    write_file(output, text.as_bytes())?;
+    Ok(ExitCode::SUCCESS)
+}
+
+pub(crate) fn parse_format_json_text(path: &Path) -> Result<String, Box<dyn std::error::Error>> {
+    let value = parse_format_json_value(path)?;
+    Ok(serde_json::to_string_pretty(&value)?)
+}
+
+fn parse_format_json_value(path: &Path) -> Result<serde_json::Value, Box<dyn std::error::Error>> {
+    let data = read_file(path)?;
     let value = match mmd_anim_format::detect_mmd_format(
         &data,
         path.file_name().and_then(|v| v.to_str()),
@@ -346,8 +368,7 @@ pub(crate) fn parse_format_json(path: &Path) -> Result<ExitCode, Box<dyn std::er
         mmd_anim_format::MmdFormatKind::Nmd => {
             serde_json::to_value(mmd_anim_format::parse_nmd_manifest(&data)?)?
         }
-        mmd_anim_format::MmdFormatKind::Unknown => return Err("unknown MMD format".into()),
+        mmd_anim_format::MmdFormatKind::Unknown => return Err(unsupported_format_error(path)),
     };
-    println!("{}", serde_json::to_string_pretty(&value)?);
-    Ok(ExitCode::SUCCESS)
+    Ok(value)
 }

--- a/crates/mmd-anim-cli/src/commands/patch.rs
+++ b/crates/mmd-anim-cli/src/commands/patch.rs
@@ -1,4 +1,6 @@
-use std::{fs, path::Path, process::ExitCode};
+use std::{path::Path, process::ExitCode};
+
+use crate::{read_file, write_file};
 
 pub(crate) const PATCH_PMM_SCENE_FRAME_RANGE_USAGE: &str = "usage: mmd-anim patch-pmm-scene-frame-range <input.pmm> <output.pmm> [--current-frame <i32>] [--current-frame-text <i32>] [--begin-frame <i32>] [--end-frame <i32>] [--begin-frame-enabled <bool>] [--end-frame-enabled <bool>]";
 
@@ -121,7 +123,7 @@ pub(crate) fn patch_pmm_scene_frame_range(
     option_args: &[String],
 ) -> Result<ExitCode, Box<dyn std::error::Error>> {
     let patch = parse_pmm_scene_frame_range_patch_options(option_args)?;
-    let data = fs::read(input)?;
+    let data = read_file(input)?;
     let bytes_in = data.len();
     let parsed = mmd_anim_format::parse_pmm_manifest(&data)?;
     let exported =
@@ -129,7 +131,7 @@ pub(crate) fn patch_pmm_scene_frame_range(
             .map_err(|e| format!("PMM scene frame range patch failed: {e}"))?;
     let bytes_out = exported.len();
     let changed_fields = count_pmm_scene_frame_range_patch_fields(&patch);
-    fs::write(output, &exported)?;
+    write_file(output, &exported)?;
     println!(
         "PMM scene frame range patch: ok bytesIn={} bytesOut={} changedFields={} output={}",
         bytes_in,
@@ -146,7 +148,7 @@ pub(crate) fn patch_pmm_document_model_path(
     model_path: &str,
     output: &Path,
 ) -> Result<ExitCode, Box<dyn std::error::Error>> {
-    let data = fs::read(input)?;
+    let data = read_file(input)?;
     let bytes_in = data.len();
     let parsed = mmd_anim_format::parse_pmm_manifest(&data)?;
     let index: u8 = document_model_index.parse().map_err(|_| {
@@ -161,7 +163,7 @@ pub(crate) fn patch_pmm_document_model_path(
     )
     .map_err(|e| format!("PMM document model path patch failed: {e}"))?;
     let bytes_out = exported.len();
-    fs::write(output, &exported)?;
+    write_file(output, &exported)?;
     println!(
         "PMM document model path patch: ok bytesIn={} bytesOut={} documentModelIndex={} output={}",
         bytes_in,

--- a/crates/mmd-anim-cli/src/commands/patch.rs
+++ b/crates/mmd-anim-cli/src/commands/patch.rs
@@ -1,0 +1,173 @@
+use std::{fs, path::Path, process::ExitCode};
+
+pub(crate) const PATCH_PMM_SCENE_FRAME_RANGE_USAGE: &str = "usage: mmd-anim patch-pmm-scene-frame-range <input.pmm> <output.pmm> [--current-frame <i32>] [--current-frame-text <i32>] [--begin-frame <i32>] [--end-frame <i32>] [--begin-frame-enabled <bool>] [--end-frame-enabled <bool>]";
+
+fn parse_bool_option(value: &str, label: &str) -> Result<bool, String> {
+    if value.eq_ignore_ascii_case("true")
+        || value == "1"
+        || value.eq_ignore_ascii_case("yes")
+        || value.eq_ignore_ascii_case("on")
+    {
+        Ok(true)
+    } else if value.eq_ignore_ascii_case("false")
+        || value == "0"
+        || value.eq_ignore_ascii_case("no")
+        || value.eq_ignore_ascii_case("off")
+    {
+        Ok(false)
+    } else {
+        Err(format!(
+            "invalid {label}: {value} (expected true/false, 1/0, yes/no, or on/off)"
+        ))
+    }
+}
+
+pub(crate) fn parse_pmm_scene_frame_range_patch_options(
+    option_args: &[String],
+) -> Result<mmd_anim_format::pmm::PmmSceneFrameRangePatch, String> {
+    let mut patch = mmd_anim_format::pmm::PmmSceneFrameRangePatch::default();
+    let mut iter = option_args.iter();
+    while let Some(arg) = iter.next() {
+        let value = iter.next().ok_or_else(|| {
+            format!("missing value for option {arg}; {PATCH_PMM_SCENE_FRAME_RANGE_USAGE}")
+        })?;
+        match arg.as_str() {
+            "--current-frame" => {
+                patch.current_frame_index = Some(value.parse().map_err(|_| {
+                    format!("invalid --current-frame value: {value} (expected i32)")
+                })?);
+            }
+            "--current-frame-text" => {
+                patch.current_frame_index_in_text_field = Some(value.parse().map_err(|_| {
+                    format!("invalid --current-frame-text value: {value} (expected i32)")
+                })?);
+            }
+            "--begin-frame" => {
+                patch.begin_frame_index =
+                    Some(value.parse().map_err(|_| {
+                        format!("invalid --begin-frame value: {value} (expected i32)")
+                    })?);
+            }
+            "--end-frame" => {
+                patch.end_frame_index =
+                    Some(value.parse().map_err(|_| {
+                        format!("invalid --end-frame value: {value} (expected i32)")
+                    })?);
+            }
+            "--begin-frame-enabled" => {
+                patch.begin_frame_index_enabled =
+                    Some(parse_bool_option(value, "--begin-frame-enabled")?);
+            }
+            "--end-frame-enabled" => {
+                patch.end_frame_index_enabled =
+                    Some(parse_bool_option(value, "--end-frame-enabled")?);
+            }
+            other if other.starts_with("--") => {
+                return Err(format!(
+                    "unknown option {other}; {PATCH_PMM_SCENE_FRAME_RANGE_USAGE}"
+                ));
+            }
+            other => {
+                return Err(format!(
+                    "unexpected positional argument {other:?}; {PATCH_PMM_SCENE_FRAME_RANGE_USAGE}"
+                ));
+            }
+        }
+    }
+
+    if patch.current_frame_index.is_none()
+        && patch.current_frame_index_in_text_field.is_none()
+        && patch.begin_frame_index.is_none()
+        && patch.end_frame_index.is_none()
+        && patch.begin_frame_index_enabled.is_none()
+        && patch.end_frame_index_enabled.is_none()
+    {
+        return Err(format!(
+            "at least one patch option is required; {PATCH_PMM_SCENE_FRAME_RANGE_USAGE}"
+        ));
+    }
+
+    Ok(patch)
+}
+
+pub(crate) fn count_pmm_scene_frame_range_patch_fields(
+    patch: &mmd_anim_format::pmm::PmmSceneFrameRangePatch,
+) -> usize {
+    let mut count = 0usize;
+    if patch.current_frame_index.is_some() {
+        count += 1;
+    }
+    if patch.current_frame_index_in_text_field.is_some() {
+        count += 1;
+    }
+    if patch.begin_frame_index.is_some() {
+        count += 1;
+    }
+    if patch.end_frame_index.is_some() {
+        count += 1;
+    }
+    if patch.begin_frame_index_enabled.is_some() {
+        count += 1;
+    }
+    if patch.end_frame_index_enabled.is_some() {
+        count += 1;
+    }
+    count
+}
+
+pub(crate) fn patch_pmm_scene_frame_range(
+    input: &Path,
+    output: &Path,
+    option_args: &[String],
+) -> Result<ExitCode, Box<dyn std::error::Error>> {
+    let patch = parse_pmm_scene_frame_range_patch_options(option_args)?;
+    let data = fs::read(input)?;
+    let bytes_in = data.len();
+    let parsed = mmd_anim_format::parse_pmm_manifest(&data)?;
+    let exported =
+        mmd_anim_format::pmm::export_pmm_manifest_with_scene_frame_range_patch(&parsed, &patch)
+            .map_err(|e| format!("PMM scene frame range patch failed: {e}"))?;
+    let bytes_out = exported.len();
+    let changed_fields = count_pmm_scene_frame_range_patch_fields(&patch);
+    fs::write(output, &exported)?;
+    println!(
+        "PMM scene frame range patch: ok bytesIn={} bytesOut={} changedFields={} output={}",
+        bytes_in,
+        bytes_out,
+        changed_fields,
+        output.display()
+    );
+    Ok(ExitCode::SUCCESS)
+}
+
+pub(crate) fn patch_pmm_document_model_path(
+    input: &Path,
+    document_model_index: &str,
+    model_path: &str,
+    output: &Path,
+) -> Result<ExitCode, Box<dyn std::error::Error>> {
+    let data = fs::read(input)?;
+    let bytes_in = data.len();
+    let parsed = mmd_anim_format::parse_pmm_manifest(&data)?;
+    let index: u8 = document_model_index.parse().map_err(|_| {
+        format!(
+            "invalid document-model-index {:?}: expected u8 (0-255)",
+            document_model_index
+        )
+    })?;
+    let exported = mmd_anim_format::pmm::export_pmm_manifest_with_document_model_path_overrides(
+        &parsed,
+        &[(index, model_path)],
+    )
+    .map_err(|e| format!("PMM document model path patch failed: {e}"))?;
+    let bytes_out = exported.len();
+    fs::write(output, &exported)?;
+    println!(
+        "PMM document model path patch: ok bytesIn={} bytesOut={} documentModelIndex={} output={}",
+        bytes_in,
+        bytes_out,
+        index,
+        output.display()
+    );
+    Ok(ExitCode::SUCCESS)
+}

--- a/crates/mmd-anim-cli/src/commands/rig.rs
+++ b/crates/mmd-anim-cli/src/commands/rig.rs
@@ -5,9 +5,15 @@ pub(crate) fn rig_inspect(
     use_json: bool,
     show_bones: bool,
 ) -> Result<ExitCode, Box<dyn std::error::Error>> {
-    let data = fs::read(pmx_path)
-        .map_err(|e| format!("failed to read {}: {}", pmx_path.display(), e))?;
-    let parsed = mmd_anim_format::parse_pmx_model(&data)?;
+    let data =
+        fs::read(pmx_path).map_err(|e| format!("failed to read {}: {}", pmx_path.display(), e))?;
+    let parsed = mmd_anim_format::parse_pmx_model(&data).map_err(|e| {
+        format!(
+            "rig-inspect requires a PMX model file: {}: {}",
+            pmx_path.display(),
+            e
+        )
+    })?;
     let bones = &parsed.skeleton.bones;
     let bone_count = bones.len();
 
@@ -183,7 +189,7 @@ fn print_human(
     show_bones: bool,
 ) {
     println!(
-        "rig-inspect: model={} bones={} ikChains={} grants={}",
+        "rig-inspect: model={} bones={} ikChains={} grantCount={}",
         parsed.metadata.name,
         bone_count,
         ik_bones.len(),
@@ -206,7 +212,7 @@ fn print_human(
                 .map(|b| b.name.as_str())
                 .unwrap_or("<unknown>");
             println!(
-                "  [{idx}] {} -> target={} links={} iterations={} limitAngle={:.6}",
+                "  [{idx}] {} -> target={} links={} loopCount={} limitAngle={}",
                 bone.name,
                 target_name,
                 ik.links.len(),
@@ -255,7 +261,7 @@ fn print_human(
         println!("\nbones ({bone_count}):");
         for (idx, bone) in bones.iter().enumerate() {
             let parent_str = if bone.parent_index < 0 {
-                "root".to_owned()
+                "-1".to_owned()
             } else {
                 format!("{}", bone.parent_index)
             };
@@ -303,6 +309,9 @@ mod tests {
         let result = rig_inspect(Path::new("nonexistent.pmx"), false, false);
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
-        assert!(err.contains("nonexistent.pmx"), "error should contain path: {err}");
+        assert!(
+            err.contains("nonexistent.pmx"),
+            "error should contain path: {err}"
+        );
     }
 }

--- a/crates/mmd-anim-cli/src/commands/rig.rs
+++ b/crates/mmd-anim-cli/src/commands/rig.rs
@@ -1,0 +1,308 @@
+use std::{collections::BTreeMap, fs, path::Path, process::ExitCode};
+
+pub(crate) fn rig_inspect(
+    pmx_path: &Path,
+    use_json: bool,
+    show_bones: bool,
+) -> Result<ExitCode, Box<dyn std::error::Error>> {
+    let data = fs::read(pmx_path)
+        .map_err(|e| format!("failed to read {}: {}", pmx_path.display(), e))?;
+    let parsed = mmd_anim_format::parse_pmx_model(&data)?;
+    let bones = &parsed.skeleton.bones;
+    let bone_count = bones.len();
+
+    let ik_bones: Vec<(usize, &mmd_anim_format::pmx::PmxParsedBone)> = bones
+        .iter()
+        .enumerate()
+        .filter(|(_, b)| b.ik.is_some())
+        .collect();
+
+    let grant_bones: Vec<(usize, &mmd_anim_format::pmx::PmxParsedBone)> = bones
+        .iter()
+        .enumerate()
+        .filter(|(_, b)| b.append_transform.is_some())
+        .collect();
+
+    let mut layer_distribution = BTreeMap::<i32, usize>::new();
+    for bone in bones {
+        *layer_distribution.entry(bone.layer).or_default() += 1;
+    }
+
+    if use_json {
+        print_json(
+            &parsed,
+            bones,
+            &ik_bones,
+            &grant_bones,
+            &layer_distribution,
+            show_bones,
+        )?;
+    } else {
+        print_human(
+            &parsed,
+            bones,
+            bone_count,
+            &ik_bones,
+            &grant_bones,
+            &layer_distribution,
+            show_bones,
+        );
+    }
+
+    Ok(ExitCode::SUCCESS)
+}
+
+fn print_json(
+    parsed: &mmd_anim_format::pmx::PmxParsedModel,
+    bones: &[mmd_anim_format::pmx::PmxParsedBone],
+    ik_bones: &[(usize, &mmd_anim_format::pmx::PmxParsedBone)],
+    grant_bones: &[(usize, &mmd_anim_format::pmx::PmxParsedBone)],
+    layer_distribution: &BTreeMap<i32, usize>,
+    show_bones: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let ik_chains: Vec<serde_json::Value> = ik_bones
+        .iter()
+        .map(|(idx, bone)| {
+            let ik = bone.ik.as_ref().unwrap();
+            let links: Vec<serde_json::Value> = ik
+                .links
+                .iter()
+                .map(|link| {
+                    let link_name = bones
+                        .get(link.bone_index as usize)
+                        .map(|b| b.name.as_str())
+                        .unwrap_or("<unknown>");
+                    let mut obj = serde_json::json!({
+                        "boneIndex": link.bone_index,
+                        "boneName": link_name,
+                    });
+                    if let Some(limits) = &link.limits {
+                        obj["limits"] = serde_json::json!({
+                            "lower": limits.lower,
+                            "upper": limits.upper,
+                        });
+                    }
+                    obj
+                })
+                .collect();
+            let target_name = bones
+                .get(ik.target_index as usize)
+                .map(|b| b.name.as_str())
+                .unwrap_or("<unknown>");
+            serde_json::json!({
+                "boneIndex": idx,
+                "boneName": bone.name,
+                "targetIndex": ik.target_index,
+                "targetName": target_name,
+                "loopCount": ik.loop_count,
+                "limitAngle": ik.limit_angle,
+                "linkCount": ik.links.len(),
+                "links": links,
+            })
+        })
+        .collect();
+
+    let grants: Vec<serde_json::Value> = grant_bones
+        .iter()
+        .map(|(idx, bone)| {
+            let append = bone.append_transform.as_ref().unwrap();
+            let source_name = bones
+                .get(append.parent_index as usize)
+                .map(|b| b.name.as_str())
+                .unwrap_or("<unknown>");
+            serde_json::json!({
+                "boneIndex": idx,
+                "boneName": bone.name,
+                "sourceIndex": append.parent_index,
+                "sourceName": source_name,
+                "weight": append.weight,
+                "affectRotation": bone.flags.append_rotate,
+                "affectTranslation": bone.flags.append_translate,
+                "local": bone.flags.append_local,
+            })
+        })
+        .collect();
+
+    let layers: serde_json::Value = layer_distribution
+        .iter()
+        .map(|(layer, count)| (layer.to_string(), serde_json::json!(count)))
+        .collect::<serde_json::Map<String, serde_json::Value>>()
+        .into();
+
+    let mut root = serde_json::json!({
+        "modelName": parsed.metadata.name,
+        "boneCount": bones.len(),
+        "ikChainCount": ik_bones.len(),
+        "grantCount": grant_bones.len(),
+        "ikChains": ik_chains,
+        "grants": grants,
+        "deformLayers": layers,
+    });
+
+    if show_bones {
+        let bone_list: Vec<serde_json::Value> = bones
+            .iter()
+            .enumerate()
+            .map(|(idx, bone)| {
+                serde_json::json!({
+                    "index": idx,
+                    "name": bone.name,
+                    "englishName": bone.english_name,
+                    "parentIndex": bone.parent_index,
+                    "layer": bone.layer,
+                    "position": bone.position,
+                    "flags": {
+                        "rotatable": bone.flags.rotatable,
+                        "translatable": bone.flags.translatable,
+                        "visible": bone.flags.visible,
+                        "enabled": bone.flags.enabled,
+                        "ik": bone.flags.ik,
+                        "appendRotate": bone.flags.append_rotate,
+                        "appendTranslate": bone.flags.append_translate,
+                        "fixedAxis": bone.flags.fixed_axis,
+                        "localAxis": bone.flags.local_axis,
+                        "transformAfterPhysics": bone.flags.transform_after_physics,
+                    },
+                })
+            })
+            .collect();
+        root["bones"] = serde_json::json!(bone_list);
+    }
+
+    println!("{}", serde_json::to_string_pretty(&root)?);
+    Ok(())
+}
+
+fn print_human(
+    parsed: &mmd_anim_format::pmx::PmxParsedModel,
+    bones: &[mmd_anim_format::pmx::PmxParsedBone],
+    bone_count: usize,
+    ik_bones: &[(usize, &mmd_anim_format::pmx::PmxParsedBone)],
+    grant_bones: &[(usize, &mmd_anim_format::pmx::PmxParsedBone)],
+    layer_distribution: &BTreeMap<i32, usize>,
+    show_bones: bool,
+) {
+    println!(
+        "rig-inspect: model={} bones={} ikChains={} grants={}",
+        parsed.metadata.name,
+        bone_count,
+        ik_bones.len(),
+        grant_bones.len(),
+    );
+
+    let layer_str = layer_distribution
+        .iter()
+        .map(|(layer, count)| format!("{layer}:{count}"))
+        .collect::<Vec<_>>()
+        .join(",");
+    println!("deform layers: {layer_str}");
+
+    if !ik_bones.is_empty() {
+        println!("\nIK chains ({}):", ik_bones.len());
+        for (idx, bone) in ik_bones {
+            let ik = bone.ik.as_ref().unwrap();
+            let target_name = bones
+                .get(ik.target_index as usize)
+                .map(|b| b.name.as_str())
+                .unwrap_or("<unknown>");
+            println!(
+                "  [{idx}] {} -> target={} links={} iterations={} limitAngle={:.6}",
+                bone.name,
+                target_name,
+                ik.links.len(),
+                ik.loop_count,
+                ik.limit_angle,
+            );
+        }
+    }
+
+    if !grant_bones.is_empty() {
+        println!("\ngrants ({}):", grant_bones.len());
+        for (idx, bone) in grant_bones {
+            let append = bone.append_transform.as_ref().unwrap();
+            let source_name = bones
+                .get(append.parent_index as usize)
+                .map(|b| b.name.as_str())
+                .unwrap_or("<unknown>");
+            let mut affects = Vec::new();
+            if bone.flags.append_rotate {
+                affects.push("rotation");
+            }
+            if bone.flags.append_translate {
+                affects.push("translation");
+            }
+            let affects_str = if affects.is_empty() {
+                "none".to_owned()
+            } else {
+                affects.join("+")
+            };
+            println!(
+                "  [{idx}] {} <- source={} weight={:.4} affects={}{}",
+                bone.name,
+                source_name,
+                append.weight,
+                affects_str,
+                if bone.flags.append_local {
+                    " (local)"
+                } else {
+                    ""
+                },
+            );
+        }
+    }
+
+    if show_bones {
+        println!("\nbones ({bone_count}):");
+        for (idx, bone) in bones.iter().enumerate() {
+            let parent_str = if bone.parent_index < 0 {
+                "root".to_owned()
+            } else {
+                format!("{}", bone.parent_index)
+            };
+            let mut flags = Vec::new();
+            if bone.flags.ik {
+                flags.push("IK");
+            }
+            if bone.flags.append_rotate || bone.flags.append_translate {
+                flags.push("grant");
+            }
+            if bone.flags.fixed_axis {
+                flags.push("fixedAxis");
+            }
+            if bone.flags.transform_after_physics {
+                flags.push("afterPhysics");
+            }
+            if !bone.flags.visible {
+                flags.push("hidden");
+            }
+            let flags_str = if flags.is_empty() {
+                String::new()
+            } else {
+                format!(" [{}]", flags.join(","))
+            };
+            println!(
+                "  [{idx}] {} parent={} layer={} pos=({:.4},{:.4},{:.4}){}",
+                bone.name,
+                parent_str,
+                bone.layer,
+                bone.position[0],
+                bone.position[1],
+                bone.position[2],
+                flags_str,
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rig_inspect_returns_error_for_missing_file() {
+        let result = rig_inspect(Path::new("nonexistent.pmx"), false, false);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("nonexistent.pmx"), "error should contain path: {err}");
+    }
+}

--- a/crates/mmd-anim-cli/src/main.rs
+++ b/crates/mmd-anim-cli/src/main.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::HashSet,
-    fs, io,
+    fs,
+    io::{self, Read},
     path::{Path, PathBuf},
     process::ExitCode,
 };
@@ -186,7 +187,7 @@ enum Commands {
 
     /// Export an asset to another binary file.
     #[command(
-        long_about = "Write an MMD asset to an output path, optionally starting from JSON.\nWith --from-json, the input must be UTF-8 JSON text and the output extension selects the binary format.\nUse this for parser/exporter smoke checks and JSON-to-binary conversion.\n\nSupported formats: .pmx, .pmd, .vmd",
+        long_about = "Write an MMD asset to an output path, optionally starting from JSON.\nWith --from-json, the input must be UTF-8 JSON text and the output extension selects the binary format.\nThe JSON shape is the raw parsed DTO emitted by `mmd-anim inspect <asset> --json`, for example PmxParsedModel for .pmx, PmdParsedModel for .pmd, or VmdParsedAnimation for .vmd.\nUse this for parser/exporter smoke checks and JSON-to-binary conversion.\n\nSupported formats: .pmx, .pmd, .vmd",
         after_help = "Examples:\n  mmd-anim export input.vmd output.vmd\n  mmd-anim export input.json output.vmd --from-json"
     )]
     Export {
@@ -337,7 +338,7 @@ fn dispatch_inspect(
         return usage_error("inspect --json and --ik cannot be combined");
     }
     if show_ik {
-        if !has_extension(asset, "pmx") {
+        if detect_path_format(asset)? != mmd_anim_format::MmdFormatKind::Pmx {
             return usage_error("inspect --ik requires a PMX model file");
         }
         return commands::import::import_pmx_ik_summary(asset);
@@ -348,7 +349,7 @@ fn dispatch_inspect(
         }
         return commands::parse::parse_format_json(asset);
     }
-    if has_extension(asset, "pmx") {
+    if detect_path_format(asset)? == mmd_anim_format::MmdFormatKind::Pmx {
         commands::parse::parse_pmx_summary(asset)
     } else {
         commands::parse::parse_format_summary(asset)
@@ -382,17 +383,14 @@ fn dispatch_import(
     if show_clip || frame.is_some() {
         return usage_error("import --clip and --frame require a motion argument");
     }
-    if has_extension(model, "pmx") {
-        commands::import::import_pmx_summary(model)
-    } else if has_extension(model, "pmd") {
-        commands::import::import_pmd_summary(model)
-    } else if has_extension(model, "vmd") {
-        commands::import::import_vmd_summary(model)
-    } else {
-        usage_error(format!(
+    match detect_path_format(model)? {
+        mmd_anim_format::MmdFormatKind::Pmx => commands::import::import_pmx_summary(model),
+        mmd_anim_format::MmdFormatKind::Pmd => commands::import::import_pmd_summary(model),
+        mmd_anim_format::MmdFormatKind::Vmd => commands::import::import_vmd_summary(model),
+        _ => usage_error(format!(
             "unsupported or unrecognized file format: {}; import requires a PMX, PMD, or VMD input when no motion is provided",
             model.display()
-        ))
+        )),
     }
 }
 
@@ -691,10 +689,30 @@ fn dispatch_export(
     }
 }
 
-fn has_extension(path: &Path, expected: &str) -> bool {
-    path.extension()
-        .and_then(|ext| ext.to_str())
-        .is_some_and(|ext| ext.eq_ignore_ascii_case(expected))
+const FORMAT_SNIFF_BYTES: usize = 64;
+
+fn detect_path_format(
+    path: &Path,
+) -> Result<mmd_anim_format::MmdFormatKind, Box<dyn std::error::Error>> {
+    let mut file = fs::File::open(path).map_err(|error| {
+        format!(
+            "failed to read {}: {}",
+            path.display(),
+            io_error_label(error.kind())
+        )
+    })?;
+    let mut data = [0u8; FORMAT_SNIFF_BYTES];
+    let len = file.read(&mut data).map_err(|error| {
+        format!(
+            "failed to read {}: {}",
+            path.display(),
+            io_error_label(error.kind())
+        )
+    })?;
+    Ok(mmd_anim_format::detect_mmd_format(
+        &data[..len],
+        path.file_name().and_then(|v| v.to_str()),
+    ))
 }
 
 fn usage_error(message: impl AsRef<str>) -> Result<ExitCode, Box<dyn std::error::Error>> {

--- a/crates/mmd-anim-cli/src/main.rs
+++ b/crates/mmd-anim-cli/src/main.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::HashSet,
+    fs, io,
     path::{Path, PathBuf},
     process::ExitCode,
 };
@@ -17,6 +18,7 @@ mod commands;
     name = "mmd-anim",
     version,
     about = "CLI diagnostics and roundtrip tools for mmd-anim\n\nExit codes: 0 = success, 1 = runtime error, 2 = usage error",
+    after_help = "Quick start:\n  mmd-anim inspect model.pmx              Show model summary\n  mmd-anim import model.pmx motion.vmd    Import and inspect pair\n  mmd-anim roundtrip model.pmx            Verify parse-export stability",
     arg_required_else_help = true
 )]
 struct Cli {
@@ -40,12 +42,15 @@ enum Commands {
         /// Show PMX IK solver details
         #[arg(long)]
         ik: bool,
+        /// Write inspect output to a file instead of stdout
+        #[arg(long, value_name = "FILE")]
+        output: Option<PathBuf>,
     },
 
     /// Import model and optional motion into runtime structures.
     #[command(
         long_about = "Run the runtime importer for a model, or a model/motion pair.\nUse this when checking runtime names, clip build stats, or a single evaluated frame.",
-        after_help = "Examples:\n  mmd-anim import model.pmx\n  mmd-anim import model.pmx motion.vmd --clip\n  mmd-anim import model.pmx motion.vmd --frame 120"
+        after_help = "Examples:\n  mmd-anim import model.pmx\n  mmd-anim import model.pmx motion.vmd --clip\n  mmd-anim import model.pmx motion.vmd --frame 120\n    (unit: MMD coordinate)"
     )]
     Import {
         /// Path to the PMX/PMD model file
@@ -65,7 +70,7 @@ enum Commands {
 
     /// Verify parse/export/re-parse stability.
     #[command(
-        long_about = "Parse an asset, export it, then re-parse the exported bytes.\nUse this before changing readers, writers, or JSON DTO conversion paths.",
+        long_about = "Parse an asset, export it, then re-parse the exported bytes.\nUse this before changing readers, writers, or JSON DTO conversion paths.\nJSON reports use jsonBytes for the JSON serialized byte count when --via-json is set.",
         after_help = "Examples:\n  mmd-anim roundtrip model.pmx\n  mmd-anim roundtrip motion.vmd --json\n  mmd-anim roundtrip model.pmx --via-json"
     )]
     Roundtrip {
@@ -97,8 +102,8 @@ enum Commands {
 
     /// Benchmark runtime evaluation.
     #[command(
-        long_about = "Benchmark a PMX/VMD pair by default, or synthetic runtime data with --synthetic.\nUse this for local performance checks around import, clip build, and evaluation.",
-        after_help = "Examples:\n  mmd-anim bench model.pmx motion.vmd\n  mmd-anim bench --synthetic"
+        long_about = "Benchmark a PMX/VMD pair by default, or synthetic runtime data with --synthetic.\nUse this for local performance checks around import, clip build, and evaluation.\nPair mode positional arguments: <model.pmx> <motion.vmd> [start-frame] [frame-count] [step]. Pair flags: --no-ik, --ik-tolerance <value>, --ik-max-iterations-cap <count>.\nSynthetic mode arguments: [models] [bones] [frames] [--json]. Defaults are models=1, bones=32, frames=1000.",
+        after_help = "Examples:\n  mmd-anim bench model.pmx motion.vmd\n  mmd-anim bench model.pmx motion.vmd 0 240 1 --no-ik\n  mmd-anim bench --synthetic\n  mmd-anim bench --synthetic 4 64 2000\n  mmd-anim bench --synthetic 4 64 2000 --json"
     )]
     Bench {
         /// Path to the PMX model file
@@ -108,12 +113,19 @@ enum Commands {
         /// Run the synthetic benchmark instead of a PMX/VMD pair
         #[arg(long)]
         synthetic: bool,
+        /// Additional pair or synthetic benchmark arguments
+        #[arg(
+            value_name = "ARGS",
+            trailing_var_arg = true,
+            allow_hyphen_values = true
+        )]
+        extra_args: Vec<String>,
     },
 
     /// Verify oracle, golden, parser, or numeric comparison data.
     #[command(
-        long_about = "Run comparison and oracle diagnostics from a manifest, oracle file, or golden root.\nUse this for numeric, camera, IK, parser, and focused diagnosis workflows.",
-        after_help = "Examples:\n  mmd-anim verify oracle.jsonl\n  mmd-anim verify manifest.json --mode numeric\n  mmd-anim verify golden-root --mode ik --compare\n  mmd-anim verify manifest.json --mode numeric --diagnose case-a 120 左足ＩＫ"
+        long_about = "Run comparison and oracle diagnostics from a manifest, oracle file, or golden root.\nWhen --mode is omitted, verify reads the target as an oracle JSONL summary file.\nMode inputs:\n  numeric: manifest JSON for numeric model/motion/oracle cases\n  camera: manifest JSON for camera comparison cases\n  ik: golden root directory containing IK fixture/oracle data\n  parser: golden root directory containing parser golden data\n  omitted: oracle JSONL summary file\nUse this for numeric, camera, IK, parser, and focused diagnosis workflows.",
+        after_help = "Examples:\n  mmd-anim verify oracle.jsonl\n  mmd-anim verify manifest.json --mode numeric\n  mmd-anim verify camera-manifest.json --mode camera\n  mmd-anim verify golden-root --mode ik\n  mmd-anim verify golden-root --mode ik --compare\n  mmd-anim verify golden-root --mode parser\n  mmd-anim verify manifest.json --mode numeric --diagnose case-a 120 左足ＩＫ"
     )]
     Verify {
         /// Path to a manifest, oracle JSONL file, or golden root directory
@@ -140,8 +152,8 @@ enum Commands {
 
     /// Patch PMM fields in place to a new output file.
     #[command(
-        long_about = "Rewrite selected PMM document fields while preserving the rest of the file.\nUse this for model path and scene frame range fixes in generated PMM scenes.",
-        after_help = "Examples:\n  mmd-anim patch scene.pmm --model-path 0 model.pmx out.pmm\n  mmd-anim patch scene.pmm --frame-range out.pmm --current-frame 120\n  mmd-anim patch scene.pmm --frame-range out.pmm --begin-frame 0 --end-frame 240"
+        long_about = "Rewrite selected PMM document fields while preserving the rest of the file.\nUse --model-path when a PMM document model slot points at the wrong model path.\nUse --frame-range when the scene timeline current frame, begin/end frame, or range enabled flags need correction.\nThe flag structure is intentionally stable: --model-path takes <idx> <path> <out>, and --frame-range takes <out> plus one or more frame-range options.",
+        after_help = "Examples:\n  mmd-anim patch scene.pmm --model-path 0 model.pmx out.pmm\n  mmd-anim patch scene.pmm --frame-range out.pmm --current-frame 120\n  mmd-anim patch scene.pmm --frame-range out.pmm --begin-frame 0 --end-frame 240\n  mmd-anim patch scene.pmm --frame-range out.pmm --begin-frame-enabled true --end-frame-enabled true"
     )]
     Patch {
         /// Path to the input PMM file
@@ -174,7 +186,7 @@ enum Commands {
 
     /// Export an asset to another binary file.
     #[command(
-        long_about = "Write an MMD asset to an output path, optionally starting from JSON.\nUse this for parser/exporter smoke checks and JSON-to-binary conversion.",
+        long_about = "Write an MMD asset to an output path, optionally starting from JSON.\nWith --from-json, the input must be UTF-8 JSON text and the output extension selects the binary format.\nUse this for parser/exporter smoke checks and JSON-to-binary conversion.",
         after_help = "Examples:\n  mmd-anim export input.vmd output.vmd\n  mmd-anim export input.json output.vmd --from-json"
     )]
     Export {
@@ -224,7 +236,12 @@ fn main() -> ExitCode {
             Ok(ExitCode::SUCCESS)
         }
 
-        Some(Commands::Inspect { asset, json, ik }) => dispatch_inspect(&asset, json, ik),
+        Some(Commands::Inspect {
+            asset,
+            json,
+            ik,
+            output,
+        }) => dispatch_inspect(&asset, json, ik, output.as_deref()),
         Some(Commands::Import {
             model,
             motion,
@@ -244,7 +261,8 @@ fn main() -> ExitCode {
             model,
             motion,
             synthetic,
-        }) => dispatch_bench(model, motion, synthetic),
+            extra_args,
+        }) => dispatch_bench(model, motion, synthetic, extra_args),
         Some(Commands::Verify {
             target,
             mode,
@@ -300,7 +318,7 @@ fn main() -> ExitCode {
     match result {
         Ok(code) => code,
         Err(error) => {
-            eprintln!("{error}");
+            eprintln!("{}", format_cli_error(error.as_ref()));
             ExitCode::FAILURE
         }
     }
@@ -310,7 +328,11 @@ fn dispatch_inspect(
     asset: &Path,
     use_json: bool,
     show_ik: bool,
+    output: Option<&Path>,
 ) -> Result<ExitCode, Box<dyn std::error::Error>> {
+    if output.is_some() && !use_json {
+        return usage_error("inspect --output requires --json");
+    }
     if use_json && show_ik {
         return usage_error("inspect --json and --ik cannot be combined");
     }
@@ -321,6 +343,9 @@ fn dispatch_inspect(
         return commands::import::import_pmx_ik_summary(asset);
     }
     if use_json {
+        if let Some(output) = output {
+            return commands::parse::parse_format_json_to_file(asset, output);
+        }
         return commands::parse::parse_format_json(asset);
     }
     if has_extension(asset, "pmx") {
@@ -364,7 +389,10 @@ fn dispatch_import(
     } else if has_extension(model, "vmd") {
         commands::import::import_vmd_summary(model)
     } else {
-        usage_error("import requires a PMX, PMD, or VMD input when no motion is provided")
+        usage_error(format!(
+            "unsupported or unrecognized file format: {}; import requires a PMX, PMD, or VMD input when no motion is provided",
+            model.display()
+        ))
     }
 }
 
@@ -385,12 +413,18 @@ fn dispatch_bench(
     model: Option<PathBuf>,
     motion: Option<PathBuf>,
     synthetic: bool,
+    extra_args: Vec<String>,
 ) -> Result<ExitCode, Box<dyn std::error::Error>> {
     if synthetic {
-        if model.is_some() || motion.is_some() {
-            return usage_error("bench --synthetic does not accept model or motion arguments");
+        let mut raw = Vec::<String>::new();
+        if let Some(model) = model {
+            raw.push(model.to_string_lossy().into_owned());
         }
-        let mut iter = Vec::<String>::new().into_iter();
+        if let Some(motion) = motion {
+            raw.push(motion.to_string_lossy().into_owned());
+        }
+        raw.extend(extra_args);
+        let mut iter = raw.into_iter();
         commands::bench::parse_bench_synthetic_args(&mut iter)
             .and_then(commands::bench::bench_synthetic)
     } else {
@@ -400,11 +434,12 @@ fn dispatch_bench(
         let Some(motion) = motion else {
             return usage_error("bench requires <model> <motion> unless --synthetic is set");
         };
-        let mut iter = vec![
+        let mut raw = vec![
             model.to_string_lossy().into_owned(),
             motion.to_string_lossy().into_owned(),
-        ]
-        .into_iter();
+        ];
+        raw.extend(extra_args);
+        let mut iter = raw.into_iter();
         commands::bench::parse_bench_pair_args(&mut iter).and_then(commands::bench::bench_pair)
     }
 }
@@ -419,7 +454,12 @@ fn dispatch_verify(
     sample_frame_offset: Option<f32>,
 ) -> Result<ExitCode, Box<dyn std::error::Error>> {
     let Some(mode) = mode else {
-        if diagnose.is_some() || compare || use_json || eval_frame.is_some() || sample_frame_offset.is_some() {
+        if diagnose.is_some()
+            || compare
+            || use_json
+            || eval_frame.is_some()
+            || sample_frame_offset.is_some()
+        {
             return usage_error("verify without --mode only supports oracle summary files");
         }
         return commands::oracle::oracle_summary(&target.to_string_lossy());
@@ -445,7 +485,9 @@ fn dispatch_verify(
             }
             commands::compare::compare_numeric_manifest(target)
         }
-        VerifyMode::Ik => dispatch_verify_ik(target, diagnose, compare, use_json, sample_frame_offset),
+        VerifyMode::Ik => {
+            dispatch_verify_ik(target, diagnose, compare, use_json, sample_frame_offset)
+        }
         VerifyMode::Parser => {
             if diagnose.is_some()
                 || compare
@@ -660,6 +702,79 @@ fn usage_error(message: impl AsRef<str>) -> Result<ExitCode, Box<dyn std::error:
     Ok(ExitCode::from(2))
 }
 
+pub(crate) fn read_file(path: &Path) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+    fs::read(path).map_err(|error| {
+        format!(
+            "failed to read {}: {}",
+            path.display(),
+            io_error_label(error.kind())
+        )
+        .into()
+    })
+}
+
+pub(crate) fn read_text_file(path: &Path) -> Result<String, Box<dyn std::error::Error>> {
+    fs::read_to_string(path).map_err(|error| {
+        format!(
+            "failed to read {}: {}",
+            path.display(),
+            io_error_label(error.kind())
+        )
+        .into()
+    })
+}
+
+pub(crate) fn write_file(
+    path: &Path,
+    data: impl AsRef<[u8]>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    fs::write(path, data).map_err(|error| {
+        format!(
+            "failed to write {}: {}",
+            path.display(),
+            io_error_label(error.kind())
+        )
+        .into()
+    })
+}
+
+pub(crate) fn diagnostics_suffix(count: usize) -> String {
+    if count == 0 {
+        String::new()
+    } else {
+        format!(" diagnostics={count}")
+    }
+}
+
+pub(crate) fn unsupported_format_error(path: &Path) -> Box<dyn std::error::Error> {
+    format!(
+        "unsupported or unrecognized file format: {}",
+        path.display()
+    )
+    .into()
+}
+
+fn format_cli_error(error: &(dyn std::error::Error + 'static)) -> String {
+    if let Some(io_error) = error.downcast_ref::<io::Error>() {
+        return format!("I/O error: {}", io_error_label(io_error.kind()));
+    }
+    error.to_string()
+}
+
+fn io_error_label(kind: io::ErrorKind) -> &'static str {
+    match kind {
+        io::ErrorKind::NotFound => "file not found",
+        io::ErrorKind::PermissionDenied => "permission denied",
+        io::ErrorKind::InvalidData => "invalid data",
+        io::ErrorKind::UnexpectedEof => "unexpected end of file",
+        io::ErrorKind::AlreadyExists => "already exists",
+        io::ErrorKind::WouldBlock => "operation would block",
+        io::ErrorKind::TimedOut => "operation timed out",
+        io::ErrorKind::Interrupted => "operation interrupted",
+        _ => "I/O error",
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Functions that remain in the crate root (used by multiple modules)
 // ---------------------------------------------------------------------------
@@ -708,11 +823,12 @@ pub(crate) fn copy_world_matrices_to_f32(matrices: &[glam::Mat4], out: &mut [f32
 // ---------------------------------------------------------------------------
 
 fn golden_ik_summary(root: &Path) -> Result<ExitCode, Box<dyn std::error::Error>> {
-    use std::fs;
-    use mmd_anim_schema::{DEFAULT_FOCUSED_IK_BONE_NAMES, GoldenIkBatchManifest, GoldenIkFixture, MmdDumperOracleDump};
+    use mmd_anim_schema::{
+        DEFAULT_FOCUSED_IK_BONE_NAMES, GoldenIkBatchManifest, GoldenIkFixture, MmdDumperOracleDump,
+    };
 
     let manifest_path = root.join("oracle-batch.json");
-    let manifest = GoldenIkBatchManifest::from_json_str(&fs::read_to_string(&manifest_path)?)?;
+    let manifest = GoldenIkBatchManifest::from_json_str(&read_text_file(&manifest_path)?)?;
     let mut parsed_cases = 0usize;
     let mut parsed_frames = 0usize;
     let mut parsed_bones = 0usize;
@@ -727,7 +843,7 @@ fn golden_ik_summary(root: &Path) -> Result<ExitCode, Box<dyn std::error::Error>
             continue;
         }
 
-        let fixture = GoldenIkFixture::from_json_str(&fs::read_to_string(&fixture_path)?)?;
+        let fixture = GoldenIkFixture::from_json_str(&read_text_file(&fixture_path)?)?;
         let oracle_path = resolve_maybe_absolute(&case_root, &fixture.output);
         if !oracle_path.exists() {
             missing.push(oracle_path);
@@ -740,7 +856,7 @@ fn golden_ik_summary(root: &Path) -> Result<ExitCode, Box<dyn std::error::Error>
             fixture.frames.as_slice()
         };
         let dump =
-            MmdDumperOracleDump::from_jsonl_str(&fs::read_to_string(&oracle_path)?, Some(frames))?;
+            MmdDumperOracleDump::from_jsonl_str(&read_text_file(&oracle_path)?, Some(frames))?;
         parsed_cases += 1;
         parsed_frames += dump.frames.len();
         parsed_bones += dump
@@ -785,11 +901,10 @@ fn golden_ik_summary(root: &Path) -> Result<ExitCode, Box<dyn std::error::Error>
 }
 
 fn golden_parser_summary(root: &Path) -> Result<ExitCode, Box<dyn std::error::Error>> {
-    use std::fs;
     use mmd_anim_schema::{GoldenIkBatchManifest, GoldenIkFixture, MmdDumperOracleDump};
 
     let manifest_path = root.join("oracle-batch.json");
-    let manifest = GoldenIkBatchManifest::from_json_str(&fs::read_to_string(&manifest_path)?)?;
+    let manifest = GoldenIkBatchManifest::from_json_str(&read_text_file(&manifest_path)?)?;
     let mut parsed_cases = 0usize;
     let mut skipped_unsupported = 0usize;
     let mut missing_files = Vec::new();
@@ -819,14 +934,14 @@ fn golden_parser_summary(root: &Path) -> Result<ExitCode, Box<dyn std::error::Er
             missing_files.push(fixture_path);
             continue;
         }
-        let fixture = GoldenIkFixture::from_json_str(&fs::read_to_string(&fixture_path)?)?;
+        let fixture = GoldenIkFixture::from_json_str(&read_text_file(&fixture_path)?)?;
         let oracle_path = resolve_maybe_absolute(&case_root, &fixture.output);
         if !oracle_path.exists() {
             missing_files.push(oracle_path);
             continue;
         }
 
-        let parsed = mmd_anim_format::parse_pmx_model(&fs::read(&pmx_path)?)?;
+        let parsed = mmd_anim_format::parse_pmx_model(&read_file(&pmx_path)?)?;
         let bone_names = parsed
             .skeleton
             .bones
@@ -845,7 +960,7 @@ fn golden_parser_summary(root: &Path) -> Result<ExitCode, Box<dyn std::error::Er
             fixture.frames.as_slice()
         };
         let dump =
-            MmdDumperOracleDump::from_jsonl_str(&fs::read_to_string(&oracle_path)?, Some(frames))?;
+            MmdDumperOracleDump::from_jsonl_str(&read_text_file(&oracle_path)?, Some(frames))?;
         parsed_cases += 1;
 
         let Some(model) = dump.frames.first().and_then(|frame| frame.models.first()) else {
@@ -893,12 +1008,16 @@ fn golden_parser_summary(root: &Path) -> Result<ExitCode, Box<dyn std::error::Er
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::{env, fs, sync::Arc, time::{SystemTime, UNIX_EPOCH}};
+    use std::{
+        env, fs,
+        sync::Arc,
+        time::{SystemTime, UNIX_EPOCH},
+    };
 
     use glam::{Quat, Vec3A};
     use mmd_anim_runtime::{
-        AnimationClip, BoneAnimationBinding, BoneIndex, BoneInit, ModelArena,
-        MovableBoneKeyframe, MovableBoneTrack, RuntimeInstance,
+        AnimationClip, BoneAnimationBinding, BoneIndex, BoneInit, ModelArena, MovableBoneKeyframe,
+        MovableBoneTrack, RuntimeInstance,
     };
 
     use crate::commands::{bench, compare, export, patch};
@@ -1172,7 +1291,10 @@ mod tests {
         let case = serde_json::json!({});
         let defaults = vec!["右腕".to_owned(), "左腕".to_owned()];
 
-        assert_eq!(compare::motion_case_focus_bones(&case, Some(&defaults)), defaults);
+        assert_eq!(
+            compare::motion_case_focus_bones(&case, Some(&defaults)),
+            defaults
+        );
     }
 
     #[test]
@@ -1183,7 +1305,10 @@ mod tests {
             }
         });
 
-        assert_eq!(compare::json_f32(&value, "/compare/evalFrameOffset"), Some(1.25));
+        assert_eq!(
+            compare::json_f32(&value, "/compare/evalFrameOffset"),
+            Some(1.25)
+        );
     }
 
     #[test]
@@ -1870,16 +1995,19 @@ mod tests {
 
     #[test]
     fn parse_pmm_scene_frame_range_patch_options_rejects_unknown_and_invalid_values() {
-        let unknown =
-            patch::parse_pmm_scene_frame_range_patch_options(&["--unknown".to_string(), "1".to_string()])
-                .unwrap_err();
+        let unknown = patch::parse_pmm_scene_frame_range_patch_options(&[
+            "--unknown".to_string(),
+            "1".to_string(),
+        ])
+        .unwrap_err();
         assert!(
             unknown.contains("unknown option"),
             "unexpected unknown-option error: {unknown}"
         );
 
         let missing_value =
-            patch::parse_pmm_scene_frame_range_patch_options(&["--begin-frame".to_string()]).unwrap_err();
+            patch::parse_pmm_scene_frame_range_patch_options(&["--begin-frame".to_string()])
+                .unwrap_err();
         assert!(
             missing_value.contains("missing value"),
             "unexpected missing-value error: {missing_value}"

--- a/crates/mmd-anim-cli/src/main.rs
+++ b/crates/mmd-anim-cli/src/main.rs
@@ -4,7 +4,7 @@ use std::{
     process::ExitCode,
 };
 
-use clap::{Parser, Subcommand};
+use clap::{Parser, Subcommand, ValueEnum};
 
 mod commands;
 
@@ -16,7 +16,8 @@ mod commands;
 #[command(
     name = "mmd-anim",
     version,
-    about = "CLI diagnostics and roundtrip tools for mmd-anim"
+    about = "CLI diagnostics and roundtrip tools for mmd-anim\n\nExit codes: 0 = success, 1 = runtime error, 2 = usage error",
+    arg_required_else_help = true
 )]
 struct Cli {
     #[command(subcommand)]
@@ -25,275 +26,189 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Commands {
-    // -- Parse commands ------------------------------------------------------
-    /// Parse a PMX model and show summary counts
-    #[command(name = "parse-pmx-summary")]
-    ParsePmxSummary {
-        /// Path to the PMX model file
+    /// Inspect an MMD asset without changing it.
+    #[command(
+        long_about = "Parse an MMD asset and print a compact summary by default.\nUse this for quick format triage, JSON dumps, or PMX IK solver inspection.",
+        after_help = "Examples:\n  mmd-anim inspect model.pmx\n  mmd-anim inspect motion.vmd --json\n  mmd-anim inspect model.pmx --ik"
+    )]
+    Inspect {
+        /// Path to the asset to inspect
         asset: PathBuf,
+        /// Output parsed data as JSON
+        #[arg(long)]
+        json: bool,
+        /// Show PMX IK solver details
+        #[arg(long)]
+        ik: bool,
     },
 
-    /// Parse any MMD asset and show a human-readable summary
-    #[command(name = "parse-format-summary")]
-    ParseFormatSummary {
-        /// Path to the MMD asset file
+    /// Import model and optional motion into runtime structures.
+    #[command(
+        long_about = "Run the runtime importer for a model, or a model/motion pair.\nUse this when checking runtime names, clip build stats, or a single evaluated frame.",
+        after_help = "Examples:\n  mmd-anim import model.pmx\n  mmd-anim import model.pmx motion.vmd --clip\n  mmd-anim import model.pmx motion.vmd --frame 120"
+    )]
+    Import {
+        /// Path to the PMX/PMD model file
+        model: PathBuf,
+        /// Optional path to the VMD motion file
+        motion: Option<PathBuf>,
+        /// Request JSON output where supported
+        #[arg(long)]
+        json: bool,
+        /// Show clip build statistics for a model/motion pair
+        #[arg(long)]
+        clip: bool,
+        /// Evaluate a single frame for a model/motion pair
+        #[arg(long)]
+        frame: Option<f32>,
+    },
+
+    /// Verify parse/export/re-parse stability.
+    #[command(
+        long_about = "Parse an asset, export it, then re-parse the exported bytes.\nUse this before changing readers, writers, or JSON DTO conversion paths.",
+        after_help = "Examples:\n  mmd-anim roundtrip model.pmx\n  mmd-anim roundtrip motion.vmd --json\n  mmd-anim roundtrip model.pmx --via-json"
+    )]
+    Roundtrip {
+        /// Path to the asset to roundtrip
         asset: PathBuf,
+        /// Output roundtrip report as JSON
+        #[arg(long)]
+        json: bool,
+        /// Roundtrip through JSON serialization before binary export
+        #[arg(long)]
+        via_json: bool,
     },
 
-    /// Parse any MMD asset and output full parsed data as JSON
-    #[command(name = "parse-format-json")]
-    ParseFormatJson {
-        /// Path to the MMD asset file
-        asset: PathBuf,
-    },
-
-    // -- Import commands -----------------------------------------------------
-    /// Import a PMX model into runtime format and show summary
-    #[command(name = "import-pmx-summary")]
-    ImportPmxSummary {
-        /// Path to the PMX model file
-        model: PathBuf,
-    },
-
-    /// Import a PMX model and show IK solver details
-    #[command(name = "import-pmx-ik-summary")]
-    ImportPmxIkSummary {
-        /// Path to the PMX model file
-        model: PathBuf,
-    },
-
-    /// Import a PMD model into runtime format and show summary
-    #[command(name = "import-pmd-summary")]
-    ImportPmdSummary {
-        /// Path to the PMD model file
-        model: PathBuf,
-    },
-
-    /// Import a VMD motion and show summary
-    #[command(name = "import-vmd-summary")]
-    ImportVmdSummary {
-        /// Path to the VMD motion file
-        motion: PathBuf,
-    },
-
-    /// Import a PMX/VMD pair and show matching statistics
-    #[command(name = "import-pair-summary")]
-    ImportPairSummary {
-        /// Path to the PMX model file
-        model: PathBuf,
-        /// Path to the VMD motion file
-        motion: PathBuf,
-    },
-
-    /// Import a PMX/VMD pair and show clip build statistics
-    #[command(name = "import-pair-clip-summary")]
-    ImportPairClipSummary {
-        /// Path to the PMX model file
-        model: PathBuf,
-        /// Path to the VMD motion file
-        motion: PathBuf,
-    },
-
-    /// Import a PMX/VMD pair and evaluate a single frame
-    #[command(name = "import-pair-frame-summary")]
-    ImportPairFrameSummary {
-        /// Path to the PMX model file
-        model: PathBuf,
-        /// Path to the VMD motion file
-        motion: PathBuf,
-        /// Frame number to evaluate
-        frame: f32,
-    },
-
-    // -- Export commands ------------------------------------------------------
-    /// Export roundtrip: parse, export, re-parse and verify
-    #[command(name = "export-roundtrip-summary")]
-    ExportRoundtripSummary {
-        /// Path to the MMD asset file
-        asset: PathBuf,
-    },
-
-    /// Export roundtrip with JSON output
-    #[command(name = "export-roundtrip-json")]
-    ExportRoundtripJson {
-        /// Path to the MMD asset file
-        asset: PathBuf,
-    },
-
-    /// JSON roundtrip: parse, JSON serialize/deserialize, export, re-parse and verify
-    #[command(name = "export-json-roundtrip-summary")]
-    ExportJsonRoundtripSummary {
-        /// Path to the MMD asset file
-        asset: PathBuf,
-    },
-
-    /// JSON roundtrip with JSON output
-    #[command(name = "export-json-roundtrip-json")]
-    ExportJsonRoundtripJson {
-        /// Path to the MMD asset file
-        asset: PathBuf,
-    },
-
-    /// Export a parsed MMD asset to a binary file
-    #[command(name = "export-format")]
-    ExportFormat {
-        /// Path to the input asset file
-        input: PathBuf,
-        /// Path to the output asset file
-        output: PathBuf,
-    },
-
-    /// Export a JSON-serialized asset to a binary file
-    #[command(name = "export-json-format")]
-    ExportJsonFormat {
-        /// Path to the input JSON file
-        input: PathBuf,
-        /// Path to the output asset file
-        output: PathBuf,
-    },
-
-    /// Build a PMM scene from a PMX model and VMD motion
-    #[command(name = "export-pmm-scene")]
-    ExportPmmScene {
-        /// Path to the PMX model file
-        model: PathBuf,
-        /// Path to the VMD motion file
-        motion: PathBuf,
-        /// Path to the output PMM file
-        output: PathBuf,
-    },
-
-    // -- Bench commands ------------------------------------------------------
-    /// Benchmark animation evaluation with a PMX/VMD pair
-    #[command(name = "bench-pair")]
-    BenchPair {
-        /// All arguments (model, motion, options) passed as raw args
-        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
-        args: Vec<String>,
-    },
-
-    /// Benchmark animation evaluation with synthetic data
-    #[command(name = "bench-synthetic")]
-    BenchSynthetic {
-        /// All arguments passed as raw args
-        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
-        args: Vec<String>,
-    },
-
-    // -- Patch commands ------------------------------------------------------
-    /// Patch a PMM file's document model path
-    #[command(name = "patch-pmm-document-model-path")]
-    PatchPmmDocumentModelPath {
-        /// Path to the input PMM file
-        input: PathBuf,
-        /// Document model index (0-255)
-        document_model_index: String,
-        /// New model path to set
-        model_path: String,
-        /// Path to the output PMM file
-        output: PathBuf,
-    },
-
-    /// Patch a PMM file's scene frame range settings
-    #[command(name = "patch-pmm-scene-frame-range")]
-    PatchPmmSceneFrameRange {
-        /// Path to the input PMM file
-        input: PathBuf,
-        /// Path to the output PMM file
-        output: PathBuf,
-        /// Additional options
-        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
-        options: Vec<String>,
-    },
-
-    // -- Rig commands ---------------------------------------------------------
-    /// Inspect rig structure (IK chains, grants, deform layers) of a PMX model
-    #[command(name = "rig-inspect")]
-    RigInspect {
+    /// Inspect PMX rig structure.
+    #[command(
+        long_about = "Inspect IK chains, grant/append transforms, and deform layer distribution.\nUse this for rig debugging before runtime import or solver comparison.",
+        after_help = "Examples:\n  mmd-anim rig model.pmx\n  mmd-anim rig model.pmx --bones\n  mmd-anim rig model.pmx --json --bones"
+    )]
+    Rig {
         /// Path to the PMX model file
         model: PathBuf,
         /// Output as JSON
         #[arg(long)]
         json: bool,
-        /// Include full bone list
+        /// Include the full bone list
         #[arg(long)]
         bones: bool,
     },
 
-    // -- Compare commands ----------------------------------------------------
-    /// Run numeric comparison against oracle data
-    #[command(name = "compare-numeric")]
-    CompareNumeric {
-        /// Path to the comparison manifest JSON file
-        manifest: PathBuf,
+    /// Benchmark runtime evaluation.
+    #[command(
+        long_about = "Benchmark a PMX/VMD pair by default, or synthetic runtime data with --synthetic.\nUse this for local performance checks around import, clip build, and evaluation.",
+        after_help = "Examples:\n  mmd-anim bench model.pmx motion.vmd\n  mmd-anim bench --synthetic"
+    )]
+    Bench {
+        /// Path to the PMX model file
+        model: Option<PathBuf>,
+        /// Path to the VMD motion file
+        motion: Option<PathBuf>,
+        /// Run the synthetic benchmark instead of a PMX/VMD pair
+        #[arg(long)]
+        synthetic: bool,
     },
 
-    /// Run camera VMD numeric comparison against oracle data
-    #[command(name = "compare-camera-vmd-numeric")]
-    CompareCameraVmdNumeric {
-        /// Path to the comparison manifest JSON file
-        manifest: PathBuf,
+    /// Verify oracle, golden, parser, or numeric comparison data.
+    #[command(
+        long_about = "Run comparison and oracle diagnostics from a manifest, oracle file, or golden root.\nUse this for numeric, camera, IK, parser, and focused diagnosis workflows.",
+        after_help = "Examples:\n  mmd-anim verify oracle.jsonl\n  mmd-anim verify manifest.json --mode numeric\n  mmd-anim verify golden-root --mode ik --compare\n  mmd-anim verify manifest.json --mode numeric --diagnose case-a 120 左足ＩＫ"
+    )]
+    Verify {
+        /// Path to a manifest, oracle JSONL file, or golden root directory
+        target: PathBuf,
+        /// Verification mode
+        #[arg(long, value_enum)]
+        mode: Option<VerifyMode>,
+        /// Diagnose a specific case/frame, with optional bone name
+        #[arg(long, num_args = 2..=3, value_names = ["CASE", "FRAME", "BONE"])]
+        diagnose: Option<Vec<String>>,
+        /// Compare IK golden data instead of printing the IK summary
+        #[arg(long)]
+        compare: bool,
+        /// Request JSON output where supported
+        #[arg(long)]
+        json: bool,
+        /// Numeric diagnosis evaluation frame override
+        #[arg(long)]
+        eval_frame: Option<f32>,
+        /// IK comparison/diagnosis sample frame offset
+        #[arg(long)]
+        sample_frame_offset: Option<f32>,
     },
 
-    /// Diagnose numeric comparison results for specific bones
-    #[command(name = "diagnose-numeric-bone")]
-    DiagnoseNumericBone {
-        /// Path to the comparison manifest JSON file
-        manifest: PathBuf,
-        /// Case name from the manifest
-        case_name: String,
-        /// Oracle frame number
-        frame: f32,
-        /// Additional options and bone names
-        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
-        rest: Vec<String>,
+    /// Patch PMM fields in place to a new output file.
+    #[command(
+        long_about = "Rewrite selected PMM document fields while preserving the rest of the file.\nUse this for model path and scene frame range fixes in generated PMM scenes.",
+        after_help = "Examples:\n  mmd-anim patch scene.pmm --model-path 0 model.pmx out.pmm\n  mmd-anim patch scene.pmm --frame-range out.pmm --current-frame 120\n  mmd-anim patch scene.pmm --frame-range out.pmm --begin-frame 0 --end-frame 240"
+    )]
+    Patch {
+        /// Path to the input PMM file
+        pmm: PathBuf,
+        /// Patch a document model path: <idx> <path> <out>
+        #[arg(long, num_args = 3, value_names = ["IDX", "PATH", "OUT"])]
+        model_path: Option<Vec<String>>,
+        /// Patch scene frame range settings and write to this output path
+        #[arg(long, value_name = "OUT")]
+        frame_range: Option<PathBuf>,
+        /// Set current frame index
+        #[arg(long)]
+        current_frame: Option<i32>,
+        /// Set current frame text field index
+        #[arg(long)]
+        current_frame_text: Option<i32>,
+        /// Set begin frame index
+        #[arg(long)]
+        begin_frame: Option<i32>,
+        /// Set end frame index
+        #[arg(long)]
+        end_frame: Option<i32>,
+        /// Enable or disable begin frame range
+        #[arg(long)]
+        begin_frame_enabled: Option<String>,
+        /// Enable or disable end frame range
+        #[arg(long)]
+        end_frame_enabled: Option<String>,
     },
 
-    // -- Golden commands -----------------------------------------------------
-    /// Show golden IK oracle summary
-    #[command(name = "golden-ik-summary")]
-    GoldenIkSummary {
-        /// Path to the golden IK oracle root directory
-        root: PathBuf,
+    /// Export an asset to another binary file.
+    #[command(
+        long_about = "Write an MMD asset to an output path, optionally starting from JSON.\nUse this for parser/exporter smoke checks and JSON-to-binary conversion.",
+        after_help = "Examples:\n  mmd-anim export input.vmd output.vmd\n  mmd-anim export input.json output.vmd --from-json"
+    )]
+    Export {
+        /// Path to the input asset or JSON file
+        input: PathBuf,
+        /// Path to the output asset file
+        output: PathBuf,
+        /// Treat input as JSON and export binary format
+        #[arg(long)]
+        from_json: bool,
     },
 
-    /// Compare runtime IK results against golden oracle
-    #[command(name = "golden-ik-compare")]
-    GoldenIkCompare {
-        /// All arguments passed as raw args
-        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
-        args: Vec<String>,
+    /// Build a PMM scene from a model and motion.
+    #[command(
+        name = "build-pmm",
+        long_about = "Create a PMM scene from a PMX model and VMD motion.\nUse this when preparing MMD GUI-compatible scenes from runtime fixtures.",
+        after_help = "Examples:\n  mmd-anim build-pmm model.pmx motion.vmd scene.pmm\n  mmd-anim build-pmm ./model.pmx ./motion.vmd ./out/scene.pmm"
+    )]
+    BuildPmm {
+        /// Path to the PMX model file
+        model: PathBuf,
+        /// Path to the VMD motion file
+        motion: PathBuf,
+        /// Path to the output PMM file
+        output: PathBuf,
     },
+}
 
-    /// Diagnose a specific IK comparison case
-    #[command(name = "golden-ik-diagnose")]
-    GoldenIkDiagnose {
-        /// Path to the golden IK oracle root directory
-        root: PathBuf,
-        /// Case name
-        case_name: String,
-        /// Frame number
-        frame: i32,
-        /// Bone name to diagnose
-        bone_name: String,
-        /// Optional sample frame offset
-        offset: Option<f32>,
-    },
-
-    /// Show golden parser summary
-    #[command(name = "golden-parser-summary")]
-    GoldenParserSummary {
-        /// Path to the golden run root directory
-        root: PathBuf,
-    },
-
-    // -- Oracle commands -----------------------------------------------------
-    /// Show MMDDumper oracle file summary
-    #[command(name = "oracle-summary")]
-    OracleSummary {
-        /// Path to the oracle JSONL file
-        path: PathBuf,
-    },
+#[derive(Copy, Clone, Debug, ValueEnum)]
+enum VerifyMode {
+    Numeric,
+    Camera,
+    Ik,
+    Parser,
 }
 
 // ---------------------------------------------------------------------------
@@ -309,136 +224,77 @@ fn main() -> ExitCode {
             Ok(ExitCode::SUCCESS)
         }
 
-        Some(Commands::ParsePmxSummary { asset }) => {
-            commands::parse::parse_pmx_summary(&asset)
-        }
-        Some(Commands::ParseFormatSummary { asset }) => {
-            commands::parse::parse_format_summary(&asset)
-        }
-        Some(Commands::ParseFormatJson { asset }) => {
-            commands::parse::parse_format_json(&asset)
-        }
-
-        Some(Commands::ImportPmxSummary { model }) => {
-            commands::import::import_pmx_summary(&model)
-        }
-        Some(Commands::ImportPmxIkSummary { model }) => {
-            commands::import::import_pmx_ik_summary(&model)
-        }
-        Some(Commands::ImportPmdSummary { model }) => {
-            commands::import::import_pmd_summary(&model)
-        }
-        Some(Commands::ImportVmdSummary { motion }) => {
-            commands::import::import_vmd_summary(&motion)
-        }
-        Some(Commands::ImportPairSummary { model, motion }) => {
-            commands::import::import_pair_summary(&model, &motion)
-        }
-        Some(Commands::ImportPairClipSummary { model, motion }) => {
-            commands::import::import_pair_clip_summary(&model, &motion)
-        }
-        Some(Commands::ImportPairFrameSummary { model, motion, frame }) => {
-            commands::import::import_pair_frame_summary(&model, &motion, frame)
-        }
-
-        Some(Commands::ExportRoundtripSummary { asset }) => {
-            commands::export::export_roundtrip_summary(&asset)
-        }
-        Some(Commands::ExportRoundtripJson { asset }) => {
-            commands::export::export_roundtrip_json(&asset)
-        }
-        Some(Commands::ExportJsonRoundtripSummary { asset }) => {
-            commands::export::export_json_roundtrip_summary(&asset)
-        }
-        Some(Commands::ExportJsonRoundtripJson { asset }) => {
-            commands::export::export_json_roundtrip_json(&asset)
-        }
-        Some(Commands::ExportFormat { input, output }) => {
-            commands::export::export_format(&input, &output)
-        }
-        Some(Commands::ExportJsonFormat { input, output }) => {
-            commands::export::export_json_format(&input, &output)
-        }
-        Some(Commands::ExportPmmScene { model, motion, output }) => {
-            commands::export::export_pmm_scene(&model, &motion, &output)
-        }
-
-        Some(Commands::BenchPair { args }) => {
-            let mut iter = args.into_iter();
-            commands::bench::parse_bench_pair_args(&mut iter)
-                .and_then(commands::bench::bench_pair)
-        }
-        Some(Commands::BenchSynthetic { args }) => {
-            let mut iter = args.into_iter();
-            commands::bench::parse_bench_synthetic_args(&mut iter)
-                .and_then(commands::bench::bench_synthetic)
-        }
-
-        Some(Commands::PatchPmmDocumentModelPath { input, document_model_index, model_path, output }) => {
-            commands::patch::patch_pmm_document_model_path(&input, &document_model_index, &model_path, &output)
-        }
-        Some(Commands::PatchPmmSceneFrameRange { input, output, options }) => {
-            commands::patch::patch_pmm_scene_frame_range(&input, &output, &options)
-        }
-
-        Some(Commands::RigInspect { model, json, bones }) => {
+        Some(Commands::Inspect { asset, json, ik }) => dispatch_inspect(&asset, json, ik),
+        Some(Commands::Import {
+            model,
+            motion,
+            json,
+            clip,
+            frame,
+        }) => dispatch_import(&model, motion.as_deref(), json, clip, frame),
+        Some(Commands::Roundtrip {
+            asset,
+            json,
+            via_json,
+        }) => dispatch_roundtrip(&asset, json, via_json),
+        Some(Commands::Rig { model, json, bones }) => {
             commands::rig::rig_inspect(&model, json, bones)
         }
-
-        Some(Commands::CompareNumeric { manifest }) => {
-            commands::compare::compare_numeric_manifest(&manifest)
-        }
-        Some(Commands::CompareCameraVmdNumeric { manifest }) => {
-            commands::compare::compare_numeric_manifest(&manifest)
-        }
-        Some(Commands::DiagnoseNumericBone { manifest, case_name, frame, rest }) => {
-            let diagnose_options = commands::compare::parse_diagnose_numeric_bone_rest(rest, frame);
-            let eval_frame = diagnose_options.eval_frame;
-            let bone_names = diagnose_options.bone_names;
-            if bone_names.is_empty() {
-                eprintln!("{}", commands::compare::DIAGNOSE_NUMERIC_BONE_USAGE);
-                return ExitCode::from(2);
-            }
-            commands::compare::diagnose_numeric_bones(
-                &manifest,
-                &case_name,
-                frame,
-                eval_frame,
-                &bone_names,
-            )
-        }
-
-        Some(Commands::GoldenIkSummary { root }) => {
-            golden_ik_summary(&root)
-        }
-        Some(Commands::GoldenIkCompare { args }) => {
-            let mut iter = args.into_iter();
-            match commands::golden::parse_golden_ik_compare_args(&mut iter) {
-                Ok((root, offset, use_json)) => {
-                    commands::golden::golden_ik_compare(Path::new(&root), offset, use_json)
-                }
-                Err(error) => {
-                    eprintln!("{error}");
-                    return ExitCode::from(2);
-                }
-            }
-        }
-        Some(Commands::GoldenIkDiagnose { root, case_name, frame, bone_name, offset }) => {
-            commands::golden::golden_ik_diagnose(
-                &root,
-                &case_name,
-                frame,
-                &bone_name,
-                offset.unwrap_or(0.0),
-            )
-        }
-        Some(Commands::GoldenParserSummary { root }) => {
-            golden_parser_summary(&root)
-        }
-
-        Some(Commands::OracleSummary { path }) => {
-            commands::oracle::oracle_summary(&path.to_string_lossy())
-        }
+        Some(Commands::Bench {
+            model,
+            motion,
+            synthetic,
+        }) => dispatch_bench(model, motion, synthetic),
+        Some(Commands::Verify {
+            target,
+            mode,
+            diagnose,
+            compare,
+            json,
+            eval_frame,
+            sample_frame_offset,
+        }) => dispatch_verify(
+            &target,
+            mode,
+            diagnose,
+            compare,
+            json,
+            eval_frame,
+            sample_frame_offset,
+        ),
+        Some(Commands::Patch {
+            pmm,
+            model_path,
+            frame_range,
+            current_frame,
+            current_frame_text,
+            begin_frame,
+            end_frame,
+            begin_frame_enabled,
+            end_frame_enabled,
+        }) => dispatch_patch(
+            &pmm,
+            model_path,
+            frame_range,
+            PmmFrameRangeArgs {
+                current_frame,
+                current_frame_text,
+                begin_frame,
+                end_frame,
+                begin_frame_enabled,
+                end_frame_enabled,
+            },
+        ),
+        Some(Commands::Export {
+            input,
+            output,
+            from_json,
+        }) => dispatch_export(&input, &output, from_json),
+        Some(Commands::BuildPmm {
+            model,
+            motion,
+            output,
+        }) => commands::export::export_pmm_scene(&model, &motion, &output),
     };
 
     match result {
@@ -448,6 +304,360 @@ fn main() -> ExitCode {
             ExitCode::FAILURE
         }
     }
+}
+
+fn dispatch_inspect(
+    asset: &Path,
+    use_json: bool,
+    show_ik: bool,
+) -> Result<ExitCode, Box<dyn std::error::Error>> {
+    if use_json && show_ik {
+        return usage_error("inspect --json and --ik cannot be combined");
+    }
+    if show_ik {
+        if !has_extension(asset, "pmx") {
+            return usage_error("inspect --ik requires a PMX model file");
+        }
+        return commands::import::import_pmx_ik_summary(asset);
+    }
+    if use_json {
+        return commands::parse::parse_format_json(asset);
+    }
+    if has_extension(asset, "pmx") {
+        commands::parse::parse_pmx_summary(asset)
+    } else {
+        commands::parse::parse_format_summary(asset)
+    }
+}
+
+fn dispatch_import(
+    model: &Path,
+    motion: Option<&Path>,
+    use_json: bool,
+    show_clip: bool,
+    frame: Option<f32>,
+) -> Result<ExitCode, Box<dyn std::error::Error>> {
+    if use_json {
+        return usage_error("import --json is not supported by the existing import summaries");
+    }
+    if show_clip && frame.is_some() {
+        return usage_error("import --clip and --frame cannot be combined");
+    }
+
+    if let Some(motion) = motion {
+        if show_clip {
+            return commands::import::import_pair_clip_summary(model, motion);
+        }
+        if let Some(frame) = frame {
+            return commands::import::import_pair_frame_summary(model, motion, frame);
+        }
+        return commands::import::import_pair_summary(model, motion);
+    }
+
+    if show_clip || frame.is_some() {
+        return usage_error("import --clip and --frame require a motion argument");
+    }
+    if has_extension(model, "pmx") {
+        commands::import::import_pmx_summary(model)
+    } else if has_extension(model, "pmd") {
+        commands::import::import_pmd_summary(model)
+    } else if has_extension(model, "vmd") {
+        commands::import::import_vmd_summary(model)
+    } else {
+        usage_error("import requires a PMX, PMD, or VMD input when no motion is provided")
+    }
+}
+
+fn dispatch_roundtrip(
+    asset: &Path,
+    use_json: bool,
+    via_json: bool,
+) -> Result<ExitCode, Box<dyn std::error::Error>> {
+    match (via_json, use_json) {
+        (true, true) => commands::export::export_json_roundtrip_json(asset),
+        (true, false) => commands::export::export_json_roundtrip_summary(asset),
+        (false, true) => commands::export::export_roundtrip_json(asset),
+        (false, false) => commands::export::export_roundtrip_summary(asset),
+    }
+}
+
+fn dispatch_bench(
+    model: Option<PathBuf>,
+    motion: Option<PathBuf>,
+    synthetic: bool,
+) -> Result<ExitCode, Box<dyn std::error::Error>> {
+    if synthetic {
+        if model.is_some() || motion.is_some() {
+            return usage_error("bench --synthetic does not accept model or motion arguments");
+        }
+        let mut iter = Vec::<String>::new().into_iter();
+        commands::bench::parse_bench_synthetic_args(&mut iter)
+            .and_then(commands::bench::bench_synthetic)
+    } else {
+        let Some(model) = model else {
+            return usage_error("bench requires <model> <motion> unless --synthetic is set");
+        };
+        let Some(motion) = motion else {
+            return usage_error("bench requires <model> <motion> unless --synthetic is set");
+        };
+        let mut iter = vec![
+            model.to_string_lossy().into_owned(),
+            motion.to_string_lossy().into_owned(),
+        ]
+        .into_iter();
+        commands::bench::parse_bench_pair_args(&mut iter).and_then(commands::bench::bench_pair)
+    }
+}
+
+fn dispatch_verify(
+    target: &Path,
+    mode: Option<VerifyMode>,
+    diagnose: Option<Vec<String>>,
+    compare: bool,
+    use_json: bool,
+    eval_frame: Option<f32>,
+    sample_frame_offset: Option<f32>,
+) -> Result<ExitCode, Box<dyn std::error::Error>> {
+    let Some(mode) = mode else {
+        if diagnose.is_some() || compare || use_json || eval_frame.is_some() || sample_frame_offset.is_some() {
+            return usage_error("verify without --mode only supports oracle summary files");
+        }
+        return commands::oracle::oracle_summary(&target.to_string_lossy());
+    };
+
+    match mode {
+        VerifyMode::Numeric | VerifyMode::Camera => {
+            if compare || use_json {
+                return usage_error(
+                    "verify --mode numeric|camera does not support --compare or --json",
+                );
+            }
+            if sample_frame_offset.is_some() {
+                return usage_error(
+                    "verify --mode numeric|camera does not support --sample-frame-offset",
+                );
+            }
+            if let Some(parts) = diagnose {
+                return dispatch_numeric_diagnose(target, parts, eval_frame);
+            }
+            if eval_frame.is_some() {
+                return usage_error("verify --eval-frame requires --diagnose");
+            }
+            commands::compare::compare_numeric_manifest(target)
+        }
+        VerifyMode::Ik => dispatch_verify_ik(target, diagnose, compare, use_json, sample_frame_offset),
+        VerifyMode::Parser => {
+            if diagnose.is_some()
+                || compare
+                || use_json
+                || eval_frame.is_some()
+                || sample_frame_offset.is_some()
+            {
+                return usage_error(
+                    "verify --mode parser only supports parser golden summary for the target root",
+                );
+            }
+            golden_parser_summary(target)
+        }
+    }
+}
+
+fn dispatch_numeric_diagnose(
+    manifest: &Path,
+    parts: Vec<String>,
+    eval_frame: Option<f32>,
+) -> Result<ExitCode, Box<dyn std::error::Error>> {
+    let mut parts = parts.into_iter();
+    let case_name = parts.next().ok_or("missing diagnose case name")?;
+    let frame_text = parts.next().ok_or("missing diagnose frame")?;
+    let frame = frame_text
+        .parse::<f32>()
+        .map_err(|_| format!("invalid diagnose frame: {frame_text}"))?;
+    let mut rest = Vec::new();
+    if let Some(bone_name) = parts.next() {
+        rest.push(bone_name);
+    }
+    if let Some(eval_frame) = eval_frame {
+        rest.push("--eval-frame".to_owned());
+        rest.push(eval_frame.to_string());
+    }
+
+    let diagnose_options = commands::compare::parse_diagnose_numeric_bone_rest(rest, frame);
+    let eval_frame = diagnose_options.eval_frame;
+    let bone_names = diagnose_options.bone_names;
+    if bone_names.is_empty() {
+        eprintln!("{}", commands::compare::DIAGNOSE_NUMERIC_BONE_USAGE);
+        return Ok(ExitCode::from(2));
+    }
+    commands::compare::diagnose_numeric_bones(manifest, &case_name, frame, eval_frame, &bone_names)
+}
+
+fn dispatch_verify_ik(
+    root: &Path,
+    diagnose: Option<Vec<String>>,
+    compare: bool,
+    use_json: bool,
+    sample_frame_offset: Option<f32>,
+) -> Result<ExitCode, Box<dyn std::error::Error>> {
+    if let Some(parts) = diagnose {
+        if compare || use_json {
+            return usage_error(
+                "verify --mode ik --diagnose cannot be combined with --compare or --json",
+            );
+        }
+        return dispatch_ik_diagnose(root, parts, sample_frame_offset);
+    }
+
+    if compare || use_json || sample_frame_offset.is_some() {
+        let mut raw = vec![root.to_string_lossy().into_owned()];
+        if let Some(offset) = sample_frame_offset {
+            raw.push(offset.to_string());
+        }
+        if use_json {
+            raw.push("--json".to_owned());
+        }
+        let mut iter = raw.into_iter();
+        return match commands::golden::parse_golden_ik_compare_args(&mut iter) {
+            Ok((root, offset, use_json)) => {
+                commands::golden::golden_ik_compare(Path::new(&root), offset, use_json)
+            }
+            Err(error) => {
+                eprintln!("{error}");
+                Ok(ExitCode::from(2))
+            }
+        };
+    }
+
+    golden_ik_summary(root)
+}
+
+fn dispatch_ik_diagnose(
+    root: &Path,
+    parts: Vec<String>,
+    sample_frame_offset: Option<f32>,
+) -> Result<ExitCode, Box<dyn std::error::Error>> {
+    let mut parts = parts.into_iter();
+    let case_name = parts.next().ok_or("missing diagnose case name")?;
+    let frame_text = parts.next().ok_or("missing diagnose frame")?;
+    let frame = frame_text
+        .parse::<i32>()
+        .map_err(|_| format!("invalid IK diagnose frame: {frame_text}"))?;
+    let bone_name = parts
+        .next()
+        .ok_or("verify --mode ik --diagnose requires a bone name")?;
+    let offset = sample_frame_offset.unwrap_or(0.0);
+
+    commands::golden::golden_ik_diagnose(root, &case_name, frame, &bone_name, offset)
+}
+
+struct PmmFrameRangeArgs {
+    current_frame: Option<i32>,
+    current_frame_text: Option<i32>,
+    begin_frame: Option<i32>,
+    end_frame: Option<i32>,
+    begin_frame_enabled: Option<String>,
+    end_frame_enabled: Option<String>,
+}
+
+impl PmmFrameRangeArgs {
+    fn has_any(&self) -> bool {
+        self.current_frame.is_some()
+            || self.current_frame_text.is_some()
+            || self.begin_frame.is_some()
+            || self.end_frame.is_some()
+            || self.begin_frame_enabled.is_some()
+            || self.end_frame_enabled.is_some()
+    }
+
+    fn to_option_args(&self) -> Vec<String> {
+        let mut args = Vec::new();
+        if let Some(value) = self.current_frame {
+            args.push("--current-frame".to_owned());
+            args.push(value.to_string());
+        }
+        if let Some(value) = self.current_frame_text {
+            args.push("--current-frame-text".to_owned());
+            args.push(value.to_string());
+        }
+        if let Some(value) = self.begin_frame {
+            args.push("--begin-frame".to_owned());
+            args.push(value.to_string());
+        }
+        if let Some(value) = self.end_frame {
+            args.push("--end-frame".to_owned());
+            args.push(value.to_string());
+        }
+        if let Some(value) = &self.begin_frame_enabled {
+            args.push("--begin-frame-enabled".to_owned());
+            args.push(value.clone());
+        }
+        if let Some(value) = &self.end_frame_enabled {
+            args.push("--end-frame-enabled".to_owned());
+            args.push(value.clone());
+        }
+        args
+    }
+}
+
+fn dispatch_patch(
+    input: &Path,
+    model_path: Option<Vec<String>>,
+    frame_range: Option<PathBuf>,
+    frame_args: PmmFrameRangeArgs,
+) -> Result<ExitCode, Box<dyn std::error::Error>> {
+    match (model_path, frame_range) {
+        (Some(values), None) => {
+            if frame_args.has_any() {
+                return usage_error("patch --model-path does not accept trailing options");
+            }
+            let [index, path, output]: [String; 3] = values
+                .try_into()
+                .map_err(|_| "patch --model-path requires <idx> <path> <out>")?;
+            commands::patch::patch_pmm_document_model_path(
+                input,
+                &index,
+                &path,
+                &PathBuf::from(output),
+            )
+        }
+        (None, Some(output)) => {
+            if !frame_args.has_any() {
+                return usage_error("patch --frame-range requires at least one frame range option");
+            }
+            commands::patch::patch_pmm_scene_frame_range(
+                input,
+                &output,
+                &frame_args.to_option_args(),
+            )
+        }
+        (Some(_), Some(_)) => {
+            usage_error("patch --model-path and --frame-range cannot be combined")
+        }
+        (None, None) => usage_error("patch requires --model-path or --frame-range"),
+    }
+}
+
+fn dispatch_export(
+    input: &Path,
+    output: &Path,
+    from_json: bool,
+) -> Result<ExitCode, Box<dyn std::error::Error>> {
+    if from_json {
+        commands::export::export_json_format(input, output)
+    } else {
+        commands::export::export_format(input, output)
+    }
+}
+
+fn has_extension(path: &Path, expected: &str) -> bool {
+    path.extension()
+        .and_then(|ext| ext.to_str())
+        .is_some_and(|ext| ext.eq_ignore_ascii_case(expected))
+}
+
+fn usage_error(message: impl AsRef<str>) -> Result<ExitCode, Box<dyn std::error::Error>> {
+    eprintln!("{}", message.as_ref());
+    Ok(ExitCode::from(2))
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/mmd-anim-cli/src/main.rs
+++ b/crates/mmd-anim-cli/src/main.rs
@@ -206,6 +206,20 @@ enum Commands {
         options: Vec<String>,
     },
 
+    // -- Rig commands ---------------------------------------------------------
+    /// Inspect rig structure (IK chains, grants, deform layers) of a PMX model
+    #[command(name = "rig-inspect")]
+    RigInspect {
+        /// Path to the PMX model file
+        model: PathBuf,
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
+        /// Include full bone list
+        #[arg(long)]
+        bones: bool,
+    },
+
     // -- Compare commands ----------------------------------------------------
     /// Run numeric comparison against oracle data
     #[command(name = "compare-numeric")]
@@ -365,6 +379,10 @@ fn main() -> ExitCode {
         }
         Some(Commands::PatchPmmSceneFrameRange { input, output, options }) => {
             commands::patch::patch_pmm_scene_frame_range(&input, &output, &options)
+        }
+
+        Some(Commands::RigInspect { model, json, bones }) => {
+            commands::rig::rig_inspect(&model, json, bones)
         }
 
         Some(Commands::CompareNumeric { manifest }) => {

--- a/crates/mmd-anim-cli/src/main.rs
+++ b/crates/mmd-anim-cli/src/main.rs
@@ -1,3385 +1,488 @@
 use std::{
-    collections::{BTreeMap, HashMap, HashSet},
-    env, fs,
+    collections::HashSet,
     path::{Path, PathBuf},
     process::ExitCode,
-    sync::Arc,
-    time::Instant,
 };
 
-use glam::{Quat, Vec3A};
-use mmd_anim_format::vmd::VmdBoneKeyframeRaw;
-use mmd_anim_runtime::{
-    AnimationClip, BoneAnimationBinding, BoneIndex, BoneInit, IkSolveOptions, ModelArena,
-    MorphIndex, MovableBoneKeyframe, MovableBoneTrack, RuntimeInstance,
-};
-use mmd_anim_schema::{
-    DEFAULT_FOCUSED_IK_BONE_NAMES, GoldenIkBatchManifest, GoldenIkFixture, MmdDumperOracleBone,
-    MmdDumperOracleDump, MmdDumperOracleModel,
-};
-use serde_json::json;
-mod golden;
+use clap::{Parser, Subcommand};
 
-const IMPORT_PAIR_USAGE: &str = "usage: mmd-anim import-pair-summary <model.pmx> <motion.vmd>";
-const IMPORT_PAIR_CLIP_USAGE: &str =
-    "usage: mmd-anim import-pair-clip-summary <model.pmx> <motion.vmd>";
-const IMPORT_PAIR_FRAME_USAGE: &str =
-    "usage: mmd-anim import-pair-frame-summary <model.pmx> <motion.vmd> <frame>";
-const BENCH_PAIR_USAGE: &str = "usage: mmd-anim bench-pair <model.pmx> <motion.vmd> [start-frame] [frame-count] [step] [--no-ik] [--ik-tolerance <value>] [--ik-max-iterations-cap <count>]";
-const IMPORT_PMD_SUMMARY_USAGE: &str = "usage: mmd-anim import-pmd-summary <model.pmd>";
-const PARSE_PMX_SUMMARY_USAGE: &str = "usage: mmd-anim parse-pmx-summary <model.pmx>";
-const PARSE_FORMAT_USAGE: &str = "usage: mmd-anim parse-format-summary <asset>";
-const PARSE_FORMAT_JSON_USAGE: &str = "usage: mmd-anim parse-format-json <asset>";
-const EXPORT_ROUNDTRIP_USAGE: &str = "usage: mmd-anim export-roundtrip-summary <asset>";
-const EXPORT_ROUNDTRIP_JSON_USAGE: &str = "usage: mmd-anim export-roundtrip-json <asset>";
-const EXPORT_JSON_ROUNDTRIP_USAGE: &str = "usage: mmd-anim export-json-roundtrip-summary <asset>";
-const EXPORT_JSON_ROUNDTRIP_JSON_USAGE: &str = "usage: mmd-anim export-json-roundtrip-json <asset>";
-const GOLDEN_PARSER_SUMMARY_USAGE: &str = "usage: mmd-anim golden-parser-summary <golden-run-root>";
-const GOLDEN_IK_DIAGNOSE_USAGE: &str = "usage: mmd-anim golden-ik-diagnose <golden-ik-oracle-root> <case-name> <frame> <bone-name> [sample-frame-offset]";
-const COMPARE_NUMERIC_USAGE: &str = "usage: mmd-anim compare-numeric <manifest.json>";
-const DIAGNOSE_NUMERIC_BONE_USAGE: &str = "usage: mmd-anim diagnose-numeric-bone <manifest.json> <case-name> <oracle-frame> [--eval-frame <frame>] <bone-name> [bone-name...]";
-const EXPORT_FORMAT_USAGE: &str = "usage: mmd-anim export-format <input-asset> <output-asset>";
-const EXPORT_JSON_FORMAT_USAGE: &str =
-    "usage: mmd-anim export-json-format <input-json> <output-asset>";
-const EXPORT_PMM_SCENE_USAGE: &str =
-    "usage: mmd-anim export-pmm-scene <model.pmx> <motion.vmd> <output.pmm>";
-const PATCH_PMM_DOCUMENT_MODEL_PATH_USAGE: &str = "usage: mmd-anim patch-pmm-document-model-path <input.pmm> <document-model-index> <model-path> <output.pmm>";
-const PATCH_PMM_SCENE_FRAME_RANGE_USAGE: &str = "usage: mmd-anim patch-pmm-scene-frame-range <input.pmm> <output.pmm> [--current-frame <i32>] [--current-frame-text <i32>] [--begin-frame <i32>] [--end-frame <i32>] [--begin-frame-enabled <bool>] [--end-frame-enabled <bool>]";
+mod commands;
 
-fn main() {
-    let mut args = env::args().skip(1);
-    match args.next().as_deref() {
-        Some("oracle-summary") => {
-            let path = required_arg(&mut args, "usage: mmd-anim oracle-summary <oracle.jsonl>");
-            if let Err(error) = oracle_summary(&path) {
-                eprintln!("{error}");
-                std::process::exit(1);
-            }
+// ---------------------------------------------------------------------------
+// Clap CLI definition
+// ---------------------------------------------------------------------------
+
+#[derive(Parser)]
+#[command(
+    name = "mmd-anim",
+    version,
+    about = "CLI diagnostics and roundtrip tools for mmd-anim"
+)]
+struct Cli {
+    #[command(subcommand)]
+    command: Option<Commands>,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    // -- Parse commands ------------------------------------------------------
+    /// Parse a PMX model and show summary counts
+    #[command(name = "parse-pmx-summary")]
+    ParsePmxSummary {
+        /// Path to the PMX model file
+        asset: PathBuf,
+    },
+
+    /// Parse any MMD asset and show a human-readable summary
+    #[command(name = "parse-format-summary")]
+    ParseFormatSummary {
+        /// Path to the MMD asset file
+        asset: PathBuf,
+    },
+
+    /// Parse any MMD asset and output full parsed data as JSON
+    #[command(name = "parse-format-json")]
+    ParseFormatJson {
+        /// Path to the MMD asset file
+        asset: PathBuf,
+    },
+
+    // -- Import commands -----------------------------------------------------
+    /// Import a PMX model into runtime format and show summary
+    #[command(name = "import-pmx-summary")]
+    ImportPmxSummary {
+        /// Path to the PMX model file
+        model: PathBuf,
+    },
+
+    /// Import a PMX model and show IK solver details
+    #[command(name = "import-pmx-ik-summary")]
+    ImportPmxIkSummary {
+        /// Path to the PMX model file
+        model: PathBuf,
+    },
+
+    /// Import a PMD model into runtime format and show summary
+    #[command(name = "import-pmd-summary")]
+    ImportPmdSummary {
+        /// Path to the PMD model file
+        model: PathBuf,
+    },
+
+    /// Import a VMD motion and show summary
+    #[command(name = "import-vmd-summary")]
+    ImportVmdSummary {
+        /// Path to the VMD motion file
+        motion: PathBuf,
+    },
+
+    /// Import a PMX/VMD pair and show matching statistics
+    #[command(name = "import-pair-summary")]
+    ImportPairSummary {
+        /// Path to the PMX model file
+        model: PathBuf,
+        /// Path to the VMD motion file
+        motion: PathBuf,
+    },
+
+    /// Import a PMX/VMD pair and show clip build statistics
+    #[command(name = "import-pair-clip-summary")]
+    ImportPairClipSummary {
+        /// Path to the PMX model file
+        model: PathBuf,
+        /// Path to the VMD motion file
+        motion: PathBuf,
+    },
+
+    /// Import a PMX/VMD pair and evaluate a single frame
+    #[command(name = "import-pair-frame-summary")]
+    ImportPairFrameSummary {
+        /// Path to the PMX model file
+        model: PathBuf,
+        /// Path to the VMD motion file
+        motion: PathBuf,
+        /// Frame number to evaluate
+        frame: f32,
+    },
+
+    // -- Export commands ------------------------------------------------------
+    /// Export roundtrip: parse, export, re-parse and verify
+    #[command(name = "export-roundtrip-summary")]
+    ExportRoundtripSummary {
+        /// Path to the MMD asset file
+        asset: PathBuf,
+    },
+
+    /// Export roundtrip with JSON output
+    #[command(name = "export-roundtrip-json")]
+    ExportRoundtripJson {
+        /// Path to the MMD asset file
+        asset: PathBuf,
+    },
+
+    /// JSON roundtrip: parse, JSON serialize/deserialize, export, re-parse and verify
+    #[command(name = "export-json-roundtrip-summary")]
+    ExportJsonRoundtripSummary {
+        /// Path to the MMD asset file
+        asset: PathBuf,
+    },
+
+    /// JSON roundtrip with JSON output
+    #[command(name = "export-json-roundtrip-json")]
+    ExportJsonRoundtripJson {
+        /// Path to the MMD asset file
+        asset: PathBuf,
+    },
+
+    /// Export a parsed MMD asset to a binary file
+    #[command(name = "export-format")]
+    ExportFormat {
+        /// Path to the input asset file
+        input: PathBuf,
+        /// Path to the output asset file
+        output: PathBuf,
+    },
+
+    /// Export a JSON-serialized asset to a binary file
+    #[command(name = "export-json-format")]
+    ExportJsonFormat {
+        /// Path to the input JSON file
+        input: PathBuf,
+        /// Path to the output asset file
+        output: PathBuf,
+    },
+
+    /// Build a PMM scene from a PMX model and VMD motion
+    #[command(name = "export-pmm-scene")]
+    ExportPmmScene {
+        /// Path to the PMX model file
+        model: PathBuf,
+        /// Path to the VMD motion file
+        motion: PathBuf,
+        /// Path to the output PMM file
+        output: PathBuf,
+    },
+
+    // -- Bench commands ------------------------------------------------------
+    /// Benchmark animation evaluation with a PMX/VMD pair
+    #[command(name = "bench-pair")]
+    BenchPair {
+        /// All arguments (model, motion, options) passed as raw args
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
+
+    /// Benchmark animation evaluation with synthetic data
+    #[command(name = "bench-synthetic")]
+    BenchSynthetic {
+        /// All arguments passed as raw args
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
+
+    // -- Patch commands ------------------------------------------------------
+    /// Patch a PMM file's document model path
+    #[command(name = "patch-pmm-document-model-path")]
+    PatchPmmDocumentModelPath {
+        /// Path to the input PMM file
+        input: PathBuf,
+        /// Document model index (0-255)
+        document_model_index: String,
+        /// New model path to set
+        model_path: String,
+        /// Path to the output PMM file
+        output: PathBuf,
+    },
+
+    /// Patch a PMM file's scene frame range settings
+    #[command(name = "patch-pmm-scene-frame-range")]
+    PatchPmmSceneFrameRange {
+        /// Path to the input PMM file
+        input: PathBuf,
+        /// Path to the output PMM file
+        output: PathBuf,
+        /// Additional options
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        options: Vec<String>,
+    },
+
+    // -- Compare commands ----------------------------------------------------
+    /// Run numeric comparison against oracle data
+    #[command(name = "compare-numeric")]
+    CompareNumeric {
+        /// Path to the comparison manifest JSON file
+        manifest: PathBuf,
+    },
+
+    /// Run camera VMD numeric comparison against oracle data
+    #[command(name = "compare-camera-vmd-numeric")]
+    CompareCameraVmdNumeric {
+        /// Path to the comparison manifest JSON file
+        manifest: PathBuf,
+    },
+
+    /// Diagnose numeric comparison results for specific bones
+    #[command(name = "diagnose-numeric-bone")]
+    DiagnoseNumericBone {
+        /// Path to the comparison manifest JSON file
+        manifest: PathBuf,
+        /// Case name from the manifest
+        case_name: String,
+        /// Oracle frame number
+        frame: f32,
+        /// Additional options and bone names
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        rest: Vec<String>,
+    },
+
+    // -- Golden commands -----------------------------------------------------
+    /// Show golden IK oracle summary
+    #[command(name = "golden-ik-summary")]
+    GoldenIkSummary {
+        /// Path to the golden IK oracle root directory
+        root: PathBuf,
+    },
+
+    /// Compare runtime IK results against golden oracle
+    #[command(name = "golden-ik-compare")]
+    GoldenIkCompare {
+        /// All arguments passed as raw args
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
+
+    /// Diagnose a specific IK comparison case
+    #[command(name = "golden-ik-diagnose")]
+    GoldenIkDiagnose {
+        /// Path to the golden IK oracle root directory
+        root: PathBuf,
+        /// Case name
+        case_name: String,
+        /// Frame number
+        frame: i32,
+        /// Bone name to diagnose
+        bone_name: String,
+        /// Optional sample frame offset
+        offset: Option<f32>,
+    },
+
+    /// Show golden parser summary
+    #[command(name = "golden-parser-summary")]
+    GoldenParserSummary {
+        /// Path to the golden run root directory
+        root: PathBuf,
+    },
+
+    // -- Oracle commands -----------------------------------------------------
+    /// Show MMDDumper oracle file summary
+    #[command(name = "oracle-summary")]
+    OracleSummary {
+        /// Path to the oracle JSONL file
+        path: PathBuf,
+    },
+}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+fn main() -> ExitCode {
+    let cli = Cli::parse();
+
+    let result: Result<ExitCode, Box<dyn std::error::Error>> = match cli.command {
+        None => {
+            println!("mmd-anim {}", env!("CARGO_PKG_VERSION"));
+            Ok(ExitCode::SUCCESS)
         }
-        Some("golden-ik-summary") => {
-            let root = required_arg(
-                &mut args,
-                "usage: mmd-anim golden-ik-summary <golden-ik-oracle-root>",
-            );
-            if let Err(error) = golden_ik_summary(Path::new(&root)) {
-                eprintln!("{error}");
-                std::process::exit(1);
-            }
+
+        Some(Commands::ParsePmxSummary { asset }) => {
+            commands::parse::parse_pmx_summary(&asset)
         }
-        Some("golden-parser-summary") => {
-            let root = required_arg(&mut args, GOLDEN_PARSER_SUMMARY_USAGE);
-            if let Err(error) = golden_parser_summary(Path::new(&root)) {
-                eprintln!("{error}");
-                std::process::exit(1);
-            }
+        Some(Commands::ParseFormatSummary { asset }) => {
+            commands::parse::parse_format_summary(&asset)
         }
-        Some("compare-numeric") => {
-            let manifest = required_arg(&mut args, COMPARE_NUMERIC_USAGE);
-            if let Err(error) = compare_numeric_manifest(Path::new(&manifest)) {
-                eprintln!("{error}");
-                std::process::exit(1);
-            }
+        Some(Commands::ParseFormatJson { asset }) => {
+            commands::parse::parse_format_json(&asset)
         }
-        Some("compare-camera-vmd-numeric") => {
-            let manifest = required_arg(&mut args, COMPARE_NUMERIC_USAGE);
-            if let Err(error) = compare_numeric_manifest(Path::new(&manifest)) {
-                eprintln!("{error}");
-                std::process::exit(1);
-            }
+
+        Some(Commands::ImportPmxSummary { model }) => {
+            commands::import::import_pmx_summary(&model)
         }
-        Some("diagnose-numeric-bone") => {
-            let manifest = required_arg(&mut args, DIAGNOSE_NUMERIC_BONE_USAGE);
-            let case_name = required_arg(&mut args, DIAGNOSE_NUMERIC_BONE_USAGE);
-            let frame = required_arg(&mut args, DIAGNOSE_NUMERIC_BONE_USAGE);
-            let frame: f32 = frame.parse().unwrap_or_else(|_| {
-                eprintln!("{DIAGNOSE_NUMERIC_BONE_USAGE}");
-                std::process::exit(1);
-            });
-            let rest: Vec<String> = args.collect();
-            let diagnose_options = parse_diagnose_numeric_bone_rest(rest, frame);
+        Some(Commands::ImportPmxIkSummary { model }) => {
+            commands::import::import_pmx_ik_summary(&model)
+        }
+        Some(Commands::ImportPmdSummary { model }) => {
+            commands::import::import_pmd_summary(&model)
+        }
+        Some(Commands::ImportVmdSummary { motion }) => {
+            commands::import::import_vmd_summary(&motion)
+        }
+        Some(Commands::ImportPairSummary { model, motion }) => {
+            commands::import::import_pair_summary(&model, &motion)
+        }
+        Some(Commands::ImportPairClipSummary { model, motion }) => {
+            commands::import::import_pair_clip_summary(&model, &motion)
+        }
+        Some(Commands::ImportPairFrameSummary { model, motion, frame }) => {
+            commands::import::import_pair_frame_summary(&model, &motion, frame)
+        }
+
+        Some(Commands::ExportRoundtripSummary { asset }) => {
+            commands::export::export_roundtrip_summary(&asset)
+        }
+        Some(Commands::ExportRoundtripJson { asset }) => {
+            commands::export::export_roundtrip_json(&asset)
+        }
+        Some(Commands::ExportJsonRoundtripSummary { asset }) => {
+            commands::export::export_json_roundtrip_summary(&asset)
+        }
+        Some(Commands::ExportJsonRoundtripJson { asset }) => {
+            commands::export::export_json_roundtrip_json(&asset)
+        }
+        Some(Commands::ExportFormat { input, output }) => {
+            commands::export::export_format(&input, &output)
+        }
+        Some(Commands::ExportJsonFormat { input, output }) => {
+            commands::export::export_json_format(&input, &output)
+        }
+        Some(Commands::ExportPmmScene { model, motion, output }) => {
+            commands::export::export_pmm_scene(&model, &motion, &output)
+        }
+
+        Some(Commands::BenchPair { args }) => {
+            let mut iter = args.into_iter();
+            commands::bench::parse_bench_pair_args(&mut iter)
+                .and_then(commands::bench::bench_pair)
+        }
+        Some(Commands::BenchSynthetic { args }) => {
+            let mut iter = args.into_iter();
+            commands::bench::parse_bench_synthetic_args(&mut iter)
+                .and_then(commands::bench::bench_synthetic)
+        }
+
+        Some(Commands::PatchPmmDocumentModelPath { input, document_model_index, model_path, output }) => {
+            commands::patch::patch_pmm_document_model_path(&input, &document_model_index, &model_path, &output)
+        }
+        Some(Commands::PatchPmmSceneFrameRange { input, output, options }) => {
+            commands::patch::patch_pmm_scene_frame_range(&input, &output, &options)
+        }
+
+        Some(Commands::CompareNumeric { manifest }) => {
+            commands::compare::compare_numeric_manifest(&manifest)
+        }
+        Some(Commands::CompareCameraVmdNumeric { manifest }) => {
+            commands::compare::compare_numeric_manifest(&manifest)
+        }
+        Some(Commands::DiagnoseNumericBone { manifest, case_name, frame, rest }) => {
+            let diagnose_options = commands::compare::parse_diagnose_numeric_bone_rest(rest, frame);
             let eval_frame = diagnose_options.eval_frame;
             let bone_names = diagnose_options.bone_names;
             if bone_names.is_empty() {
-                eprintln!("{DIAGNOSE_NUMERIC_BONE_USAGE}");
-                std::process::exit(1);
+                eprintln!("{}", commands::compare::DIAGNOSE_NUMERIC_BONE_USAGE);
+                return ExitCode::from(2);
             }
-            if let Err(error) = diagnose_numeric_bones(
-                Path::new(&manifest),
+            commands::compare::diagnose_numeric_bones(
+                &manifest,
                 &case_name,
                 frame,
                 eval_frame,
                 &bone_names,
-            ) {
-                eprintln!("{error}");
-                std::process::exit(1);
-            }
+            )
         }
-        Some("import-pmx-summary") => {
-            let path = required_arg(&mut args, "usage: mmd-anim import-pmx-summary <model.pmx>");
-            if let Err(error) = import_pmx_summary(Path::new(&path)) {
-                eprintln!("{error}");
-                std::process::exit(1);
-            }
+
+        Some(Commands::GoldenIkSummary { root }) => {
+            golden_ik_summary(&root)
         }
-        Some("import-pmx-ik-summary") => {
-            let path = required_arg(
-                &mut args,
-                "usage: mmd-anim import-pmx-ik-summary <model.pmx>",
-            );
-            if let Err(error) = import_pmx_ik_summary(Path::new(&path)) {
-                eprintln!("{error}");
-                std::process::exit(1);
-            }
-        }
-        Some("import-pmd-summary") => {
-            let path = required_arg(&mut args, IMPORT_PMD_SUMMARY_USAGE);
-            if let Err(error) = import_pmd_summary(Path::new(&path)) {
-                eprintln!("{error}");
-                std::process::exit(1);
-            }
-        }
-        Some("parse-pmx-summary") => {
-            let path = required_arg(&mut args, PARSE_PMX_SUMMARY_USAGE);
-            if let Err(error) = parse_pmx_summary(Path::new(&path)) {
-                eprintln!("{error}");
-                std::process::exit(1);
-            }
-        }
-        Some("parse-format-summary") => {
-            let path = required_arg(&mut args, PARSE_FORMAT_USAGE);
-            if let Err(error) = parse_format_summary(Path::new(&path)) {
-                eprintln!("{error}");
-                std::process::exit(1);
-            }
-        }
-        Some("parse-format-json") => {
-            let path = required_arg(&mut args, PARSE_FORMAT_JSON_USAGE);
-            if let Err(error) = parse_format_json(Path::new(&path)) {
-                eprintln!("{error}");
-                std::process::exit(1);
-            }
-        }
-        Some("export-roundtrip-summary") => {
-            let path = required_arg(&mut args, EXPORT_ROUNDTRIP_USAGE);
-            if let Err(error) = export_roundtrip_summary(Path::new(&path)) {
-                eprintln!("{error}");
-                std::process::exit(1);
-            }
-        }
-        Some("export-roundtrip-json") => {
-            let path = required_arg(&mut args, EXPORT_ROUNDTRIP_JSON_USAGE);
-            if let Err(error) = export_roundtrip_json(Path::new(&path)) {
-                eprintln!("{error}");
-                std::process::exit(1);
-            }
-        }
-        Some("export-json-roundtrip-summary") => {
-            let path = required_arg(&mut args, EXPORT_JSON_ROUNDTRIP_USAGE);
-            if let Err(error) = export_json_roundtrip_summary(Path::new(&path)) {
-                eprintln!("{error}");
-                std::process::exit(1);
-            }
-        }
-        Some("export-json-roundtrip-json") => {
-            let path = required_arg(&mut args, EXPORT_JSON_ROUNDTRIP_JSON_USAGE);
-            if let Err(error) = export_json_roundtrip_json(Path::new(&path)) {
-                eprintln!("{error}");
-                std::process::exit(1);
-            }
-        }
-        Some("import-vmd-summary") => {
-            let path = required_arg(&mut args, "usage: mmd-anim import-vmd-summary <motion.vmd>");
-            if let Err(error) = import_vmd_summary(Path::new(&path)) {
-                eprintln!("{error}");
-                std::process::exit(1);
-            }
-        }
-        Some("import-pair-summary") => {
-            let pmx_path = required_arg(&mut args, IMPORT_PAIR_USAGE);
-            let vmd_path = required_arg(&mut args, IMPORT_PAIR_USAGE);
-            if let Err(error) = import_pair_summary(Path::new(&pmx_path), Path::new(&vmd_path)) {
-                eprintln!("{error}");
-                std::process::exit(1);
-            }
-        }
-        Some("import-pair-clip-summary") => {
-            let pmx_path = required_arg(&mut args, IMPORT_PAIR_CLIP_USAGE);
-            let vmd_path = required_arg(&mut args, IMPORT_PAIR_CLIP_USAGE);
-            if let Err(error) = import_pair_clip_summary(Path::new(&pmx_path), Path::new(&vmd_path))
-            {
-                eprintln!("{error}");
-                std::process::exit(1);
-            }
-        }
-        Some("import-pair-frame-summary") => {
-            let pmx_path = required_arg(&mut args, IMPORT_PAIR_FRAME_USAGE);
-            let vmd_path = required_arg(&mut args, IMPORT_PAIR_FRAME_USAGE);
-            let frame = required_f32_arg(&mut args, IMPORT_PAIR_FRAME_USAGE, "frame number");
-            if let Err(error) =
-                import_pair_frame_summary(Path::new(&pmx_path), Path::new(&vmd_path), frame)
-            {
-                eprintln!("{error}");
-                std::process::exit(1);
-            }
-        }
-        Some("bench-pair") => {
-            let result = parse_bench_pair_args(&mut args).and_then(bench_pair);
-            if let Err(error) = result {
-                eprintln!("{error}");
-                std::process::exit(1);
-            }
-        }
-        Some("golden-ik-compare") => {
-            let (root, offset, use_json) = match golden::parse_golden_ik_compare_args(&mut args) {
-                Ok(parsed) => parsed,
+        Some(Commands::GoldenIkCompare { args }) => {
+            let mut iter = args.into_iter();
+            match commands::golden::parse_golden_ik_compare_args(&mut iter) {
+                Ok((root, offset, use_json)) => {
+                    commands::golden::golden_ik_compare(Path::new(&root), offset, use_json)
+                }
                 Err(error) => {
                     eprintln!("{error}");
-                    std::process::exit(2);
+                    return ExitCode::from(2);
                 }
-            };
-            if let Err(error) = golden::golden_ik_compare(Path::new(&root), offset, use_json) {
-                eprintln!("{error}");
-                std::process::exit(1);
             }
         }
-        Some("golden-ik-diagnose") => {
-            let root = required_arg(&mut args, GOLDEN_IK_DIAGNOSE_USAGE);
-            let case_name = required_arg(&mut args, GOLDEN_IK_DIAGNOSE_USAGE);
-            let frame = required_i32_arg(&mut args, GOLDEN_IK_DIAGNOSE_USAGE, "frame");
-            let bone_name = required_arg(&mut args, GOLDEN_IK_DIAGNOSE_USAGE);
-            let offset = optional_f32_arg(&mut args, "sample-frame-offset");
-            if let Err(error) =
-                golden::golden_ik_diagnose(Path::new(&root), &case_name, frame, &bone_name, offset)
-            {
-                eprintln!("{error}");
-                std::process::exit(1);
-            }
-        }
-        Some("bench-synthetic") => {
-            let result = parse_bench_synthetic_args(&mut args).and_then(bench_synthetic);
-            if let Err(error) = result {
-                eprintln!("{error}");
-                std::process::exit(1);
-            }
-        }
-        Some("export-format") => {
-            let input = required_arg(&mut args, EXPORT_FORMAT_USAGE);
-            let output = required_arg(&mut args, EXPORT_FORMAT_USAGE);
-            if let Err(error) = export_format(Path::new(&input), Path::new(&output)) {
-                eprintln!("{error}");
-                std::process::exit(1);
-            }
-        }
-        Some("export-pmm-scene") => {
-            let model = required_arg(&mut args, EXPORT_PMM_SCENE_USAGE);
-            let motion = required_arg(&mut args, EXPORT_PMM_SCENE_USAGE);
-            let output = required_arg(&mut args, EXPORT_PMM_SCENE_USAGE);
-            if let Err(error) =
-                export_pmm_scene(Path::new(&model), Path::new(&motion), Path::new(&output))
-            {
-                eprintln!("{error}");
-                std::process::exit(1);
-            }
-        }
-        Some("patch-pmm-document-model-path") => {
-            let input = required_arg(&mut args, PATCH_PMM_DOCUMENT_MODEL_PATH_USAGE);
-            let index = required_arg(&mut args, PATCH_PMM_DOCUMENT_MODEL_PATH_USAGE);
-            let model_path = required_arg(&mut args, PATCH_PMM_DOCUMENT_MODEL_PATH_USAGE);
-            let output = required_arg(&mut args, PATCH_PMM_DOCUMENT_MODEL_PATH_USAGE);
-            if let Err(error) = patch_pmm_document_model_path(
-                Path::new(&input),
-                &index,
-                &model_path,
-                Path::new(&output),
-            ) {
-                eprintln!("{error}");
-                std::process::exit(1);
-            }
-        }
-        Some("patch-pmm-scene-frame-range") => {
-            let input = required_arg(&mut args, PATCH_PMM_SCENE_FRAME_RANGE_USAGE);
-            let output = required_arg(&mut args, PATCH_PMM_SCENE_FRAME_RANGE_USAGE);
-            let rest: Vec<String> = args.collect();
-            if let Err(error) =
-                patch_pmm_scene_frame_range(Path::new(&input), Path::new(&output), &rest)
-            {
-                eprintln!("{error}");
-                std::process::exit(1);
-            }
-        }
-        Some("export-json-format") => {
-            let input = required_arg(&mut args, EXPORT_JSON_FORMAT_USAGE);
-            let output = required_arg(&mut args, EXPORT_JSON_FORMAT_USAGE);
-            if let Err(error) = export_json_format(Path::new(&input), Path::new(&output)) {
-                eprintln!("{error}");
-                std::process::exit(1);
-            }
-        }
-        Some("--version") | Some("-V") => println!("mmd-anim {}", env!("CARGO_PKG_VERSION")),
-        None => println!("mmd-anim {}", env!("CARGO_PKG_VERSION")),
-        Some(command) => {
-            eprintln!("unknown command: {command}");
-            std::process::exit(2);
-        }
-    }
-}
-
-fn required_arg(args: &mut impl Iterator<Item = String>, usage: &str) -> String {
-    match args.next() {
-        Some(value) => value,
-        None => {
-            eprintln!("{usage}");
-            std::process::exit(2);
-        }
-    }
-}
-
-fn required_f32_arg(args: &mut impl Iterator<Item = String>, usage: &str, label: &str) -> f32 {
-    let value = required_arg(args, usage);
-    match value.parse::<f32>() {
-        Ok(parsed) => parsed,
-        Err(_) => {
-            eprintln!("invalid {label}: {value}");
-            std::process::exit(2);
-        }
-    }
-}
-
-fn required_i32_arg(args: &mut impl Iterator<Item = String>, usage: &str, label: &str) -> i32 {
-    let value = required_arg(args, usage);
-    match value.parse::<i32>() {
-        Ok(parsed) => parsed,
-        Err(_) => {
-            eprintln!("invalid {label}: {value}");
-            std::process::exit(2);
-        }
-    }
-}
-
-fn optional_f32_arg(args: &mut impl Iterator<Item = String>, label: &str) -> f32 {
-    match args.next() {
-        Some(value) => match value.parse::<f32>() {
-            Ok(parsed) => parsed,
-            Err(_) => {
-                eprintln!("invalid {label}: {value}");
-                std::process::exit(2);
-            }
-        },
-        None => 0.0,
-    }
-}
-
-fn import_pmx_summary(path: &Path) -> Result<ExitCode, Box<dyn std::error::Error>> {
-    let data = fs::read(path)?;
-    let imported = mmd_anim_format::import_pmx_runtime(&data)?;
-    println!(
-        "PMX runtime import: bones={} append={} fixedAxis={} ik={} boneNames={} morphNames={} ikNameMap={}",
-        imported.model.bone_count(),
-        imported.model.append_transforms().len(),
-        imported.model.fixed_axis_count(),
-        imported.model.ik_count(),
-        imported.bone_name_to_index.len(),
-        imported.morph_name_to_index.len(),
-        imported.ik_solver_bone_name_to_index.len()
-    );
-    Ok(ExitCode::SUCCESS)
-}
-
-fn import_pmx_ik_summary(path: &Path) -> Result<ExitCode, Box<dyn std::error::Error>> {
-    let data = fs::read(path)?;
-    let imported = mmd_anim_format::import_pmx_runtime(&data)?;
-    let solvers = imported.model.ik_solvers();
-    let max_iterations = solvers
-        .iter()
-        .map(|solver| solver.iteration_count)
-        .max()
-        .unwrap_or(0);
-    let mut distribution = BTreeMap::<u32, usize>::new();
-    for solver in solvers {
-        *distribution.entry(solver.iteration_count).or_default() += 1;
-    }
-    let distribution = distribution
-        .iter()
-        .map(|(iterations, count)| format!("{iterations}:{count}"))
-        .collect::<Vec<_>>()
-        .join(",");
-
-    println!(
-        "PMX IK summary: bones={} ik={} maxIterations={} distribution={}",
-        imported.model.bone_count(),
-        solvers.len(),
-        max_iterations,
-        distribution
-    );
-    for (solver_index, solver) in solvers.iter().enumerate() {
-        if solver.iteration_count == max_iterations {
-            let name = imported
-                .bone_names
-                .get(solver.ik_bone.as_usize())
-                .map(String::as_str)
-                .unwrap_or("<unknown>");
-            println!(
-                "max IK: solver={} bone={} name={} target={} iterations={} limitAngle={:.6} links={}",
-                solver_index,
-                solver.ik_bone.as_usize(),
-                name,
-                solver.target_bone.as_usize(),
-                solver.iteration_count,
-                solver.limit_angle,
-                solver.links.len()
-            );
-        }
-    }
-    Ok(ExitCode::SUCCESS)
-}
-
-fn import_pmd_summary(path: &Path) -> Result<ExitCode, Box<dyn std::error::Error>> {
-    let data = fs::read(path)?;
-    let imported = mmd_anim_format::import_pmd_runtime(&data)?;
-    println!(
-        "PMD runtime import: bones={} ik={} morphSlots={} vertexMorphOffsets={} boneNames={} morphNames={} ikNameMap={} diagnostics={}",
-        imported.model.bone_count(),
-        imported.model.ik_count(),
-        imported.model.morph_count(),
-        imported.model.vertex_morph_offsets().len(),
-        imported.bone_name_to_index.len(),
-        imported.morph_name_to_index.len(),
-        imported.ik_solver_bone_name_to_index.len(),
-        imported.diagnostics.len()
-    );
-    Ok(ExitCode::SUCCESS)
-}
-
-fn parse_pmx_summary(path: &Path) -> Result<ExitCode, Box<dyn std::error::Error>> {
-    let data = fs::read(path)?;
-    let parsed = mmd_anim_format::parse_pmx_model(&data)?;
-    println!(
-        "PMX parser: vertices={} faces={} materials={} bones={} morphs={} displayFrames={} rigidBodies={} joints={} softBodies={} diagnostics={}",
-        parsed.metadata.counts.vertices,
-        parsed.metadata.counts.faces,
-        parsed.metadata.counts.materials,
-        parsed.metadata.counts.bones,
-        parsed.metadata.counts.morphs,
-        parsed.metadata.counts.display_frames,
-        parsed.metadata.counts.rigid_bodies,
-        parsed.metadata.counts.joints,
-        parsed.metadata.counts.soft_bodies,
-        parsed.diagnostics.len()
-    );
-    Ok(ExitCode::SUCCESS)
-}
-
-fn parse_format_summary(path: &Path) -> Result<ExitCode, Box<dyn std::error::Error>> {
-    let data = fs::read(path)?;
-    match mmd_anim_format::detect_mmd_format(&data, path.file_name().and_then(|v| v.to_str())) {
-        mmd_anim_format::MmdFormatKind::Pmx => parse_pmx_summary(path),
-        mmd_anim_format::MmdFormatKind::Pmd => {
-            let parsed = mmd_anim_format::parse_pmd_model(&data)?;
-            println!(
-                "PMD parser: vertices={} faces={} materials={} bones={} ik={} morphs={} displayFrames={} rigidBodies={} joints={}",
-                parsed.metadata.counts.vertices,
-                parsed.metadata.counts.faces,
-                parsed.metadata.counts.materials,
-                parsed.metadata.counts.bones,
-                parsed.metadata.counts.ik,
-                parsed.metadata.counts.morphs,
-                parsed.metadata.counts.display_frames,
-                parsed.metadata.counts.rigid_bodies,
-                parsed.metadata.counts.joints
-            );
-            Ok(ExitCode::SUCCESS)
-        }
-        mmd_anim_format::MmdFormatKind::Vmd => {
-            let parsed = mmd_anim_format::parse_vmd_animation(&data)?;
-            println!(
-                "VMD parser: boneFrames={} morphFrames={} cameraFrames={} lightFrames={} selfShadowFrames={} propertyFrames={} maxFrame={}",
-                parsed.metadata.counts.bones,
-                parsed.metadata.counts.morphs,
-                parsed.metadata.counts.cameras,
-                parsed.metadata.counts.lights,
-                parsed.metadata.counts.self_shadows,
-                parsed.metadata.counts.properties,
-                parsed.metadata.max_frame
-            );
-            Ok(ExitCode::SUCCESS)
-        }
-        mmd_anim_format::MmdFormatKind::Vpd => {
-            let parsed = mmd_anim_format::parse_vpd_pose(&data)?;
-            println!(
-                "VPD parser: bones={} diagnostics={}",
-                parsed.bone_count,
-                parsed.diagnostics.len()
-            );
-            Ok(ExitCode::SUCCESS)
-        }
-        mmd_anim_format::MmdFormatKind::Pmm => {
-            let parsed = mmd_anim_format::parse_pmm_manifest(&data)?;
-            let model_slot_flag_counts = parsed
-                .display_state
-                .model_slot_flag_counts
-                .iter()
-                .map(|(flag, count)| format!("{flag}:{count}"))
-                .collect::<Vec<_>>()
-                .join(",");
-            let asset_kind_counts = parsed
-                .asset_summary
-                .kind_counts
-                .iter()
-                .map(|(kind, count)| format!("{kind}:{count}"))
-                .collect::<Vec<_>>()
-                .join(",");
-            let asset_extension_counts = parsed
-                .asset_summary
-                .extension_counts
-                .iter()
-                .map(|(extension, count)| format!("{extension}:{count}"))
-                .collect::<Vec<_>>()
-                .join(",");
-            let first_model_slot_padding = parsed
-                .model_slots
-                .first()
-                .map(|slot| slot.trailing_zero_padding_bytes.to_string())
-                .unwrap_or_else(|| "unknown".to_owned());
-            let first_model_slot_next_non_zero = parsed
-                .model_slots
-                .first()
-                .and_then(|slot| slot.next_non_zero_offset)
-                .map(|offset| offset.to_string())
-                .unwrap_or_else(|| "unknown".to_owned());
-            let document_models = parsed
-                .document_summary
-                .as_ref()
-                .map(|document| document.counts.models.to_string())
-                .unwrap_or_else(|| "unknown".to_owned());
-            let document_bone_keyframes = parsed
-                .document_summary
-                .as_ref()
-                .map(|document| document.counts.bone_keyframes.to_string())
-                .unwrap_or_else(|| "unknown".to_owned());
-            let document_morph_keyframes = parsed
-                .document_summary
-                .as_ref()
-                .map(|document| document.counts.morph_keyframes.to_string())
-                .unwrap_or_else(|| "unknown".to_owned());
-            let global_camera_keyframes = parsed
-                .document_global_summary
-                .as_ref()
-                .map(|g| (g.camera.initial_keyframes + g.camera.keyframes).to_string())
-                .unwrap_or_else(|| "unknown".to_owned());
-            let global_light_keyframes = parsed
-                .document_global_summary
-                .as_ref()
-                .map(|g| (g.light.initial_keyframes + g.light.keyframes).to_string())
-                .unwrap_or_else(|| "unknown".to_owned());
-            let global_accessory_count = parsed
-                .document_global_summary
-                .as_ref()
-                .map(|g| g.accessories.accessory_count.to_string())
-                .unwrap_or_else(|| "unknown".to_owned());
-            let global_accessory_keyframes = parsed
-                .document_global_summary
-                .as_ref()
-                .map(|g| g.accessories.keyframes.to_string())
-                .unwrap_or_else(|| "unknown".to_owned());
-            let global_gravity_keyframes = parsed
-                .document_global_summary
-                .as_ref()
-                .map(|g| (g.gravity.initial_keyframes + g.gravity.keyframes).to_string())
-                .unwrap_or_else(|| "unknown".to_owned());
-            let global_self_shadow_keyframes = parsed
-                .document_global_summary
-                .as_ref()
-                .map(|g| (g.self_shadow.initial_keyframes + g.self_shadow.keyframes).to_string())
-                .unwrap_or_else(|| "unknown".to_owned());
-            let global_audio_path = parsed
-                .document_global_summary
-                .as_ref()
-                .map(|g| (!g.settings.audio_path.is_empty()).to_string())
-                .unwrap_or_else(|| "unknown".to_owned());
-            let global_bg_video_path = parsed
-                .document_global_summary
-                .as_ref()
-                .map(|g| (!g.settings.background_video_path.is_empty()).to_string())
-                .unwrap_or_else(|| "unknown".to_owned());
-            let global_bg_image_path = parsed
-                .document_global_summary
-                .as_ref()
-                .map(|g| (!g.settings.background_image_path.is_empty()).to_string())
-                .unwrap_or_else(|| "unknown".to_owned());
-            println!(
-                "PMM parser: references={} version={} parsedVersion={} models={} accessories={} motions={} audio={} images={} videos={} modelAssets={} modelSlots={} firstModelSlotPadding={} firstModelSlotNextNonZeroOffset={} documentModels={} documentBoneKeyframes={} documentMorphKeyframes={} headerTextEntries={} audioAssets={} assetConfidence=high:{} medium:{} low:{} assetKindCounts={} assetExtensionCounts={} screen={}x{} timelineFrames={} timelineRange={}..{} frameRate={} durationSeconds={} displayLayout={} selectedModelIndex={} documentModelCount={} declaredModelSlotCount={} modelSlotCount={} nonZeroModelSlotCount={} modelSlotFlags={} activeModelSlotIndices={} emptyModelSlotIndices={} modelSlotFlagCounts={} accessorySlotCount={} globalCameraKeyframes={} globalLightKeyframes={} globalAccessoryCount={} globalAccessoryKeyframes={} globalGravityKeyframes={} globalSelfShadowKeyframes={} globalAudioPath={} globalBgVideoPath={} globalBgImagePath={} diagnostics={}",
-                parsed.asset_summary.reference_count,
-                parsed.version,
-                parsed
-                    .parsed_version
-                    .map(|value| value.to_string())
-                    .unwrap_or_else(|| "unknown".to_owned()),
-                parsed.model_paths.len(),
-                parsed.accessory_paths.len(),
-                parsed.motion_paths.len(),
-                parsed.audio_paths.len(),
-                parsed.image_paths.len(),
-                parsed.video_paths.len(),
-                parsed.model_assets.len(),
-                parsed.model_slots.len(),
-                first_model_slot_padding,
-                first_model_slot_next_non_zero,
-                document_models,
-                document_bone_keyframes,
-                document_morph_keyframes,
-                parsed.header_text_entries.len(),
-                parsed.audio_assets.len(),
-                parsed.asset_summary.high_confidence_count,
-                parsed.asset_summary.medium_confidence_count,
-                parsed.asset_summary.low_confidence_count,
-                asset_kind_counts,
-                asset_extension_counts,
-                parsed
-                    .project_settings
-                    .screen_width
-                    .map(|value| value.to_string())
-                    .unwrap_or_else(|| "unknown".to_owned()),
-                parsed
-                    .project_settings
-                    .screen_height
-                    .map(|value| value.to_string())
-                    .unwrap_or_else(|| "unknown".to_owned()),
-                parsed
-                    .project_settings
-                    .timeline_frame_count
-                    .map(|value| value.to_string())
-                    .unwrap_or_else(|| "unknown".to_owned()),
-                parsed
-                    .timeline
-                    .start_frame
-                    .map(|value| value.to_string())
-                    .unwrap_or_else(|| "unknown".to_owned()),
-                parsed
-                    .timeline
-                    .end_frame_exclusive
-                    .map(|value| value.to_string())
-                    .unwrap_or_else(|| "unknown".to_owned()),
-                parsed
-                    .project_settings
-                    .frame_rate
-                    .map(|value| value.to_string())
-                    .unwrap_or_else(|| "unknown".to_owned()),
-                parsed
-                    .timeline
-                    .duration_seconds
-                    .map(|value| value.to_string())
-                    .unwrap_or_else(|| "unknown".to_owned()),
-                parsed.display_state.layout,
-                parsed
-                    .display_state
-                    .selected_model_index
-                    .map(|value| value.to_string())
-                    .unwrap_or_else(|| "unknown".to_owned()),
-                parsed
-                    .display_state
-                    .document_model_count
-                    .map(|value| value.to_string())
-                    .unwrap_or_else(|| "unknown".to_owned()),
-                parsed
-                    .display_state
-                    .declared_model_slot_count
-                    .map(|value| value.to_string())
-                    .unwrap_or_else(|| "unknown".to_owned()),
-                parsed.display_state.model_slot_count,
-                parsed.display_state.non_zero_model_slot_count,
-                parsed
-                    .display_state
-                    .model_slot_flags
-                    .iter()
-                    .map(|flag| flag.to_string())
-                    .collect::<Vec<_>>()
-                    .join(","),
-                parsed
-                    .display_state
-                    .active_model_slot_indices
-                    .iter()
-                    .map(|index| index.to_string())
-                    .collect::<Vec<_>>()
-                    .join(","),
-                parsed
-                    .display_state
-                    .empty_model_slot_indices
-                    .iter()
-                    .map(|index| index.to_string())
-                    .collect::<Vec<_>>()
-                    .join(","),
-                model_slot_flag_counts,
-                parsed
-                    .display_state
-                    .accessory_slot_count
-                    .map(|value| value.to_string())
-                    .unwrap_or_else(|| "unknown".to_owned()),
-                global_camera_keyframes,
-                global_light_keyframes,
-                global_accessory_count,
-                global_accessory_keyframes,
-                global_gravity_keyframes,
-                global_self_shadow_keyframes,
-                global_audio_path,
-                global_bg_video_path,
-                global_bg_image_path,
-                parsed.diagnostics.len()
-            );
-            Ok(ExitCode::SUCCESS)
-        }
-        mmd_anim_format::MmdFormatKind::X | mmd_anim_format::MmdFormatKind::Vac => {
-            let parsed = mmd_anim_format::parse_accessory_manifest(
-                &data,
-                path.file_name().and_then(|v| v.to_str()),
-            )?;
-            println!(
-                "{} parser: byteLength={} meshes={} materials={} textures={} diagnostics={}",
-                parsed.format.to_uppercase(),
-                parsed.byte_length,
-                parsed.mesh_count,
-                parsed.material_count,
-                parsed.texture_references.len(),
-                parsed.diagnostics.len()
-            );
-            Ok(ExitCode::SUCCESS)
-        }
-        mmd_anim_format::MmdFormatKind::Nmd => {
-            let parsed = mmd_anim_format::parse_nmd_manifest(&data)?;
-            println!(
-                "NMD parser: byteLength={} annotations={} globalTracks={} bundles={{accessory:{}, bone:{}, camera:{}, light:{}, model:{}, morph:{}, selfShadow:{}, unknown:{}}} diagnostics={}",
-                parsed.byte_length,
-                parsed.metadata.annotation_count,
-                parsed.global_track_count,
-                parsed.keyframe_bundles.accessory,
-                parsed.keyframe_bundles.bone,
-                parsed.keyframe_bundles.camera,
-                parsed.keyframe_bundles.light,
-                parsed.keyframe_bundles.model,
-                parsed.keyframe_bundles.morph,
-                parsed.keyframe_bundles.self_shadow,
-                parsed.keyframe_bundles.unknown,
-                parsed.diagnostics.len()
-            );
-            Ok(ExitCode::SUCCESS)
-        }
-        mmd_anim_format::MmdFormatKind::Unknown => Err("unknown MMD format".into()),
-    }
-}
-
-fn parse_format_json(path: &Path) -> Result<ExitCode, Box<dyn std::error::Error>> {
-    let data = fs::read(path)?;
-    let value = match mmd_anim_format::detect_mmd_format(
-        &data,
-        path.file_name().and_then(|v| v.to_str()),
-    ) {
-        mmd_anim_format::MmdFormatKind::Pmx => {
-            serde_json::to_value(mmd_anim_format::parse_pmx_model(&data)?)?
-        }
-        mmd_anim_format::MmdFormatKind::Pmd => {
-            serde_json::to_value(mmd_anim_format::parse_pmd_model(&data)?)?
-        }
-        mmd_anim_format::MmdFormatKind::Vmd => {
-            serde_json::to_value(mmd_anim_format::parse_vmd_animation(&data)?)?
-        }
-        mmd_anim_format::MmdFormatKind::Vpd => {
-            serde_json::to_value(mmd_anim_format::parse_vpd_pose(&data)?)?
-        }
-        mmd_anim_format::MmdFormatKind::Pmm => {
-            serde_json::to_value(mmd_anim_format::parse_pmm_manifest(&data)?)?
-        }
-        mmd_anim_format::MmdFormatKind::X | mmd_anim_format::MmdFormatKind::Vac => {
-            serde_json::to_value(mmd_anim_format::parse_accessory_manifest(
-                &data,
-                path.file_name().and_then(|v| v.to_str()),
-            )?)?
-        }
-        mmd_anim_format::MmdFormatKind::Nmd => {
-            serde_json::to_value(mmd_anim_format::parse_nmd_manifest(&data)?)?
-        }
-        mmd_anim_format::MmdFormatKind::Unknown => return Err("unknown MMD format".into()),
-    };
-    println!("{}", serde_json::to_string_pretty(&value)?);
-    Ok(ExitCode::SUCCESS)
-}
-
-fn export_roundtrip_summary(path: &Path) -> Result<ExitCode, Box<dyn std::error::Error>> {
-    let data = fs::read(path)?;
-    match mmd_anim_format::detect_mmd_format(&data, path.file_name().and_then(|v| v.to_str())) {
-        mmd_anim_format::MmdFormatKind::Vmd => {
-            let parsed = mmd_anim_format::parse_vmd_animation(&data)?;
-            let exported = mmd_anim_format::export_vmd_animation(&parsed);
-            let reparsed = mmd_anim_format::parse_vmd_animation(&exported)?;
-            ensure_vmd_roundtrip(&parsed, &reparsed)?;
-            println!(
-                "VMD export roundtrip: ok bytesIn={} bytesOut={} boneFrames={} morphFrames={} cameraFrames={} lightFrames={} selfShadowFrames={} propertyFrames={} maxFrame={}",
-                data.len(),
-                exported.len(),
-                parsed.metadata.counts.bones,
-                parsed.metadata.counts.morphs,
-                parsed.metadata.counts.cameras,
-                parsed.metadata.counts.lights,
-                parsed.metadata.counts.self_shadows,
-                parsed.metadata.counts.properties,
-                parsed.metadata.max_frame
-            );
-            Ok(ExitCode::SUCCESS)
-        }
-        mmd_anim_format::MmdFormatKind::Vpd => {
-            let parsed = mmd_anim_format::parse_vpd_pose(&data)?;
-            let exported = mmd_anim_format::export_vpd_pose(&parsed);
-            let reparsed = mmd_anim_format::parse_vpd_pose(&exported)?;
-            ensure_vpd_roundtrip(&parsed, &reparsed)?;
-            println!(
-                "VPD export roundtrip: ok bytesIn={} bytesOut={} bones={}",
-                data.len(),
-                exported.len(),
-                parsed.bone_count
-            );
-            Ok(ExitCode::SUCCESS)
-        }
-        mmd_anim_format::MmdFormatKind::Pmx => {
-            let parsed = mmd_anim_format::parse_pmx_model(&data)?;
-            let exported = mmd_anim_format::export_pmx_model(&parsed);
-            let reparsed = mmd_anim_format::parse_pmx_model(&exported)?;
-            ensure_pmx_roundtrip(&parsed, &reparsed)?;
-            println!(
-                "PMX export roundtrip: ok bytesIn={} bytesOut={} vertices={} faces={} materials={} bones={} morphs={} displayFrames={} rigidBodies={} joints={} softBodies={}",
-                data.len(),
-                exported.len(),
-                parsed.metadata.counts.vertices,
-                parsed.metadata.counts.faces,
-                parsed.metadata.counts.materials,
-                parsed.metadata.counts.bones,
-                parsed.metadata.counts.morphs,
-                parsed.metadata.counts.display_frames,
-                parsed.metadata.counts.rigid_bodies,
-                parsed.metadata.counts.joints,
-                parsed.metadata.counts.soft_bodies
-            );
-            Ok(ExitCode::SUCCESS)
-        }
-        mmd_anim_format::MmdFormatKind::Pmd => {
-            let parsed = mmd_anim_format::parse_pmd_model(&data)?;
-            let exported = mmd_anim_format::export_pmd_model(&parsed);
-            let reparsed = mmd_anim_format::parse_pmd_model(&exported)?;
-            ensure_pmd_roundtrip(&parsed, &reparsed)?;
-            println!(
-                "PMD export roundtrip: ok bytesIn={} bytesOut={} vertices={} faces={} materials={} bones={} ik={} morphs={} displayFrames={} rigidBodies={} joints={}",
-                data.len(),
-                exported.len(),
-                parsed.metadata.counts.vertices,
-                parsed.metadata.counts.faces,
-                parsed.metadata.counts.materials,
-                parsed.metadata.counts.bones,
-                parsed.metadata.counts.ik,
-                parsed.metadata.counts.morphs,
-                parsed.metadata.counts.display_frames,
-                parsed.metadata.counts.rigid_bodies,
-                parsed.metadata.counts.joints
-            );
-            Ok(ExitCode::SUCCESS)
-        }
-        mmd_anim_format::MmdFormatKind::Pmm => {
-            let parsed = mmd_anim_format::parse_pmm_manifest(&data)?;
-            let exported = mmd_anim_format::export_pmm_manifest(&parsed);
-            let _reparsed = mmd_anim_format::parse_pmm_manifest(&exported)?;
-            ensure_pmm_lossless_roundtrip(&data, &exported)?;
-            println!(
-                "PMM export roundtrip: ok bytesIn={} bytesOut={} version={} modelReferences={} assetReferences={} diagnostics={}",
-                data.len(),
-                exported.len(),
-                parsed.version,
-                parsed.model_paths.len(),
-                parsed.asset_summary.reference_count,
-                parsed.diagnostics.len()
-            );
-            Ok(ExitCode::SUCCESS)
-        }
-        mmd_anim_format::MmdFormatKind::X | mmd_anim_format::MmdFormatKind::Vac => {
-            let file_name = path.file_name().and_then(|v| v.to_str());
-            let parsed = mmd_anim_format::parse_accessory_manifest(&data, file_name)?;
-            let exported = mmd_anim_format::export_accessory_manifest(&parsed);
-            let reparsed = mmd_anim_format::parse_accessory_manifest(&exported, file_name)?;
-            ensure_accessory_roundtrip(&parsed, &reparsed)?;
-            println!(
-                "{} export roundtrip: ok bytesIn={} bytesOut={} textures={} diagnostics={}",
-                parsed.format.to_ascii_uppercase(),
-                data.len(),
-                exported.len(),
-                parsed.texture_references.len(),
-                parsed.diagnostics.len()
-            );
-            Ok(ExitCode::SUCCESS)
-        }
-        kind => Err(format!("export roundtrip is not implemented for {kind:?}").into()),
-    }
-}
-
-fn export_roundtrip_json(path: &Path) -> Result<ExitCode, Box<dyn std::error::Error>> {
-    let data = fs::read(path)?;
-    let result = match mmd_anim_format::detect_mmd_format(
-        &data,
-        path.file_name().and_then(|v| v.to_str()),
-    ) {
-        mmd_anim_format::MmdFormatKind::Vmd => {
-            let parsed = mmd_anim_format::parse_vmd_animation(&data)?;
-            let exported = mmd_anim_format::export_vmd_animation(&parsed);
-            let reparsed = mmd_anim_format::parse_vmd_animation(&exported)?;
-            ensure_vmd_roundtrip(&parsed, &reparsed)?;
-            vmd_roundtrip_json(
-                path,
-                "parse-export-parse",
-                data.len(),
-                exported.len(),
-                None,
-                &parsed,
+        Some(Commands::GoldenIkDiagnose { root, case_name, frame, bone_name, offset }) => {
+            commands::golden::golden_ik_diagnose(
+                &root,
+                &case_name,
+                frame,
+                &bone_name,
+                offset.unwrap_or(0.0),
             )
         }
-        mmd_anim_format::MmdFormatKind::Vpd => {
-            let parsed = mmd_anim_format::parse_vpd_pose(&data)?;
-            let exported = mmd_anim_format::export_vpd_pose(&parsed);
-            let reparsed = mmd_anim_format::parse_vpd_pose(&exported)?;
-            ensure_vpd_roundtrip(&parsed, &reparsed)?;
-            vpd_roundtrip_json(
-                path,
-                "parse-export-parse",
-                data.len(),
-                exported.len(),
-                None,
-                &parsed,
-            )
+        Some(Commands::GoldenParserSummary { root }) => {
+            golden_parser_summary(&root)
         }
-        mmd_anim_format::MmdFormatKind::Pmx => {
-            let parsed = mmd_anim_format::parse_pmx_model(&data)?;
-            let exported = mmd_anim_format::export_pmx_model(&parsed);
-            let reparsed = mmd_anim_format::parse_pmx_model(&exported)?;
-            ensure_pmx_roundtrip(&parsed, &reparsed)?;
-            pmx_roundtrip_json(
-                path,
-                "parse-export-parse",
-                data.len(),
-                exported.len(),
-                None,
-                &parsed,
-            )
-        }
-        mmd_anim_format::MmdFormatKind::Pmd => {
-            let parsed = mmd_anim_format::parse_pmd_model(&data)?;
-            let exported = mmd_anim_format::export_pmd_model(&parsed);
-            let reparsed = mmd_anim_format::parse_pmd_model(&exported)?;
-            ensure_pmd_roundtrip(&parsed, &reparsed)?;
-            pmd_roundtrip_json(
-                path,
-                "parse-export-parse",
-                data.len(),
-                exported.len(),
-                None,
-                &parsed,
-            )
-        }
-        mmd_anim_format::MmdFormatKind::Pmm => {
-            let parsed = mmd_anim_format::parse_pmm_manifest(&data)?;
-            let exported = mmd_anim_format::export_pmm_manifest(&parsed);
-            let _reparsed = mmd_anim_format::parse_pmm_manifest(&exported)?;
-            ensure_pmm_lossless_roundtrip(&data, &exported)?;
-            pmm_roundtrip_json(
-                path,
-                "parse-export-parse-lossless",
-                data.len(),
-                exported.len(),
-                data == exported,
-                &parsed,
-            )
-        }
-        mmd_anim_format::MmdFormatKind::X | mmd_anim_format::MmdFormatKind::Vac => {
-            let file_name = path.file_name().and_then(|v| v.to_str());
-            let parsed = mmd_anim_format::parse_accessory_manifest(&data, file_name)?;
-            let exported = mmd_anim_format::export_accessory_manifest(&parsed);
-            let reparsed = mmd_anim_format::parse_accessory_manifest(&exported, file_name)?;
-            ensure_accessory_roundtrip(&parsed, &reparsed)?;
-            accessory_roundtrip_json(
-                path,
-                "parse-export-parse",
-                data.len(),
-                exported.len(),
-                None,
-                &parsed,
-            )
-        }
-        kind => return Err(format!("export roundtrip is not implemented for {kind:?}").into()),
-    };
-    println!("{}", serde_json::to_string_pretty(&result)?);
-    Ok(ExitCode::SUCCESS)
-}
 
-fn export_json_roundtrip_summary(path: &Path) -> Result<ExitCode, Box<dyn std::error::Error>> {
-    let data = fs::read(path)?;
-    match mmd_anim_format::detect_mmd_format(&data, path.file_name().and_then(|v| v.to_str())) {
-        mmd_anim_format::MmdFormatKind::Vmd => {
-            let parsed = mmd_anim_format::parse_vmd_animation(&data)?;
-            let json = serde_json::to_string(&parsed)?;
-            let from_json: mmd_anim_format::VmdParsedAnimation = serde_json::from_str(&json)?;
-            let exported = mmd_anim_format::export_vmd_animation(&from_json);
-            let reparsed = mmd_anim_format::parse_vmd_animation(&exported)?;
-            ensure_vmd_roundtrip(&parsed, &reparsed)?;
-            println!(
-                "VMD export JSON roundtrip: ok jsonBytes={} bytesIn={} bytesOut={} boneFrames={} morphFrames={} cameraFrames={} lightFrames={} selfShadowFrames={} propertyFrames={} maxFrame={}",
-                json.len(),
-                data.len(),
-                exported.len(),
-                parsed.metadata.counts.bones,
-                parsed.metadata.counts.morphs,
-                parsed.metadata.counts.cameras,
-                parsed.metadata.counts.lights,
-                parsed.metadata.counts.self_shadows,
-                parsed.metadata.counts.properties,
-                parsed.metadata.max_frame
-            );
-            Ok(ExitCode::SUCCESS)
-        }
-        mmd_anim_format::MmdFormatKind::Vpd => {
-            let parsed = mmd_anim_format::parse_vpd_pose(&data)?;
-            let json = serde_json::to_string(&parsed)?;
-            let from_json: mmd_anim_format::VpdParsedPose = serde_json::from_str(&json)?;
-            let exported = mmd_anim_format::export_vpd_pose(&from_json);
-            let reparsed = mmd_anim_format::parse_vpd_pose(&exported)?;
-            ensure_vpd_roundtrip(&parsed, &reparsed)?;
-            println!(
-                "VPD export JSON roundtrip: ok jsonBytes={} bytesIn={} bytesOut={} bones={}",
-                json.len(),
-                data.len(),
-                exported.len(),
-                parsed.bone_count
-            );
-            Ok(ExitCode::SUCCESS)
-        }
-        mmd_anim_format::MmdFormatKind::Pmx => {
-            let parsed = mmd_anim_format::parse_pmx_model(&data)?;
-            let json = serde_json::to_string(&parsed)?;
-            let from_json: mmd_anim_format::PmxParsedModel = serde_json::from_str(&json)?;
-            let exported = mmd_anim_format::export_pmx_model(&from_json);
-            let reparsed = mmd_anim_format::parse_pmx_model(&exported)?;
-            ensure_pmx_roundtrip(&parsed, &reparsed)?;
-            println!(
-                "PMX export JSON roundtrip: ok jsonBytes={} bytesIn={} bytesOut={} vertices={} faces={} materials={} bones={} morphs={} displayFrames={} rigidBodies={} joints={} softBodies={}",
-                json.len(),
-                data.len(),
-                exported.len(),
-                parsed.metadata.counts.vertices,
-                parsed.metadata.counts.faces,
-                parsed.metadata.counts.materials,
-                parsed.metadata.counts.bones,
-                parsed.metadata.counts.morphs,
-                parsed.metadata.counts.display_frames,
-                parsed.metadata.counts.rigid_bodies,
-                parsed.metadata.counts.joints,
-                parsed.metadata.counts.soft_bodies
-            );
-            Ok(ExitCode::SUCCESS)
-        }
-        mmd_anim_format::MmdFormatKind::Pmd => {
-            let parsed = mmd_anim_format::parse_pmd_model(&data)?;
-            let json = serde_json::to_string(&parsed)?;
-            let from_json: mmd_anim_format::PmdParsedModel = serde_json::from_str(&json)?;
-            let exported = mmd_anim_format::export_pmd_model(&from_json);
-            let reparsed = mmd_anim_format::parse_pmd_model(&exported)?;
-            ensure_pmd_roundtrip(&parsed, &reparsed)?;
-            println!(
-                "PMD export JSON roundtrip: ok jsonBytes={} bytesIn={} bytesOut={} vertices={} faces={} materials={} bones={} ik={} morphs={} displayFrames={} rigidBodies={} joints={}",
-                json.len(),
-                data.len(),
-                exported.len(),
-                parsed.metadata.counts.vertices,
-                parsed.metadata.counts.faces,
-                parsed.metadata.counts.materials,
-                parsed.metadata.counts.bones,
-                parsed.metadata.counts.ik,
-                parsed.metadata.counts.morphs,
-                parsed.metadata.counts.display_frames,
-                parsed.metadata.counts.rigid_bodies,
-                parsed.metadata.counts.joints
-            );
-            Ok(ExitCode::SUCCESS)
-        }
-        mmd_anim_format::MmdFormatKind::X | mmd_anim_format::MmdFormatKind::Vac => {
-            let file_name = path.file_name().and_then(|v| v.to_str());
-            let parsed = mmd_anim_format::parse_accessory_manifest(&data, file_name)?;
-            let json = serde_json::to_string(&parsed)?;
-            let from_json: mmd_anim_format::AccessoryParsedManifest = serde_json::from_str(&json)?;
-            ensure_accessory_json_roundtrip(&parsed, &from_json)?;
-            let exported = mmd_anim_format::export_accessory_manifest(&from_json);
-            let reparsed = mmd_anim_format::parse_accessory_manifest(&exported, file_name)?;
-            ensure_accessory_roundtrip(&parsed, &reparsed)?;
-            println!(
-                "{} export JSON roundtrip: ok jsonBytes={} bytesIn={} bytesOut={} textures={} diagnostics={}",
-                parsed.format.to_ascii_uppercase(),
-                json.len(),
-                data.len(),
-                exported.len(),
-                parsed.texture_references.len(),
-                parsed.diagnostics.len()
-            );
-            Ok(ExitCode::SUCCESS)
-        }
-        kind => Err(format!("export JSON roundtrip is not implemented for {kind:?}").into()),
-    }
-}
-
-fn export_json_roundtrip_json(path: &Path) -> Result<ExitCode, Box<dyn std::error::Error>> {
-    let data = fs::read(path)?;
-    let result = match mmd_anim_format::detect_mmd_format(
-        &data,
-        path.file_name().and_then(|v| v.to_str()),
-    ) {
-        mmd_anim_format::MmdFormatKind::Vmd => {
-            let parsed = mmd_anim_format::parse_vmd_animation(&data)?;
-            let json = serde_json::to_string(&parsed)?;
-            let from_json: mmd_anim_format::VmdParsedAnimation = serde_json::from_str(&json)?;
-            let exported = mmd_anim_format::export_vmd_animation(&from_json);
-            let reparsed = mmd_anim_format::parse_vmd_animation(&exported)?;
-            ensure_vmd_roundtrip(&parsed, &reparsed)?;
-            vmd_roundtrip_json(
-                path,
-                "parse-json-export-parse",
-                data.len(),
-                exported.len(),
-                Some(json.len()),
-                &parsed,
-            )
-        }
-        mmd_anim_format::MmdFormatKind::Vpd => {
-            let parsed = mmd_anim_format::parse_vpd_pose(&data)?;
-            let json = serde_json::to_string(&parsed)?;
-            let from_json: mmd_anim_format::VpdParsedPose = serde_json::from_str(&json)?;
-            let exported = mmd_anim_format::export_vpd_pose(&from_json);
-            let reparsed = mmd_anim_format::parse_vpd_pose(&exported)?;
-            ensure_vpd_roundtrip(&parsed, &reparsed)?;
-            vpd_roundtrip_json(
-                path,
-                "parse-json-export-parse",
-                data.len(),
-                exported.len(),
-                Some(json.len()),
-                &parsed,
-            )
-        }
-        mmd_anim_format::MmdFormatKind::Pmx => {
-            let parsed = mmd_anim_format::parse_pmx_model(&data)?;
-            let json = serde_json::to_string(&parsed)?;
-            let from_json: mmd_anim_format::PmxParsedModel = serde_json::from_str(&json)?;
-            let exported = mmd_anim_format::export_pmx_model(&from_json);
-            let reparsed = mmd_anim_format::parse_pmx_model(&exported)?;
-            ensure_pmx_roundtrip(&parsed, &reparsed)?;
-            pmx_roundtrip_json(
-                path,
-                "parse-json-export-parse",
-                data.len(),
-                exported.len(),
-                Some(json.len()),
-                &parsed,
-            )
-        }
-        mmd_anim_format::MmdFormatKind::Pmd => {
-            let parsed = mmd_anim_format::parse_pmd_model(&data)?;
-            let json = serde_json::to_string(&parsed)?;
-            let from_json: mmd_anim_format::PmdParsedModel = serde_json::from_str(&json)?;
-            let exported = mmd_anim_format::export_pmd_model(&from_json);
-            let reparsed = mmd_anim_format::parse_pmd_model(&exported)?;
-            ensure_pmd_roundtrip(&parsed, &reparsed)?;
-            pmd_roundtrip_json(
-                path,
-                "parse-json-export-parse",
-                data.len(),
-                exported.len(),
-                Some(json.len()),
-                &parsed,
-            )
-        }
-        mmd_anim_format::MmdFormatKind::X | mmd_anim_format::MmdFormatKind::Vac => {
-            let file_name = path.file_name().and_then(|v| v.to_str());
-            let parsed = mmd_anim_format::parse_accessory_manifest(&data, file_name)?;
-            let json = serde_json::to_string(&parsed)?;
-            let from_json: mmd_anim_format::AccessoryParsedManifest = serde_json::from_str(&json)?;
-            ensure_accessory_json_roundtrip(&parsed, &from_json)?;
-            let exported = mmd_anim_format::export_accessory_manifest(&from_json);
-            let reparsed = mmd_anim_format::parse_accessory_manifest(&exported, file_name)?;
-            ensure_accessory_roundtrip(&parsed, &reparsed)?;
-            accessory_roundtrip_json(
-                path,
-                "parse-json-export-parse",
-                data.len(),
-                exported.len(),
-                Some(json.len()),
-                &parsed,
-            )
-        }
-        kind => {
-            return Err(format!("export JSON roundtrip is not implemented for {kind:?}").into());
-        }
-    };
-    println!("{}", serde_json::to_string_pretty(&result)?);
-    Ok(ExitCode::SUCCESS)
-}
-
-fn export_format(input: &Path, output: &Path) -> Result<ExitCode, Box<dyn std::error::Error>> {
-    let data = fs::read(input)?;
-    let kind =
-        mmd_anim_format::detect_mmd_format(&data, input.file_name().and_then(|v| v.to_str()));
-    let (exported, kind_label): (Vec<u8>, &str) = match kind {
-        mmd_anim_format::MmdFormatKind::Vmd => {
-            let parsed = mmd_anim_format::parse_vmd_animation(&data)?;
-            (mmd_anim_format::export_vmd_animation(&parsed), "VMD")
-        }
-        mmd_anim_format::MmdFormatKind::Vpd => {
-            let parsed = mmd_anim_format::parse_vpd_pose(&data)?;
-            (mmd_anim_format::export_vpd_pose(&parsed), "VPD")
-        }
-        mmd_anim_format::MmdFormatKind::Pmx => {
-            let parsed = mmd_anim_format::parse_pmx_model(&data)?;
-            (mmd_anim_format::export_pmx_model(&parsed), "PMX")
-        }
-        mmd_anim_format::MmdFormatKind::Pmd => {
-            let parsed = mmd_anim_format::parse_pmd_model(&data)?;
-            (mmd_anim_format::export_pmd_model(&parsed), "PMD")
-        }
-        mmd_anim_format::MmdFormatKind::Pmm => {
-            let parsed = mmd_anim_format::parse_pmm_manifest(&data)?;
-            (mmd_anim_format::export_pmm_manifest(&parsed), "PMM")
-        }
-        mmd_anim_format::MmdFormatKind::X | mmd_anim_format::MmdFormatKind::Vac => {
-            let file_name = input.file_name().and_then(|v| v.to_str());
-            let parsed = mmd_anim_format::parse_accessory_manifest(&data, file_name)?;
-            let label: &'static str = if parsed.format == "vac" { "VAC" } else { "X" };
-            (mmd_anim_format::export_accessory_manifest(&parsed), label)
-        }
-        kind => return Err(format!("export is not supported for {kind:?}").into()),
-    };
-    fs::write(output, &exported)?;
-    println!(
-        "{kind_label} export: ok bytesIn={} bytesOut={} output={}",
-        data.len(),
-        exported.len(),
-        output.display()
-    );
-    Ok(ExitCode::SUCCESS)
-}
-
-/// Resolves a PMX model path for PMM export to a canonical path string that MMD can open.
-fn resolve_pmx_path_for_pmm(model_path: &Path) -> Result<String, Box<dyn std::error::Error>> {
-    let canonical = model_path.canonicalize().map_err(|e| {
-        format!(
-            "failed to canonicalize PMX model path {}: {}",
-            model_path.display(),
-            e
-        )
-    })?;
-    Ok(pmm_display_path(&canonical))
-}
-
-fn pmm_display_path(path: &Path) -> String {
-    let text = path.display().to_string();
-    #[cfg(windows)]
-    {
-        if let Some(stripped) = text.strip_prefix(r"\\?\UNC\") {
-            return format!(r"\\{stripped}");
-        }
-        if let Some(stripped) = text.strip_prefix(r"\\?\") {
-            return stripped.to_owned();
-        }
-    }
-    text
-}
-
-fn export_pmm_scene(
-    model_path: &Path,
-    motion_path: &Path,
-    output_path: &Path,
-) -> Result<ExitCode, Box<dyn std::error::Error>> {
-    let model_data = fs::read(model_path)?;
-    let motion_data = fs::read(motion_path)?;
-    let model = mmd_anim_format::parse_pmx_model(&model_data)?;
-    let motion = mmd_anim_format::parse_vmd_animation(&motion_data)?;
-    let model_path_text = resolve_pmx_path_for_pmm(model_path)?;
-    let report = mmd_anim_format::export_pmm_scene_from_pmx_vmd(
-        &model,
-        &motion,
-        &model_path_text,
-        &mmd_anim_format::PmmSceneExportOptions::default(),
-    );
-    fs::write(output_path, &report.bytes)?;
-
-    let reparsed = mmd_anim_format::parse_pmm_manifest(&report.bytes)?;
-    let document = reparsed
-        .document_summary
-        .as_ref()
-        .ok_or("generated PMM does not contain a document model block")?;
-    println!(
-        "PMM scene export: ok bytesOut={} bones={} morphs={} boneKeyframes={} morphKeyframes={} frame0Bones={} frame0Morphs={} skippedBones={} skippedMorphs={} maxFrame={} output={}",
-        report.bytes.len(),
-        document.counts.bones,
-        document.counts.morphs,
-        report.bone_keyframes,
-        report.morph_keyframes,
-        report.frame_zero_bone_keyframes,
-        report.frame_zero_morph_keyframes,
-        report.skipped_bone_keyframes,
-        report.skipped_morph_keyframes,
-        report.max_frame,
-        output_path.display()
-    );
-    Ok(ExitCode::SUCCESS)
-}
-
-fn parse_bool_option(value: &str, label: &str) -> Result<bool, String> {
-    if value.eq_ignore_ascii_case("true")
-        || value == "1"
-        || value.eq_ignore_ascii_case("yes")
-        || value.eq_ignore_ascii_case("on")
-    {
-        Ok(true)
-    } else if value.eq_ignore_ascii_case("false")
-        || value == "0"
-        || value.eq_ignore_ascii_case("no")
-        || value.eq_ignore_ascii_case("off")
-    {
-        Ok(false)
-    } else {
-        Err(format!(
-            "invalid {label}: {value} (expected true/false, 1/0, yes/no, or on/off)"
-        ))
-    }
-}
-
-fn parse_pmm_scene_frame_range_patch_options(
-    option_args: &[String],
-) -> Result<mmd_anim_format::pmm::PmmSceneFrameRangePatch, String> {
-    let mut patch = mmd_anim_format::pmm::PmmSceneFrameRangePatch::default();
-    let mut iter = option_args.iter();
-    while let Some(arg) = iter.next() {
-        let value = iter.next().ok_or_else(|| {
-            format!("missing value for option {arg}; {PATCH_PMM_SCENE_FRAME_RANGE_USAGE}")
-        })?;
-        match arg.as_str() {
-            "--current-frame" => {
-                patch.current_frame_index = Some(value.parse().map_err(|_| {
-                    format!("invalid --current-frame value: {value} (expected i32)")
-                })?);
-            }
-            "--current-frame-text" => {
-                patch.current_frame_index_in_text_field = Some(value.parse().map_err(|_| {
-                    format!("invalid --current-frame-text value: {value} (expected i32)")
-                })?);
-            }
-            "--begin-frame" => {
-                patch.begin_frame_index =
-                    Some(value.parse().map_err(|_| {
-                        format!("invalid --begin-frame value: {value} (expected i32)")
-                    })?);
-            }
-            "--end-frame" => {
-                patch.end_frame_index =
-                    Some(value.parse().map_err(|_| {
-                        format!("invalid --end-frame value: {value} (expected i32)")
-                    })?);
-            }
-            "--begin-frame-enabled" => {
-                patch.begin_frame_index_enabled =
-                    Some(parse_bool_option(value, "--begin-frame-enabled")?);
-            }
-            "--end-frame-enabled" => {
-                patch.end_frame_index_enabled =
-                    Some(parse_bool_option(value, "--end-frame-enabled")?);
-            }
-            other if other.starts_with("--") => {
-                return Err(format!(
-                    "unknown option {other}; {PATCH_PMM_SCENE_FRAME_RANGE_USAGE}"
-                ));
-            }
-            other => {
-                return Err(format!(
-                    "unexpected positional argument {other:?}; {PATCH_PMM_SCENE_FRAME_RANGE_USAGE}"
-                ));
-            }
-        }
-    }
-
-    if patch.current_frame_index.is_none()
-        && patch.current_frame_index_in_text_field.is_none()
-        && patch.begin_frame_index.is_none()
-        && patch.end_frame_index.is_none()
-        && patch.begin_frame_index_enabled.is_none()
-        && patch.end_frame_index_enabled.is_none()
-    {
-        return Err(format!(
-            "at least one patch option is required; {PATCH_PMM_SCENE_FRAME_RANGE_USAGE}"
-        ));
-    }
-
-    Ok(patch)
-}
-
-fn count_pmm_scene_frame_range_patch_fields(
-    patch: &mmd_anim_format::pmm::PmmSceneFrameRangePatch,
-) -> usize {
-    let mut count = 0usize;
-    if patch.current_frame_index.is_some() {
-        count += 1;
-    }
-    if patch.current_frame_index_in_text_field.is_some() {
-        count += 1;
-    }
-    if patch.begin_frame_index.is_some() {
-        count += 1;
-    }
-    if patch.end_frame_index.is_some() {
-        count += 1;
-    }
-    if patch.begin_frame_index_enabled.is_some() {
-        count += 1;
-    }
-    if patch.end_frame_index_enabled.is_some() {
-        count += 1;
-    }
-    count
-}
-
-fn patch_pmm_scene_frame_range(
-    input: &Path,
-    output: &Path,
-    option_args: &[String],
-) -> Result<ExitCode, Box<dyn std::error::Error>> {
-    let patch = parse_pmm_scene_frame_range_patch_options(option_args)?;
-    let data = fs::read(input)?;
-    let bytes_in = data.len();
-    let parsed = mmd_anim_format::parse_pmm_manifest(&data)?;
-    let exported =
-        mmd_anim_format::pmm::export_pmm_manifest_with_scene_frame_range_patch(&parsed, &patch)
-            .map_err(|e| format!("PMM scene frame range patch failed: {e}"))?;
-    let bytes_out = exported.len();
-    let changed_fields = count_pmm_scene_frame_range_patch_fields(&patch);
-    fs::write(output, &exported)?;
-    println!(
-        "PMM scene frame range patch: ok bytesIn={} bytesOut={} changedFields={} output={}",
-        bytes_in,
-        bytes_out,
-        changed_fields,
-        output.display()
-    );
-    Ok(ExitCode::SUCCESS)
-}
-
-fn patch_pmm_document_model_path(
-    input: &Path,
-    document_model_index: &str,
-    model_path: &str,
-    output: &Path,
-) -> Result<ExitCode, Box<dyn std::error::Error>> {
-    let data = fs::read(input)?;
-    let bytes_in = data.len();
-    let parsed = mmd_anim_format::parse_pmm_manifest(&data)?;
-    let index: u8 = document_model_index.parse().map_err(|_| {
-        format!(
-            "invalid document-model-index {:?}: expected u8 (0-255)",
-            document_model_index
-        )
-    })?;
-    let exported = mmd_anim_format::pmm::export_pmm_manifest_with_document_model_path_overrides(
-        &parsed,
-        &[(index, model_path)],
-    )
-    .map_err(|e| format!("PMM document model path patch failed: {e}"))?;
-    let bytes_out = exported.len();
-    fs::write(output, &exported)?;
-    println!(
-        "PMM document model path patch: ok bytesIn={} bytesOut={} documentModelIndex={} output={}",
-        bytes_in,
-        bytes_out,
-        index,
-        output.display()
-    );
-    Ok(ExitCode::SUCCESS)
-}
-
-fn export_json_format(input: &Path, output: &Path) -> Result<ExitCode, Box<dyn std::error::Error>> {
-    let json = fs::read_to_string(input)?;
-    let ext = output
-        .extension()
-        .and_then(|v| v.to_str())
-        .unwrap_or("")
-        .to_ascii_lowercase();
-    let (exported, kind_label): (Vec<u8>, &str) = match ext.as_str() {
-        "vmd" => {
-            let dto: mmd_anim_format::VmdParsedAnimation = serde_json::from_str(&json)?;
-            (mmd_anim_format::export_vmd_animation(&dto), "VMD")
-        }
-        "vpd" => {
-            let dto: mmd_anim_format::VpdParsedPose = serde_json::from_str(&json)?;
-            (mmd_anim_format::export_vpd_pose(&dto), "VPD")
-        }
-        "pmx" => {
-            let dto: mmd_anim_format::PmxParsedModel = serde_json::from_str(&json)?;
-            (mmd_anim_format::export_pmx_model(&dto), "PMX")
-        }
-        "pmd" => {
-            let dto: mmd_anim_format::PmdParsedModel = serde_json::from_str(&json)?;
-            (mmd_anim_format::export_pmd_model(&dto), "PMD")
-        }
-        "x" | "vac" => {
-            let dto: mmd_anim_format::AccessoryParsedManifest = serde_json::from_str(&json)?;
-            let label: &'static str = if ext == "vac" { "VAC" } else { "X" };
-            (mmd_anim_format::export_accessory_manifest(&dto), label)
-        }
-        _ => {
-            return Err(format!(
-                "cannot determine export format from output extension {:?}; \
-                 supported: vmd, vpd, pmx, pmd, x, vac",
-                ext
-            )
-            .into());
-        }
-    };
-    fs::write(output, &exported)?;
-    println!(
-        "{kind_label} export from JSON: ok jsonBytes={} bytesOut={} output={}",
-        json.len(),
-        exported.len(),
-        output.display()
-    );
-    Ok(ExitCode::SUCCESS)
-}
-
-fn vmd_roundtrip_json(
-    path: &Path,
-    mode: &str,
-    bytes_in: usize,
-    bytes_out: usize,
-    json_bytes: Option<usize>,
-    parsed: &mmd_anim_format::VmdParsedAnimation,
-) -> serde_json::Value {
-    serde_json::json!({
-        "status": "ok",
-        "mode": mode,
-        "format": "vmd",
-        "path": path.display().to_string(),
-        "bytesIn": bytes_in,
-        "bytesOut": bytes_out,
-        "jsonBytes": json_bytes,
-        "counts": {
-            "boneFrames": parsed.metadata.counts.bones,
-            "morphFrames": parsed.metadata.counts.morphs,
-            "cameraFrames": parsed.metadata.counts.cameras,
-            "lightFrames": parsed.metadata.counts.lights,
-            "selfShadowFrames": parsed.metadata.counts.self_shadows,
-            "propertyFrames": parsed.metadata.counts.properties,
-        },
-        "maxFrame": parsed.metadata.max_frame,
-    })
-}
-
-fn vpd_roundtrip_json(
-    path: &Path,
-    mode: &str,
-    bytes_in: usize,
-    bytes_out: usize,
-    json_bytes: Option<usize>,
-    parsed: &mmd_anim_format::VpdParsedPose,
-) -> serde_json::Value {
-    serde_json::json!({
-        "status": "ok",
-        "mode": mode,
-        "format": "vpd",
-        "path": path.display().to_string(),
-        "bytesIn": bytes_in,
-        "bytesOut": bytes_out,
-        "jsonBytes": json_bytes,
-        "counts": {
-            "bones": parsed.bone_count,
-        },
-    })
-}
-
-fn pmd_roundtrip_json(
-    path: &Path,
-    mode: &str,
-    bytes_in: usize,
-    bytes_out: usize,
-    json_bytes: Option<usize>,
-    parsed: &mmd_anim_format::PmdParsedModel,
-) -> serde_json::Value {
-    serde_json::json!({
-        "status": "ok",
-        "mode": mode,
-        "format": "pmd",
-        "path": path.display().to_string(),
-        "bytesIn": bytes_in,
-        "bytesOut": bytes_out,
-        "jsonBytes": json_bytes,
-        "counts": {
-            "vertices": parsed.metadata.counts.vertices,
-            "faces": parsed.metadata.counts.faces,
-            "materials": parsed.metadata.counts.materials,
-            "bones": parsed.metadata.counts.bones,
-            "ik": parsed.metadata.counts.ik,
-            "morphs": parsed.metadata.counts.morphs,
-            "displayFrames": parsed.metadata.counts.display_frames,
-            "rigidBodies": parsed.metadata.counts.rigid_bodies,
-            "joints": parsed.metadata.counts.joints,
-        },
-    })
-}
-
-fn pmx_roundtrip_json(
-    path: &Path,
-    mode: &str,
-    bytes_in: usize,
-    bytes_out: usize,
-    json_bytes: Option<usize>,
-    parsed: &mmd_anim_format::PmxParsedModel,
-) -> serde_json::Value {
-    serde_json::json!({
-        "status": "ok",
-        "mode": mode,
-        "format": "pmx",
-        "path": path.display().to_string(),
-        "bytesIn": bytes_in,
-        "bytesOut": bytes_out,
-        "jsonBytes": json_bytes,
-        "metadata": {
-            "version": parsed.metadata.version,
-            "encoding": parsed.metadata.encoding,
-            "additionalUvCount": parsed.metadata.additional_uv_count,
-            "indexSizes": {
-                "vertex": parsed.metadata.index_sizes.vertex,
-                "texture": parsed.metadata.index_sizes.texture,
-                "material": parsed.metadata.index_sizes.material,
-                "bone": parsed.metadata.index_sizes.bone,
-                "morph": parsed.metadata.index_sizes.morph,
-                "rigidBody": parsed.metadata.index_sizes.rigid_body,
-            },
-        },
-        "counts": {
-            "vertices": parsed.metadata.counts.vertices,
-            "faces": parsed.metadata.counts.faces,
-            "materials": parsed.metadata.counts.materials,
-            "bones": parsed.metadata.counts.bones,
-            "morphs": parsed.metadata.counts.morphs,
-            "displayFrames": parsed.metadata.counts.display_frames,
-            "rigidBodies": parsed.metadata.counts.rigid_bodies,
-            "joints": parsed.metadata.counts.joints,
-            "softBodies": parsed.metadata.counts.soft_bodies,
-        },
-    })
-}
-
-fn accessory_roundtrip_json(
-    path: &Path,
-    mode: &str,
-    bytes_in: usize,
-    bytes_out: usize,
-    json_bytes: Option<usize>,
-    parsed: &mmd_anim_format::AccessoryParsedManifest,
-) -> serde_json::Value {
-    let mesh_material_reemitted = !parsed.mesh_summaries.is_empty();
-    let preserved_fields = if mesh_material_reemitted {
-        serde_json::json!([
-            "format",
-            "header",
-            "textureReferences",
-            "meshSummaries",
-            "materials"
-        ])
-    } else if parsed.format == "vac" {
-        serde_json::json!(["format", "header", "textureReferences", "vacSettings"])
-    } else {
-        serde_json::json!(["format", "header", "textureReferences"])
-    };
-    json!({
-        "status": "ok",
-        "mode": mode,
-        "format": parsed.format,
-        "path": path.to_string_lossy(),
-        "bytesIn": bytes_in,
-        "bytesOut": bytes_out,
-        "jsonBytes": json_bytes,
-        "counts": {
-            "meshes": parsed.mesh_count,
-            "materials": parsed.material_count,
-            "meshVertices": parsed.mesh_summaries.iter().map(|mesh| mesh.vertex_count).sum::<usize>(),
-            "meshFaces": parsed.mesh_summaries.iter().map(|mesh| mesh.face_count).sum::<usize>(),
-            "meshNormals": parsed.mesh_summaries.iter().map(|mesh| mesh.normals.len()).sum::<usize>(),
-            "meshTextureCoordinates": parsed.mesh_summaries.iter().map(|mesh| mesh.texture_coordinates.len()).sum::<usize>(),
-            "meshVertexColors": parsed.mesh_summaries.iter().map(|mesh| mesh.vertex_colors.len()).sum::<usize>(),
-            "meshMaterialIndices": parsed.mesh_summaries.iter().map(|mesh| mesh.material_indices.len()).sum::<usize>(),
-            "textureReferences": parsed.texture_references.len(),
-            "diagnostics": parsed.diagnostics.len()
-        },
-        "metadata": {
-            "text": parsed.text,
-            "header": parsed.header,
-            "exportScope": if mesh_material_reemitted { "text-mesh-material-attributes" } else { "manifest" },
-            "meshMaterialReemitted": mesh_material_reemitted,
-            "preservedFields": preserved_fields
-        }
-    })
-}
-
-fn pmm_roundtrip_json(
-    path: &Path,
-    mode: &str,
-    bytes_in: usize,
-    bytes_out: usize,
-    byte_for_byte: bool,
-    parsed: &mmd_anim_format::PmmParsedManifest,
-) -> serde_json::Value {
-    serde_json::json!({
-        "status": "ok",
-        "mode": mode,
-        "format": "pmm",
-        "path": path.display().to_string(),
-        "bytesIn": bytes_in,
-        "bytesOut": bytes_out,
-        "version": parsed.version,
-        "modelReferences": parsed.model_paths.len(),
-        "assetReferences": parsed.asset_summary.reference_count,
-        "diagnostics": parsed.diagnostics.len(),
-        "byteForByte": byte_for_byte,
-    })
-}
-
-fn ensure_pmx_roundtrip(
-    left: &mmd_anim_format::PmxParsedModel,
-    right: &mmd_anim_format::PmxParsedModel,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let left = serde_json::to_value(left)?;
-    let right = serde_json::to_value(right)?;
-    if left != right {
-        return Err("PMX parse/export/parse DTO changed".into());
-    }
-    Ok(())
-}
-
-fn ensure_pmd_roundtrip(
-    left: &mmd_anim_format::PmdParsedModel,
-    right: &mmd_anim_format::PmdParsedModel,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let left = serde_json::to_value(left)?;
-    let right = serde_json::to_value(right)?;
-    if left != right {
-        return Err("PMD parse/export/parse DTO changed".into());
-    }
-    Ok(())
-}
-
-fn ensure_pmm_lossless_roundtrip(
-    original: &[u8],
-    exported: &[u8],
-) -> Result<(), Box<dyn std::error::Error>> {
-    if original != exported {
-        return Err(
-            "PMM parse/export/parse did not preserve source bytes (lossless path failed)".into(),
-        );
-    }
-    Ok(())
-}
-
-fn ensure_accessory_roundtrip(
-    expected: &mmd_anim_format::AccessoryParsedManifest,
-    actual: &mmd_anim_format::AccessoryParsedManifest,
-) -> Result<(), String> {
-    if expected.format != actual.format {
-        return Err(format!(
-            "Accessory roundtrip format changed: expected {}, got {}",
-            expected.format, actual.format
-        ));
-    }
-    if expected.header != actual.header {
-        return Err(format!(
-            "Accessory roundtrip header changed: expected {:?}, got {:?}",
-            expected.header, actual.header
-        ));
-    }
-    if expected.text != actual.text {
-        return Err(format!(
-            "Accessory roundtrip text flag changed: expected {}, got {}",
-            expected.text, actual.text
-        ));
-    }
-    if expected.texture_references != actual.texture_references {
-        return Err(format!(
-            "Accessory roundtrip textureReferences changed: expected {:?}, got {:?}",
-            expected.texture_references, actual.texture_references
-        ));
-    }
-    if !expected.mesh_summaries.is_empty() && expected.mesh_summaries != actual.mesh_summaries {
-        return Err(format!(
-            "Accessory roundtrip meshSummaries changed: {}",
-            describe_accessory_mesh_diff(expected, actual)
-        ));
-    }
-    if expected.materials != actual.materials {
-        return Err(format!(
-            "Accessory roundtrip materials changed: expected {} entries, got {} entries",
-            expected.materials.len(),
-            actual.materials.len()
-        ));
-    }
-    if expected.vac_settings != actual.vac_settings {
-        return Err("Accessory roundtrip vacSettings changed".to_owned());
-    }
-    Ok(())
-}
-
-fn ensure_accessory_json_roundtrip(
-    expected: &mmd_anim_format::AccessoryParsedManifest,
-    actual: &mmd_anim_format::AccessoryParsedManifest,
-) -> Result<(), String> {
-    let expected = serde_json::to_value(expected).map_err(|error| {
-        format!("Accessory JSON roundtrip expected serialization failed: {error}")
-    })?;
-    let actual = serde_json::to_value(actual).map_err(|error| {
-        format!("Accessory JSON roundtrip actual serialization failed: {error}")
-    })?;
-    if expected != actual {
-        return Err("Accessory JSON DTO changed before export".to_owned());
-    }
-    Ok(())
-}
-
-fn describe_accessory_mesh_diff(
-    expected: &mmd_anim_format::AccessoryParsedManifest,
-    actual: &mmd_anim_format::AccessoryParsedManifest,
-) -> String {
-    if expected.mesh_summaries.len() != actual.mesh_summaries.len() {
-        return format!(
-            "expected {} entries, got {} entries",
-            expected.mesh_summaries.len(),
-            actual.mesh_summaries.len()
-        );
-    }
-    for (index, (expected_mesh, actual_mesh)) in expected
-        .mesh_summaries
-        .iter()
-        .zip(actual.mesh_summaries.iter())
-        .enumerate()
-    {
-        if expected_mesh.vertex_count != actual_mesh.vertex_count {
-            return format!(
-                "mesh {index} vertexCount expected {}, got {}",
-                expected_mesh.vertex_count, actual_mesh.vertex_count
-            );
-        }
-        if expected_mesh.face_count != actual_mesh.face_count {
-            return format!(
-                "mesh {index} faceCount expected {}, got {}",
-                expected_mesh.face_count, actual_mesh.face_count
-            );
-        }
-        if expected_mesh.positions != actual_mesh.positions {
-            return format!(
-                "mesh {index} positions expected {} entries, got {} entries",
-                expected_mesh.positions.len(),
-                actual_mesh.positions.len()
-            );
-        }
-        if expected_mesh.face_indices != actual_mesh.face_indices {
-            return format!(
-                "mesh {index} faceIndices expected {} entries, got {} entries",
-                expected_mesh.face_indices.len(),
-                actual_mesh.face_indices.len()
-            );
-        }
-        if expected_mesh.normals != actual_mesh.normals {
-            return format!(
-                "mesh {index} normals expected {} entries, got {} entries",
-                expected_mesh.normals.len(),
-                actual_mesh.normals.len()
-            );
-        }
-        if expected_mesh.normal_face_indices != actual_mesh.normal_face_indices {
-            return format!(
-                "mesh {index} normalFaceIndices expected {} entries, got {} entries",
-                expected_mesh.normal_face_indices.len(),
-                actual_mesh.normal_face_indices.len()
-            );
-        }
-        if expected_mesh.texture_coordinates != actual_mesh.texture_coordinates {
-            return format!(
-                "mesh {index} textureCoordinates expected {} entries, got {} entries",
-                expected_mesh.texture_coordinates.len(),
-                actual_mesh.texture_coordinates.len()
-            );
-        }
-        if expected_mesh.vertex_colors != actual_mesh.vertex_colors {
-            return format!(
-                "mesh {index} vertexColors expected {} entries, got {} entries",
-                expected_mesh.vertex_colors.len(),
-                actual_mesh.vertex_colors.len()
-            );
-        }
-        if expected_mesh.material_indices != actual_mesh.material_indices {
-            return format!(
-                "mesh {index} materialIndices expected {:?}, got {:?}",
-                expected_mesh.material_indices, actual_mesh.material_indices
-            );
-        }
-    }
-    "unknown mesh summary delta".to_owned()
-}
-
-fn ensure_vmd_roundtrip(
-    left: &mmd_anim_format::VmdParsedAnimation,
-    right: &mmd_anim_format::VmdParsedAnimation,
-) -> Result<(), Box<dyn std::error::Error>> {
-    if left.metadata.model_name != right.metadata.model_name {
-        return Err(format!(
-            "VMD metadata.model_name changed: expected={:?} got={:?}",
-            left.metadata.model_name, right.metadata.model_name
-        )
-        .into());
-    }
-    if left.metadata.max_frame != right.metadata.max_frame {
-        return Err(format!(
-            "VMD metadata.max_frame changed: expected={} got={}",
-            left.metadata.max_frame, right.metadata.max_frame
-        )
-        .into());
-    }
-    macro_rules! check_count {
-        ($field:ident, $label:expr) => {
-            if left.metadata.counts.$field != right.metadata.counts.$field {
-                return Err(format!(
-                    "VMD metadata.counts.{} changed: expected={} got={}",
-                    $label, left.metadata.counts.$field, right.metadata.counts.$field
-                )
-                .into());
-            }
-        };
-    }
-    check_count!(bones, "bones");
-    check_count!(morphs, "morphs");
-    check_count!(cameras, "cameras");
-    check_count!(lights, "lights");
-    check_count!(self_shadows, "selfShadows");
-    check_count!(properties, "properties");
-
-    for (i, (l, r)) in left.bone_frames.iter().zip(&right.bone_frames).enumerate() {
-        if l.bone_name != r.bone_name {
-            return Err(format!(
-                "VMD bone_frames[{i}] bone_name: expected={:?} got={:?}",
-                l.bone_name, r.bone_name
-            )
-            .into());
-        }
-        if l.frame != r.frame {
-            return Err(format!(
-                "VMD bone_frames[{i}] bone={:?} frame: expected={} got={}",
-                l.bone_name, l.frame, r.frame
-            )
-            .into());
-        }
-        if l.translation != r.translation {
-            return Err(format!(
-                "VMD bone_frames[{i}] bone={:?} frame={} translation: expected={:?} got={:?}",
-                l.bone_name, l.frame, l.translation, r.translation
-            )
-            .into());
-        }
-        if l.rotation != r.rotation {
-            return Err(format!(
-                "VMD bone_frames[{i}] bone={:?} frame={} rotation: expected={:?} got={:?}",
-                l.bone_name, l.frame, l.rotation, r.rotation
-            )
-            .into());
-        }
-        if l.interpolation != r.interpolation {
-            return Err(format!(
-                "VMD bone_frames[{i}] bone={:?} frame={} interpolation changed",
-                l.bone_name, l.frame
-            )
-            .into());
-        }
-    }
-
-    for (i, (l, r)) in left
-        .morph_frames
-        .iter()
-        .zip(&right.morph_frames)
-        .enumerate()
-    {
-        if l.morph_name != r.morph_name {
-            return Err(format!(
-                "VMD morph_frames[{i}] morph_name: expected={:?} got={:?}",
-                l.morph_name, r.morph_name
-            )
-            .into());
-        }
-        if l.frame != r.frame {
-            return Err(format!(
-                "VMD morph_frames[{i}] morph={:?} frame: expected={} got={}",
-                l.morph_name, l.frame, r.frame
-            )
-            .into());
-        }
-        if l.weight != r.weight {
-            return Err(format!(
-                "VMD morph_frames[{i}] morph={:?} frame={} weight: expected={} got={}",
-                l.morph_name, l.frame, l.weight, r.weight
-            )
-            .into());
-        }
-    }
-
-    for (i, (l, r)) in left
-        .camera_frames
-        .iter()
-        .zip(&right.camera_frames)
-        .enumerate()
-    {
-        if l.frame != r.frame {
-            return Err(format!(
-                "VMD camera_frames[{i}] frame: expected={} got={}",
-                l.frame, r.frame
-            )
-            .into());
-        }
-        if l.distance != r.distance {
-            return Err(format!(
-                "VMD camera_frames[{i}] frame={} distance: expected={} got={}",
-                l.frame, l.distance, r.distance
-            )
-            .into());
-        }
-        if l.position != r.position {
-            return Err(format!(
-                "VMD camera_frames[{i}] frame={} position: expected={:?} got={:?}",
-                l.frame, l.position, r.position
-            )
-            .into());
-        }
-        if l.rotation != r.rotation {
-            return Err(format!(
-                "VMD camera_frames[{i}] frame={} rotation: expected={:?} got={:?}",
-                l.frame, l.rotation, r.rotation
-            )
-            .into());
-        }
-        if l.interpolation != r.interpolation {
-            return Err(format!(
-                "VMD camera_frames[{i}] frame={} interpolation changed",
-                l.frame
-            )
-            .into());
-        }
-        if l.fov != r.fov {
-            return Err(format!(
-                "VMD camera_frames[{i}] frame={} fov: expected={} got={}",
-                l.frame, l.fov, r.fov
-            )
-            .into());
-        }
-        if l.perspective != r.perspective {
-            return Err(format!(
-                "VMD camera_frames[{i}] frame={} perspective: expected={} got={}",
-                l.frame, l.perspective, r.perspective
-            )
-            .into());
-        }
-    }
-
-    for (i, (l, r)) in left
-        .light_frames
-        .iter()
-        .zip(&right.light_frames)
-        .enumerate()
-    {
-        if l.frame != r.frame {
-            return Err(format!(
-                "VMD light_frames[{i}] frame: expected={} got={}",
-                l.frame, r.frame
-            )
-            .into());
-        }
-        if l.color != r.color {
-            return Err(format!(
-                "VMD light_frames[{i}] frame={} color: expected={:?} got={:?}",
-                l.frame, l.color, r.color
-            )
-            .into());
-        }
-        if l.direction != r.direction {
-            return Err(format!(
-                "VMD light_frames[{i}] frame={} direction: expected={:?} got={:?}",
-                l.frame, l.direction, r.direction
-            )
-            .into());
-        }
-    }
-
-    for (i, (l, r)) in left
-        .self_shadow_frames
-        .iter()
-        .zip(&right.self_shadow_frames)
-        .enumerate()
-    {
-        if l.frame != r.frame {
-            return Err(format!(
-                "VMD self_shadow_frames[{i}] frame: expected={} got={}",
-                l.frame, r.frame
-            )
-            .into());
-        }
-        if l.mode != r.mode {
-            return Err(format!(
-                "VMD self_shadow_frames[{i}] frame={} mode: expected={} got={}",
-                l.frame, l.mode, r.mode
-            )
-            .into());
-        }
-        if l.distance != r.distance {
-            return Err(format!(
-                "VMD self_shadow_frames[{i}] frame={} distance: expected={} got={}",
-                l.frame, l.distance, r.distance
-            )
-            .into());
-        }
-    }
-
-    for (i, (l, r)) in left
-        .property_frames
-        .iter()
-        .zip(&right.property_frames)
-        .enumerate()
-    {
-        if l.frame != r.frame {
-            return Err(format!(
-                "VMD property_frames[{i}] frame: expected={} got={}",
-                l.frame, r.frame
-            )
-            .into());
-        }
-        if l.visible != r.visible {
-            return Err(format!(
-                "VMD property_frames[{i}] frame={} visible: expected={} got={}",
-                l.frame, l.visible, r.visible
-            )
-            .into());
-        }
-        if l.ik_states.len() != r.ik_states.len() {
-            return Err(format!(
-                "VMD property_frames[{i}] frame={} ik_states count: expected={} got={}",
-                l.frame,
-                l.ik_states.len(),
-                r.ik_states.len()
-            )
-            .into());
-        }
-        for (j, (lk, rk)) in l.ik_states.iter().zip(&r.ik_states).enumerate() {
-            if lk.bone_name != rk.bone_name {
-                return Err(format!(
-                    "VMD property_frames[{i}] frame={} ik_states[{j}] bone_name: expected={:?} got={:?}",
-                    l.frame, lk.bone_name, rk.bone_name
-                )
-                .into());
-            }
-            if lk.enabled != rk.enabled {
-                return Err(format!(
-                    "VMD property_frames[{i}] frame={} ik_states[{j}] bone={:?} enabled: expected={} got={}",
-                    l.frame, lk.bone_name, lk.enabled, rk.enabled
-                )
-                .into());
-            }
-        }
-    }
-    Ok(())
-}
-
-fn ensure_vpd_roundtrip(
-    left: &mmd_anim_format::VpdParsedPose,
-    right: &mmd_anim_format::VpdParsedPose,
-) -> Result<(), Box<dyn std::error::Error>> {
-    if left.model_file != right.model_file {
-        return Err(format!(
-            "VPD model_file changed: expected={:?} got={:?}",
-            left.model_file, right.model_file
-        )
-        .into());
-    }
-    if left.bone_count != right.bone_count {
-        return Err(format!(
-            "VPD bone_count changed: expected={} got={}",
-            left.bone_count, right.bone_count
-        )
-        .into());
-    }
-    for (i, (l, r)) in left.bones.iter().zip(&right.bones).enumerate() {
-        if l.name != r.name {
-            return Err(format!(
-                "VPD bones[{i}] name: expected={:?} got={:?}",
-                l.name, r.name
-            )
-            .into());
-        }
-        if l.translation != r.translation {
-            return Err(format!(
-                "VPD bones[{i}] bone={:?} translation: expected={:?} got={:?}",
-                l.name, l.translation, r.translation
-            )
-            .into());
-        }
-        if l.rotation != r.rotation {
-            return Err(format!(
-                "VPD bones[{i}] bone={:?} rotation: expected={:?} got={:?}",
-                l.name, l.rotation, r.rotation
-            )
-            .into());
-        }
-    }
-    Ok(())
-}
-
-fn compare_numeric_manifest(path: &Path) -> Result<ExitCode, Box<dyn std::error::Error>> {
-    const EPSILON: f64 = 0.003;
-
-    let manifest_dir = path.parent().unwrap_or_else(|| Path::new("."));
-    let manifest_bytes = fs::read(path)
-        .map_err(|error| format!("failed to read manifest {}: {}", path.display(), error))?;
-    let manifest: serde_json::Value = serde_json::from_slice(&manifest_bytes)?;
-    let out_dir = manifest
-        .pointer("/defaults/outDir")
-        .and_then(|value| value.as_str())
-        .map(|path| resolve_manifest_path(manifest_dir, path));
-    let default_epsilon = manifest
-        .pointer("/defaults/compare/epsilon")
-        .or_else(|| manifest.pointer("/defaults/epsilon"))
-        .and_then(|value| value.as_f64())
-        .unwrap_or(EPSILON);
-    let default_focus_bones = json_string_array(&manifest, "/defaults/focus/bones");
-    let default_motion_eval_frame_offset = json_f32(&manifest, "/defaults/compare/evalFrameOffset")
-        .or_else(|| json_f32(&manifest, "/defaults/evalFrameOffset"))
-        .unwrap_or(0.0);
-    let cases = manifest
-        .get("cases")
-        .and_then(|value| value.as_array())
-        .ok_or("numeric compare manifest is missing cases")?;
-    let mut camera_stats = CameraNumericCompareStats::default();
-    let mut motion_stats = MotionNumericCompareStats::default();
-
-    for case in cases {
-        let name = case
-            .get("name")
-            .and_then(|value| value.as_str())
-            .ok_or("numeric compare case is missing name")?;
-        let kind = case
-            .get("kind")
-            .and_then(|value| value.as_str())
-            .ok_or_else(|| format!("{name} is missing kind"))?;
-        match kind {
-            "camera-vmd" => {
-                let case_dir = out_dir.as_ref().map(|out_dir| out_dir.join(name));
-                compare_camera_numeric_case(
-                    case,
-                    manifest_dir,
-                    case_dir.as_deref(),
-                    default_epsilon,
-                    &mut camera_stats,
-                )?;
-            }
-            "motion-numeric" | "physics-coarse" => {
-                compare_motion_numeric_case(
-                    case,
-                    manifest_dir,
-                    default_epsilon,
-                    default_focus_bones.as_deref(),
-                    default_motion_eval_frame_offset,
-                    &mut motion_stats,
-                )?;
-            }
-            _ => {
-                return Err(format!(
-                    "numeric compare case {} has unsupported kind {}; supported kinds: camera-vmd, motion-numeric, physics-coarse",
-                    name, kind
-                )
-                .into());
-            }
-        }
-    }
-
-    let failure_count = numeric_compare_failure_count(&camera_stats, &motion_stats);
-    if failure_count == 0 {
-        println!(
-            "Numeric compare: ok cameraCases={} cameraFrames={} cameraMaxDelta={:.6} motionCases={} motionComparedCases={} motionSkippedUnsupported={} motionMissing={} motionImportErrors={} motionFrames={} motionBones={} motionMaxAbsError={:.6} motionWorst={} motionSkippedTargets={} defaultEpsilon={}",
-            camera_stats.compared_cases,
-            camera_stats.compared_frames,
-            camera_stats.max_delta,
-            motion_stats.total_cases,
-            motion_stats.compared_cases,
-            motion_stats.skipped_unsupported,
-            motion_stats.missing,
-            motion_stats.import_errors,
-            motion_stats.compared_frames,
-            motion_stats.compared_bones,
-            motion_stats.max_abs_error,
-            motion_stats.worst,
-            motion_stats.skipped_targets_csv(),
-            default_epsilon
-        );
-        Ok(ExitCode::SUCCESS)
-    } else {
-        Err(format!(
-            "Numeric compare failed: failures={} cameraMismatches={} motionMismatches={} motionMissing={} motionImportErrors={} cameraMaxDelta={:.6} motionMaxAbsError={:.6} motionWorst={} defaultEpsilon={}",
-            failure_count,
-            camera_stats.mismatch_count,
-            motion_stats.mismatch_count,
-            motion_stats.missing,
-            motion_stats.import_errors,
-            camera_stats.max_delta,
-            motion_stats.max_abs_error,
-            motion_stats.worst,
-            default_epsilon
-        )
-        .into())
-    }
-}
-
-#[derive(Default)]
-struct CameraNumericCompareStats {
-    compared_cases: usize,
-    compared_frames: usize,
-    mismatch_count: usize,
-    max_delta: f64,
-}
-
-fn compare_camera_numeric_case(
-    case: &serde_json::Value,
-    manifest_dir: &Path,
-    case_dir: Option<&Path>,
-    default_epsilon: f64,
-    stats: &mut CameraNumericCompareStats,
-) -> Result<ExitCode, Box<dyn std::error::Error>> {
-    let name = case
-        .get("name")
-        .and_then(|value| value.as_str())
-        .ok_or("numeric compare case is missing name")?;
-    let epsilon = case
-        .pointer("/compare/epsilon")
-        .and_then(|value| value.as_f64())
-        .unwrap_or(default_epsilon);
-    let oracle_path = resolve_camera_oracle_path(case, manifest_dir, case_dir)?;
-    let oracle_bytes = fs::read(&oracle_path).map_err(|error| {
-        format!(
-            "failed to read camera oracle for case {} at {}: {}",
-            name,
-            oracle_path.display(),
-            error
-        )
-    })?;
-    let oracle: serde_json::Value = serde_json::from_slice(&oracle_bytes)?;
-    let camera_vmd = resolve_camera_vmd_path(case, manifest_dir, case_dir)?;
-    let camera_vmd_bytes = fs::read(&camera_vmd).map_err(|error| {
-        format!(
-            "failed to read camera VMD for case {} at {}: {}",
-            name,
-            camera_vmd.display(),
-            error
-        )
-    })?;
-    let parsed = mmd_anim_format::parse_vmd_animation(&camera_vmd_bytes)?;
-    let frames = oracle
-        .get("frames")
-        .and_then(|value| value.as_array())
-        .ok_or_else(|| format!("{} is missing frames", oracle_path.display()))?;
-
-    stats.compared_cases += 1;
-    for frame_record in frames {
-        let frame = frame_record
-            .get("frame")
-            .and_then(|value| value.as_f64())
-            .ok_or_else(|| format!("{name} has a frame record without frame"))?;
-        let expected = frame_record
-            .get("camera")
-            .ok_or_else(|| format!("{name} frame {frame} is missing camera"))?;
-        let actual = mmd_anim_format::sample_vmd_camera_frames(&parsed.camera_frames, frame as f32)
-            .ok_or_else(|| format!("{} has no camera frames", camera_vmd.display()))?;
-
-        stats.compared_frames += 1;
-        stats.mismatch_count += compare_camera_scalar(
-            name,
-            frame,
-            "distance",
-            actual.distance as f64,
-            expected_number(expected, "distance")?,
-            epsilon,
-            &mut stats.max_delta,
-        );
-        stats.mismatch_count += compare_camera_vec3(
-            name,
-            frame,
-            "position",
-            actual.position,
-            expected_array3(expected, "position")?,
-            epsilon,
-            &mut stats.max_delta,
-        );
-        stats.mismatch_count += compare_camera_vec3(
-            name,
-            frame,
-            "rotation",
-            actual.rotation,
-            expected_array3(expected, "rotation")?,
-            epsilon,
-            &mut stats.max_delta,
-        );
-        stats.mismatch_count += compare_camera_scalar(
-            name,
-            frame,
-            "fov",
-            actual.fov as f64,
-            expected_number(expected, "fov")?,
-            epsilon,
-            &mut stats.max_delta,
-        );
-        let expected_perspective = expected
-            .get("perspective")
-            .and_then(|value| value.as_bool())
-            .ok_or_else(|| format!("{name} frame {frame} camera.perspective is missing"))?;
-        if actual.perspective != expected_perspective {
-            stats.mismatch_count += 1;
-            eprintln!(
-                "camera mismatch case={} frame={} field=perspective actual={} expected={}",
-                name, frame, actual.perspective, expected_perspective
-            );
-        }
-    }
-    Ok(ExitCode::SUCCESS)
-}
-
-#[derive(Default)]
-struct MotionNumericCompareStats {
-    total_cases: usize,
-    compared_cases: usize,
-    skipped_unsupported: usize,
-    missing: usize,
-    import_errors: usize,
-    compared_frames: usize,
-    compared_bones: usize,
-    mismatch_count: usize,
-    skipped_targets: HashSet<String>,
-    max_abs_error: f32,
-    worst: String,
-}
-
-fn numeric_compare_failure_count(
-    camera_stats: &CameraNumericCompareStats,
-    motion_stats: &MotionNumericCompareStats,
-) -> usize {
-    camera_stats.mismatch_count
-        + motion_stats.mismatch_count
-        + motion_stats.missing
-        + motion_stats.import_errors
-}
-
-impl MotionNumericCompareStats {
-    fn skipped_targets_csv(&self) -> String {
-        let mut targets: Vec<_> = self.skipped_targets.iter().cloned().collect();
-        targets.sort();
-        targets.join(",")
-    }
-}
-
-fn compare_motion_numeric_case(
-    case: &serde_json::Value,
-    manifest_dir: &Path,
-    default_epsilon: f64,
-    default_focus_bones: Option<&[String]>,
-    default_eval_frame_offset: f32,
-    stats: &mut MotionNumericCompareStats,
-) -> Result<ExitCode, Box<dyn std::error::Error>> {
-    stats.total_cases += 1;
-    if stats.worst.is_empty() {
-        stats.worst = String::from("none");
-    }
-    let name = case
-        .get("name")
-        .and_then(|value| value.as_str())
-        .ok_or("numeric compare case is missing name")?;
-    let epsilon = case
-        .pointer("/compare/epsilon")
-        .and_then(|value| value.as_f64())
-        .unwrap_or(default_epsilon) as f32;
-    let eval_frame_offset = json_f32(case, "/compare/evalFrameOffset")
-        .or_else(|| json_f32(case, "/metadata/evalFrameOffset"))
-        .unwrap_or(default_eval_frame_offset);
-    collect_unsupported_targets(case, &mut stats.skipped_targets);
-
-    let model_path = match case
-        .pointer("/assets/model")
-        .and_then(|value| value.as_str())
-        .map(|value| resolve_manifest_path(manifest_dir, value))
-    {
-        Some(path) => path,
-        None => {
-            stats.missing += 1;
-            eprintln!("missing: {name} assets.model");
-            return Ok(ExitCode::SUCCESS);
-        }
-    };
-    let motion_path = match case
-        .pointer("/assets/motion")
-        .and_then(|value| value.as_str())
-        .map(|value| resolve_manifest_path(manifest_dir, value))
-    {
-        Some(path) => path,
-        None => {
-            stats.missing += 1;
-            eprintln!("missing: {name} assets.motion");
-            return Ok(ExitCode::SUCCESS);
-        }
-    };
-    let oracle_path = match case
-        .pointer("/oracle/path")
-        .and_then(|value| value.as_str())
-        .map(|value| resolve_manifest_path(manifest_dir, value))
-    {
-        Some(path) => path,
-        None => {
-            stats.missing += 1;
-            eprintln!("missing: {name} oracle.path");
-            return Ok(ExitCode::SUCCESS);
+        Some(Commands::OracleSummary { path }) => {
+            commands::oracle::oracle_summary(&path.to_string_lossy())
         }
     };
 
-    if !golden::is_supported_golden_model(&model_path) {
-        stats.skipped_unsupported += 1;
-        eprintln!("skipped unsupported model: {}", model_path.display());
-        return Ok(ExitCode::SUCCESS);
-    }
-    if !model_path.exists() || !motion_path.exists() || !oracle_path.exists() {
-        stats.missing += 1;
-        if !model_path.exists() {
-            eprintln!("missing: {}", model_path.display());
-        }
-        if !motion_path.exists() {
-            eprintln!("missing: {}", motion_path.display());
-        }
-        if !oracle_path.exists() {
-            eprintln!("missing: {}", oracle_path.display());
-        }
-        return Ok(ExitCode::SUCCESS);
-    }
-
-    let frames = numeric_case_frames(case)?;
-    let dump =
-        MmdDumperOracleDump::from_jsonl_str(&fs::read_to_string(&oracle_path)?, Some(&frames))?;
-    let focus_bones = motion_case_focus_bones(case, default_focus_bones);
-    let focus_bone_names: Vec<&str> = focus_bones.iter().map(String::as_str).collect();
-
-    let model_bytes = fs::read(&model_path)?;
-    let model_import = match golden::import_golden_runtime_model(&model_path, &model_bytes) {
-        Ok(import) => import,
+    match result {
+        Ok(code) => code,
         Err(error) => {
-            stats.import_errors += 1;
-            eprintln!("import-error: {}: {}", model_path.display(), error);
-            return Ok(ExitCode::SUCCESS);
-        }
-    };
-    let vmd_bytes = fs::read(&motion_path)?;
-    let vmd = match mmd_anim_format::import_vmd_motion(&vmd_bytes) {
-        Ok(vmd) => vmd,
-        Err(error) => {
-            stats.import_errors += 1;
-            eprintln!("import-error: {}: {}", motion_path.display(), error);
-            return Ok(ExitCode::SUCCESS);
-        }
-    };
-
-    let solver_count = model_import.model.ik_count();
-    let clip = mmd_anim_format::build_pair_clip_with_options(
-        &vmd,
-        &model_import.bone_name_to_index,
-        &model_import.morph_name_to_index,
-        &model_import.ik_solver_bone_name_to_index,
-        solver_count,
-        mmd_anim_format::VmdClipBuildOptions {
-            honor_property_ik: false,
-        },
-    );
-
-    let model = Arc::new(model_import.model);
-    let morph_count = model_import
-        .morph_name_to_index
-        .values()
-        .map(|index| index.as_usize() + 1)
-        .max()
-        .unwrap_or(0);
-    let mut runtime =
-        RuntimeInstance::new_with_counts(Arc::clone(&model), morph_count, solver_count);
-
-    for oracle_frame in &dump.frames {
-        let eval_frame = oracle_frame.frame as f32 + eval_frame_offset;
-        runtime.evaluate_clip_frame(&clip, eval_frame);
-        let Some(model0) = oracle_frame.models.first() else {
-            continue;
-        };
-        let world_matrices = runtime.world_matrices();
-        for oracle_bone in model0.focused_ik_bones(&focus_bone_names) {
-            if oracle_bone.index < 0 {
-                continue;
-            }
-            let index = oracle_bone.index as usize;
-            if index >= world_matrices.len() {
-                continue;
-            }
-            let runtime_matrix = world_matrices[index].to_cols_array();
-            for (component, actual) in runtime_matrix.iter().enumerate() {
-                let abs_error = (*actual - oracle_bone.world_matrix[component]).abs();
-                if abs_error > stats.max_abs_error {
-                    stats.max_abs_error = abs_error;
-                    stats.worst = format!("{}:{}:{}", name, oracle_frame.frame, oracle_bone.name);
-                }
-                if abs_error > epsilon {
-                    stats.mismatch_count += 1;
-                    eprintln!(
-                        "motion mismatch case={} frame={} evalFrame={:.3} bone={} component={} actual={:.9} expected={:.9} delta={:.9} epsilon={:.9}",
-                        name,
-                        oracle_frame.frame,
-                        eval_frame,
-                        oracle_bone.name,
-                        component,
-                        actual,
-                        oracle_bone.world_matrix[component],
-                        abs_error,
-                        epsilon
-                    );
-                }
-            }
-            stats.compared_bones += 1;
-        }
-        stats.compared_frames += 1;
-    }
-    stats.compared_cases += 1;
-    Ok(ExitCode::SUCCESS)
-}
-
-fn diagnose_numeric_bones(
-    manifest_path: &Path,
-    case_name: &str,
-    oracle_frame_number: f32,
-    eval_frame: f32,
-    bone_names: &[String],
-) -> Result<ExitCode, Box<dyn std::error::Error>> {
-    let manifest_dir = manifest_path.parent().unwrap_or_else(|| Path::new("."));
-    let manifest: serde_json::Value = serde_json::from_str(&fs::read_to_string(manifest_path)?)?;
-    let cases = manifest
-        .get("cases")
-        .and_then(|value| value.as_array())
-        .ok_or("numeric manifest is missing cases")?;
-    let case = cases
-        .iter()
-        .find(|case| case.get("name").and_then(|value| value.as_str()) == Some(case_name))
-        .ok_or_else(|| format!("numeric manifest has no case named {case_name}"))?;
-
-    let model_path = case
-        .pointer("/assets/model")
-        .and_then(|value| value.as_str())
-        .map(|value| resolve_manifest_path(manifest_dir, value))
-        .ok_or("case is missing assets.model")?;
-    let motion_path = case
-        .pointer("/assets/motion")
-        .and_then(|value| value.as_str())
-        .map(|value| resolve_manifest_path(manifest_dir, value))
-        .ok_or("case is missing assets.motion")?;
-    let oracle_path = case
-        .pointer("/oracle/path")
-        .and_then(|value| value.as_str())
-        .map(|value| resolve_manifest_path(manifest_dir, value))
-        .ok_or("case is missing oracle.path")?;
-
-    let target_frame = oracle_frame_number.round() as i32;
-    let dump = MmdDumperOracleDump::from_jsonl_str(
-        &fs::read_to_string(&oracle_path)?,
-        Some(&[target_frame]),
-    )?;
-    let oracle_frame = dump
-        .find_frame(target_frame)
-        .ok_or_else(|| format!("oracle has no frame {target_frame}"))?;
-    let oracle_model = oracle_frame
-        .models
-        .first()
-        .ok_or_else(|| format!("oracle frame {target_frame} has no model"))?;
-
-    let model_bytes = fs::read(&model_path)?;
-    let model_import = golden::import_golden_runtime_model(&model_path, &model_bytes)?;
-    let vmd = mmd_anim_format::import_vmd_motion(&fs::read(&motion_path)?)?;
-    let solver_count = model_import.model.ik_count();
-    let clip = mmd_anim_format::build_pair_clip_with_options(
-        &vmd,
-        &model_import.bone_name_to_index,
-        &model_import.morph_name_to_index,
-        &model_import.ik_solver_bone_name_to_index,
-        solver_count,
-        mmd_anim_format::VmdClipBuildOptions {
-            honor_property_ik: false,
-        },
-    );
-
-    let morph_count = model_import
-        .morph_name_to_index
-        .values()
-        .map(|index| index.as_usize() + 1)
-        .max()
-        .unwrap_or(0);
-    let model = Arc::new(model_import.model);
-    let mut pre_ik =
-        RuntimeInstance::new_with_counts(Arc::clone(&model), morph_count, solver_count);
-    let mut post_ik =
-        RuntimeInstance::new_with_counts(Arc::clone(&model), morph_count, solver_count);
-    pre_ik.evaluate_clip_frame_without_ik(&clip, eval_frame);
-    post_ik.evaluate_clip_frame_with_ik_options(&clip, eval_frame, IkSolveOptions::default());
-
-    println!(
-        "numeric bone diagnosis case={} oracleFrame={:.3} evalFrame={:.3} model={} motion={} oracle={}",
-        case_name,
-        oracle_frame_number,
-        eval_frame,
-        model_path.display(),
-        motion_path.display(),
-        oracle_path.display()
-    );
-    for bone_name in bone_names {
-        let normalized = mmd_anim_format::normalize_vmd_name(bone_name.as_bytes());
-        let Some(index) = model_import
-            .bone_name_to_index
-            .get(bone_name.as_bytes())
-            .or_else(|| model_import.bone_name_to_index.get(&normalized))
-            .copied()
-        else {
-            println!("bone={} missing runtimeIndex", bone_name);
-            continue;
-        };
-        let Some(oracle_bone) = oracle_model.find_bone(bone_name) else {
-            println!(
-                "bone={} runtimeIndex={} missing oracleBone",
-                bone_name,
-                index.as_usize()
-            );
-            continue;
-        };
-        let pre = pre_ik.world_matrices()[index.as_usize()].to_cols_array();
-        let post = post_ik.world_matrices()[index.as_usize()].to_cols_array();
-        let (pre_component, pre_delta) = max_matrix_delta(&pre, &oracle_bone.world_matrix);
-        let (post_component, post_delta) = max_matrix_delta(&post, &oracle_bone.world_matrix);
-        let pre_pos_delta = position_delta(&pre, &oracle_bone.world_matrix);
-        let post_pos_delta = position_delta(&post, &oracle_bone.world_matrix);
-        let pre_local_pos = pre_ik.pose().local_position_offset(index);
-        let post_local_pos = post_ik.pose().local_position_offset(index);
-        let pre_local_rot = pre_ik.pose().local_rotation(index);
-        let post_local_rot = post_ik.pose().local_rotation(index);
-        let pre_local_axis = pre_local_rot.to_axis_angle();
-        let post_local_axis = post_local_rot.to_axis_angle();
-        let oracle_local = oracle_local_matrix(oracle_model, &model, oracle_bone);
-        let (_, oracle_local_rot, oracle_local_pos) =
-            glam::Mat4::from_cols_array(&oracle_local).to_scale_rotation_translation();
-        let oracle_local_axis = oracle_local_rot.to_axis_angle();
-        let vmd_keyframes: Vec<_> = vmd
-            .bone_keyframes
-            .iter()
-            .filter(|kf| {
-                model_import
-                    .bone_name_to_index
-                    .get(&kf.bone_name_normalized)
-                    == Some(&index)
-            })
-            .collect();
-        let vmd_lookup_frame = eval_frame;
-        let exact_vmd_keyframes: Vec<_> = vmd_keyframes
-            .iter()
-            .copied()
-            .filter(|kf| kf.frame as f32 == vmd_lookup_frame)
-            .collect();
-        let exact_vmd_rotation = exact_vmd_keyframes
-            .first()
-            .map(|kf| kf.rotation.to_axis_angle());
-        let prev_vmd_keyframe = vmd_keyframes
-            .iter()
-            .copied()
-            .filter(|kf| kf.frame as f32 <= vmd_lookup_frame)
-            .max_by_key(|kf| kf.frame)
-            .map(format_vmd_keyframe)
-            .unwrap_or_else(|| "none".to_owned());
-        let next_vmd_keyframe = vmd_keyframes
-            .iter()
-            .copied()
-            .filter(|kf| kf.frame as f32 > vmd_lookup_frame)
-            .min_by_key(|kf| kf.frame)
-            .map(format_vmd_keyframe)
-            .unwrap_or_else(|| "none".to_owned());
-        let bone_morphs =
-            describe_active_bone_morphs(&model_import.morph_name_to_index, &post_ik, &model, index);
-        println!(
-            "bone={} index={} oracleIndex={} preMaxDelta={:.9}@{} postMaxDelta={:.9}@{} prePosDelta=({:.6},{:.6},{:.6}) postPosDelta=({:.6},{:.6},{:.6}) prePos=({:.6},{:.6},{:.6}) postPos=({:.6},{:.6},{:.6}) oraclePos=({:.6},{:.6},{:.6}) preLocalOffset=({:.6},{:.6},{:.6}) postLocalOffset=({:.6},{:.6},{:.6}) oracleLocalPos=({:.6},{:.6},{:.6}) preLocalRotAxis=({:.6},{:.6},{:.6}) preLocalRotAngle={:.6} postLocalRotAxis=({:.6},{:.6},{:.6}) postLocalRotAngle={:.6} oracleLocalRotAxis=({:.6},{:.6},{:.6}) oracleLocalRotAngle={:.6} vmdKeys={} exactVmdKeys={} exactVmdRot={} prevVmd={} nextVmd={} activeBoneMorphs={}",
-            bone_name,
-            index.as_usize(),
-            oracle_bone.index,
-            pre_delta,
-            pre_component,
-            post_delta,
-            post_component,
-            pre_pos_delta[0],
-            pre_pos_delta[1],
-            pre_pos_delta[2],
-            post_pos_delta[0],
-            post_pos_delta[1],
-            post_pos_delta[2],
-            pre[12],
-            pre[13],
-            pre[14],
-            post[12],
-            post[13],
-            post[14],
-            oracle_bone.world_matrix[12],
-            oracle_bone.world_matrix[13],
-            oracle_bone.world_matrix[14],
-            pre_local_pos.x,
-            pre_local_pos.y,
-            pre_local_pos.z,
-            post_local_pos.x,
-            post_local_pos.y,
-            post_local_pos.z,
-            oracle_local_pos.x,
-            oracle_local_pos.y,
-            oracle_local_pos.z,
-            pre_local_axis.0.x,
-            pre_local_axis.0.y,
-            pre_local_axis.0.z,
-            pre_local_axis.1,
-            post_local_axis.0.x,
-            post_local_axis.0.y,
-            post_local_axis.0.z,
-            post_local_axis.1,
-            oracle_local_axis.0.x,
-            oracle_local_axis.0.y,
-            oracle_local_axis.0.z,
-            oracle_local_axis.1,
-            vmd_keyframes.len(),
-            exact_vmd_keyframes.len(),
-            exact_vmd_rotation
-                .map(|axis| format!(
-                    "axis=({:.6},{:.6},{:.6}) angle={:.6}",
-                    axis.0.x, axis.0.y, axis.0.z, axis.1
-                ))
-                .unwrap_or_else(|| "none".to_owned()),
-            prev_vmd_keyframe,
-            next_vmd_keyframe,
-            bone_morphs,
-        );
-    }
-
-    Ok(ExitCode::SUCCESS)
-}
-
-struct DiagnoseNumericBoneOptions {
-    eval_frame: f32,
-    bone_names: Vec<String>,
-}
-
-fn parse_diagnose_numeric_bone_rest(
-    rest: Vec<String>,
-    default_eval_frame: f32,
-) -> DiagnoseNumericBoneOptions {
-    let mut eval_frame = default_eval_frame;
-    let mut bone_names = Vec::new();
-    let mut iter = rest.into_iter();
-    while let Some(arg) = iter.next() {
-        if arg == "--eval-frame" {
-            let Some(value) = iter.next() else {
-                eprintln!("{DIAGNOSE_NUMERIC_BONE_USAGE}");
-                std::process::exit(1);
-            };
-            eval_frame = value.parse().unwrap_or_else(|_| {
-                eprintln!("{DIAGNOSE_NUMERIC_BONE_USAGE}");
-                std::process::exit(1);
-            });
-        } else if arg.starts_with("--") {
-            eprintln!("unknown flag: {arg}");
-            eprintln!("{DIAGNOSE_NUMERIC_BONE_USAGE}");
-            std::process::exit(1);
-        } else {
-            bone_names.push(arg);
-        }
-    }
-    DiagnoseNumericBoneOptions {
-        eval_frame,
-        bone_names,
-    }
-}
-
-fn describe_active_bone_morphs(
-    morph_name_to_index: &HashMap<Vec<u8>, MorphIndex>,
-    runtime: &RuntimeInstance,
-    model: &ModelArena,
-    target_bone: BoneIndex,
-) -> String {
-    let mut entries = Vec::new();
-    for morph_index in 0..model.morph_count() as usize {
-        let span = model.bone_morph_spans()[morph_index];
-        if span.count == 0 {
-            continue;
-        }
-        let weight = runtime.pose().morph_weight(MorphIndex(morph_index as u32));
-        for offset_index in span.start..span.start + span.count {
-            let offset = model.bone_morph_offsets()[offset_index as usize];
-            if offset.target_bone != target_bone {
-                continue;
-            }
-            let axis = offset.rotation_offset.to_axis_angle();
-            entries.push(format!(
-                "morph={} name={} weight={:.6} pos=({:.6},{:.6},{:.6}) rotAxis=({:.6},{:.6},{:.6}) rotAngle={:.6}",
-                morph_index,
-                morph_names_for_index(morph_name_to_index, MorphIndex(morph_index as u32)).join("|"),
-                weight,
-                offset.position_offset.x,
-                offset.position_offset.y,
-                offset.position_offset.z,
-                axis.0.x,
-                axis.0.y,
-                axis.0.z,
-                axis.1
-            ));
-        }
-    }
-    if entries.is_empty() {
-        "none".to_owned()
-    } else {
-        entries.join(";")
-    }
-}
-
-fn morph_names_for_index(
-    morph_name_to_index: &HashMap<Vec<u8>, MorphIndex>,
-    target_index: MorphIndex,
-) -> Vec<String> {
-    let mut names: Vec<String> = morph_name_to_index
-        .iter()
-        .filter_map(|(name, index)| {
-            if *index != target_index {
-                return None;
-            }
-            String::from_utf8(name.clone()).ok()
-        })
-        .collect();
-    names.sort();
-    names.dedup();
-    names
-}
-
-fn format_vmd_keyframe(kf: &VmdBoneKeyframeRaw) -> String {
-    let axis = kf.rotation.to_axis_angle();
-    format!(
-        "frame={} pos=({:.6},{:.6},{:.6}) rotAxis=({:.6},{:.6},{:.6}) rotAngle={:.6}",
-        kf.frame, kf.position.x, kf.position.y, kf.position.z, axis.0.x, axis.0.y, axis.0.z, axis.1
-    )
-}
-
-fn oracle_local_matrix(
-    oracle_model: &MmdDumperOracleModel,
-    model: &ModelArena,
-    oracle_bone: &MmdDumperOracleBone,
-) -> [f32; 16] {
-    let bone_matrix = glam::Mat4::from_cols_array(&oracle_bone.world_matrix);
-    let Some(parent) = model.parent_index(BoneIndex(oracle_bone.index as u32)) else {
-        return oracle_bone.world_matrix;
-    };
-    let Some(parent_bone) = oracle_model
-        .bones
-        .iter()
-        .find(|bone| bone.index == parent.as_usize() as i32)
-    else {
-        return oracle_bone.world_matrix;
-    };
-    let parent_matrix = glam::Mat4::from_cols_array(&parent_bone.world_matrix);
-    (parent_matrix.inverse() * bone_matrix).to_cols_array()
-}
-
-fn max_matrix_delta(actual: &[f32; 16], expected: &[f32; 16]) -> (usize, f32) {
-    let mut max_component = 0;
-    let mut max_delta = 0.0f32;
-    for component in 0..16 {
-        let delta = (actual[component] - expected[component]).abs();
-        if delta > max_delta {
-            max_component = component;
-            max_delta = delta;
-        }
-    }
-    (max_component, max_delta)
-}
-
-fn position_delta(actual: &[f32; 16], expected: &[f32; 16]) -> [f32; 3] {
-    [
-        actual[12] - expected[12],
-        actual[13] - expected[13],
-        actual[14] - expected[14],
-    ]
-}
-
-fn motion_case_focus_bones(
-    case: &serde_json::Value,
-    default_focus_bones: Option<&[String]>,
-) -> Vec<String> {
-    json_string_array(case, "/metadata/focus/bones")
-        .or_else(|| json_string_array(case, "/focus/bones"))
-        .or_else(|| default_focus_bones.map(|bones| bones.to_vec()))
-        .unwrap_or_else(|| {
-            DEFAULT_FOCUSED_IK_BONE_NAMES
-                .iter()
-                .map(|name| (*name).to_owned())
-                .collect()
-        })
-}
-
-fn json_string_array(value: &serde_json::Value, pointer: &str) -> Option<Vec<String>> {
-    let values = value.pointer(pointer)?.as_array()?;
-    let strings: Vec<String> = values
-        .iter()
-        .filter_map(|value| value.as_str().map(ToOwned::to_owned))
-        .collect();
-    (!strings.is_empty()).then_some(strings)
-}
-
-fn json_f32(value: &serde_json::Value, pointer: &str) -> Option<f32> {
-    value.pointer(pointer)?.as_f64().map(|value| value as f32)
-}
-
-fn collect_unsupported_targets(case: &serde_json::Value, skipped_targets: &mut HashSet<String>) {
-    let Some(targets) = case
-        .pointer("/compare/targets")
-        .and_then(|value| value.as_array())
-    else {
-        return;
-    };
-    for target in targets {
-        let Some(target) = target.as_str() else {
-            continue;
-        };
-        if !matches!(target, "bones") {
-            skipped_targets.insert(target.to_owned());
+            eprintln!("{error}");
+            ExitCode::FAILURE
         }
     }
 }
 
-fn numeric_case_frames(case: &serde_json::Value) -> Result<Vec<i32>, Box<dyn std::error::Error>> {
-    let frames = case
-        .get("frames")
-        .and_then(|value| value.as_array())
-        .ok_or("numeric compare case is missing frames")?;
-    frames
-        .iter()
-        .map(|frame| {
-            frame
-                .as_i64()
-                .and_then(|frame| i32::try_from(frame).ok())
-                .ok_or_else(|| "numeric compare frame must be an i32".into())
-        })
-        .collect()
-}
+// ---------------------------------------------------------------------------
+// Functions that remain in the crate root (used by multiple modules)
+// ---------------------------------------------------------------------------
 
-fn resolve_manifest_path(manifest_dir: &Path, value: &str) -> PathBuf {
-    let path = PathBuf::from(value);
+pub(crate) fn resolve_maybe_absolute(root: &Path, path: &str) -> PathBuf {
+    let path = PathBuf::from(path);
     if path.is_absolute() {
         path
     } else {
-        manifest_dir.join(path)
+        root.join(path)
     }
 }
 
-fn resolve_camera_vmd_path(
-    case: &serde_json::Value,
-    manifest_dir: &Path,
-    case_dir: Option<&Path>,
-) -> Result<PathBuf, Box<dyn std::error::Error>> {
-    let camera_vmd = case
-        .pointer("/assets/cameraMotion")
-        .or_else(|| case.pointer("/assets/cameraVmd"))
-        .or_else(|| case.get("cameraVmd"))
-        .or_else(|| case.get("cameraMotion"))
-        .and_then(|value| value.as_str())
-        .ok_or("camera manifest case is missing assets.cameraMotion/cameraVmd")?;
-    let camera_vmd = resolve_manifest_path(manifest_dir, camera_vmd);
-    if camera_vmd.exists() {
-        return Ok(camera_vmd);
+pub(crate) fn translation_checksum(matrices: &[glam::Mat4]) -> u32 {
+    let mut hash: u32 = 0x811c_9dc5;
+    for m in matrices {
+        hash ^= m.w_axis.x.to_bits();
+        hash = hash.wrapping_mul(0x0100_0193);
+        hash ^= m.w_axis.y.to_bits();
+        hash = hash.wrapping_mul(0x0100_0193);
+        hash ^= m.w_axis.z.to_bits();
+        hash = hash.wrapping_mul(0x0100_0193);
     }
-
-    let fixture_path = case
-        .get("fixture")
-        .and_then(|value| value.as_str())
-        .map(|path| resolve_manifest_path(manifest_dir, path))
-        .or_else(|| case_dir.map(|case_dir| case_dir.join("fixture.json")));
-    let Some(fixture_path) = fixture_path else {
-        return Err(format!(
-            "{} does not exist and no fixture path is available",
-            camera_vmd.display()
-        )
-        .into());
-    };
-    let fixture: serde_json::Value = serde_json::from_slice(&fs::read(&fixture_path)?)?;
-    let staged = fixture
-        .get("stagedCameraVmd")
-        .or_else(|| fixture.get("stagedCameraMotion"))
-        .and_then(|value| value.as_str())
-        .ok_or_else(|| {
-            format!(
-                "{} does not exist and {} is missing stagedCameraVmd/stagedCameraMotion",
-                camera_vmd.display(),
-                fixture_path.display()
-            )
-        })?;
-    let fixture_dir = fixture_path.parent().unwrap_or(manifest_dir);
-    Ok(resolve_manifest_path(fixture_dir, staged))
+    hash
 }
 
-fn resolve_camera_oracle_path(
-    case: &serde_json::Value,
-    manifest_dir: &Path,
-    case_dir: Option<&Path>,
-) -> Result<PathBuf, Box<dyn std::error::Error>> {
-    if let Some(output) = case
-        .pointer("/oracle/path")
-        .or_else(|| case.get("output"))
-        .and_then(|value| value.as_str())
-    {
-        return Ok(resolve_manifest_path(manifest_dir, output));
+pub(crate) fn f32_checksum(values: &[f32]) -> u32 {
+    let mut hash: u32 = 0x811c_9dc5;
+    for value in values {
+        hash ^= value.to_bits();
+        hash = hash.wrapping_mul(0x0100_0193);
     }
-    if let Some(case_dir) = case_dir {
-        return Ok(case_dir.join("oracle.actual.json"));
-    }
-    Err(
-        "camera manifest case is missing oracle.path/output and no defaults.outDir is available"
-            .into(),
-    )
+    hash
 }
 
-fn expected_number(
-    camera: &serde_json::Value,
-    field: &str,
-) -> Result<f64, Box<dyn std::error::Error>> {
-    camera
-        .get(field)
-        .and_then(|value| value.as_f64())
-        .ok_or_else(|| format!("camera.{field} is missing").into())
-}
-
-fn expected_array3(
-    camera: &serde_json::Value,
-    field: &str,
-) -> Result<[f64; 3], Box<dyn std::error::Error>> {
-    let values = camera
-        .get(field)
-        .and_then(|value| value.as_array())
-        .ok_or_else(|| format!("camera.{field} is missing"))?;
-    if values.len() != 3 {
-        return Err(format!("camera.{field} must have exactly 3 values").into());
-    }
-    Ok([
-        values[0]
-            .as_f64()
-            .ok_or_else(|| format!("camera.{field}[0] is not a number"))?,
-        values[1]
-            .as_f64()
-            .ok_or_else(|| format!("camera.{field}[1] is not a number"))?,
-        values[2]
-            .as_f64()
-            .ok_or_else(|| format!("camera.{field}[2] is not a number"))?,
-    ])
-}
-
-fn compare_camera_vec3(
-    case_name: &str,
-    frame: f64,
-    field: &str,
-    actual: [f32; 3],
-    expected: [f64; 3],
-    epsilon: f64,
-    max_delta: &mut f64,
-) -> usize {
-    let mut mismatches = 0usize;
-    for component in 0..3 {
-        mismatches += compare_camera_scalar(
-            case_name,
-            frame,
-            &format!("{field}[{component}]"),
-            actual[component] as f64,
-            expected[component],
-            epsilon,
-            max_delta,
-        );
-    }
-    mismatches
-}
-
-fn compare_camera_scalar(
-    case_name: &str,
-    frame: f64,
-    field: &str,
-    actual: f64,
-    expected: f64,
-    epsilon: f64,
-    max_delta: &mut f64,
-) -> usize {
-    let delta = (actual - expected).abs();
-    *max_delta = (*max_delta).max(delta);
-    if delta <= epsilon {
-        0
-    } else {
-        eprintln!(
-            "camera mismatch case={} frame={} field={} actual={:.9} expected={:.9} delta={:.9}",
-            case_name, frame, field, actual, expected, delta
-        );
-        1
+pub(crate) fn copy_world_matrices_to_f32(matrices: &[glam::Mat4], out: &mut [f32]) {
+    debug_assert!(out.len() >= matrices.len() * 16);
+    for (index, matrix) in matrices.iter().enumerate() {
+        let offset = index * 16;
+        out[offset..offset + 16].copy_from_slice(&matrix.to_cols_array());
     }
 }
 
-fn import_vmd_summary(path: &Path) -> Result<ExitCode, Box<dyn std::error::Error>> {
-    let data = fs::read(path)?;
-    let imported = mmd_anim_format::import_vmd_motion(&data)?;
-    let property_ik_entries: usize = imported
-        .property_ik_frames
-        .iter()
-        .map(|frame| frame.entries.len())
-        .sum();
-    println!(
-        "VMD runtime import: boneKeys={} morphKeys={} propertyFrames={} propertyIkEntries={}",
-        imported.bone_keyframes.len(),
-        imported.morph_keyframes.len(),
-        imported.property_ik_frames.len(),
-        property_ik_entries
-    );
-    Ok(ExitCode::SUCCESS)
-}
-
-fn import_pair_summary(
-    pmx_path: &Path,
-    vmd_path: &Path,
-) -> Result<ExitCode, Box<dyn std::error::Error>> {
-    let pmx = mmd_anim_format::import_pmx_runtime(&fs::read(pmx_path)?)?;
-    let vmd = mmd_anim_format::import_vmd_motion(&fs::read(vmd_path)?)?;
-
-    let matched_bone_keys = vmd
-        .bone_keyframes
-        .iter()
-        .filter(|keyframe| {
-            pmx.bone_name_to_index
-                .contains_key(&keyframe.bone_name_normalized)
-        })
-        .count();
-    let matched_morph_keys = vmd
-        .morph_keyframes
-        .iter()
-        .filter(|(name, _, _)| {
-            let normalized = mmd_anim_format::normalize_vmd_name(name);
-            pmx.morph_name_to_index.contains_key(&normalized)
-        })
-        .count();
-    let property_ik_entries: usize = vmd
-        .property_ik_frames
-        .iter()
-        .map(|frame| frame.entries.len())
-        .sum();
-    let matched_property_ik_entries = vmd
-        .property_ik_frames
-        .iter()
-        .flat_map(|frame| frame.entries.iter())
-        .filter(|entry| {
-            pmx.ik_solver_bone_name_to_index
-                .contains_key(&entry.name_normalized)
-        })
-        .count();
-
-    println!(
-        "PMX/VMD runtime import: bones={} append={} fixedAxis={} ik={} vmdBoneKeys={} matchedBoneKeys={} vmdMorphKeys={} matchedMorphKeys={} propertyFrames={} propertyIkEntries={} matchedPropertyIkEntries={}",
-        pmx.model.bone_count(),
-        pmx.model.append_transforms().len(),
-        pmx.model.fixed_axis_count(),
-        pmx.model.ik_count(),
-        vmd.bone_keyframes.len(),
-        matched_bone_keys,
-        vmd.morph_keyframes.len(),
-        matched_morph_keys,
-        vmd.property_ik_frames.len(),
-        property_ik_entries,
-        matched_property_ik_entries
-    );
-    Ok(ExitCode::SUCCESS)
-}
-
-fn import_pair_clip_summary(
-    pmx_path: &Path,
-    vmd_path: &Path,
-) -> Result<ExitCode, Box<dyn std::error::Error>> {
-    let pmx = mmd_anim_format::import_pmx_runtime(&fs::read(pmx_path)?)?;
-    let vmd = mmd_anim_format::import_vmd_motion(&fs::read(vmd_path)?)?;
-
-    let solver_count = pmx.model.ik_count();
-    let clip = mmd_anim_format::build_pair_clip(
-        &vmd,
-        &pmx.bone_name_to_index,
-        &pmx.morph_name_to_index,
-        &pmx.ik_solver_bone_name_to_index,
-        solver_count,
-    );
-
-    let frame_range = clip
-        .frame_range()
-        .map(|(first, last)| format!("{first}..{last}"))
-        .unwrap_or_else(|| "none".to_owned());
-
-    println!(
-        "Pair clip built: bones={} append={} fixedAxis={} ik={} clipBoneTracks={} clipMorphTracks={} propertyTrack={} frameRange={}",
-        pmx.model.bone_count(),
-        pmx.model.append_transforms().len(),
-        pmx.model.fixed_axis_count(),
-        pmx.model.ik_count(),
-        clip.bone_track_count(),
-        clip.morph_track_count(),
-        clip.has_property_track(),
-        frame_range
-    );
-    Ok(ExitCode::SUCCESS)
-}
-
-fn oracle_summary(path: &str) -> Result<ExitCode, Box<dyn std::error::Error>> {
-    let content = fs::read_to_string(path)?;
-    let dump = MmdDumperOracleDump::from_jsonl_str(&content, None)?;
-    let model_count = dump
-        .frames
-        .iter()
-        .map(|frame| frame.models.len())
-        .max()
-        .unwrap_or(0);
-    let bone_count = dump
-        .frames
-        .first()
-        .and_then(|frame| frame.models.first())
-        .map(|model| model.bones.len())
-        .unwrap_or(0);
-    let morph_count = dump
-        .frames
-        .first()
-        .and_then(|frame| frame.models.first())
-        .map(|model| model.morphs.len())
-        .unwrap_or(0);
-
-    println!(
-        "MMDDumper oracle: frames={} models={} firstModelBones={} firstModelMorphs={} mmd={} dumper={}",
-        dump.frames.len(),
-        model_count,
-        bone_count,
-        morph_count,
-        dump.source.mmd_version,
-        dump.source.dumper_version
-    );
-    Ok(ExitCode::SUCCESS)
-}
+// ---------------------------------------------------------------------------
+// Functions that stay in main because they reference main-only schemas
+// ---------------------------------------------------------------------------
 
 fn golden_ik_summary(root: &Path) -> Result<ExitCode, Box<dyn std::error::Error>> {
+    use std::fs;
+    use mmd_anim_schema::{DEFAULT_FOCUSED_IK_BONE_NAMES, GoldenIkBatchManifest, GoldenIkFixture, MmdDumperOracleDump};
+
     let manifest_path = root.join("oracle-batch.json");
     let manifest = GoldenIkBatchManifest::from_json_str(&fs::read_to_string(&manifest_path)?)?;
     let mut parsed_cases = 0usize;
@@ -3454,6 +557,9 @@ fn golden_ik_summary(root: &Path) -> Result<ExitCode, Box<dyn std::error::Error>
 }
 
 fn golden_parser_summary(root: &Path) -> Result<ExitCode, Box<dyn std::error::Error>> {
+    use std::fs;
+    use mmd_anim_schema::{GoldenIkBatchManifest, GoldenIkFixture, MmdDumperOracleDump};
+
     let manifest_path = root.join("oracle-batch.json");
     let manifest = GoldenIkBatchManifest::from_json_str(&fs::read_to_string(&manifest_path)?)?;
     let mut parsed_cases = 0usize;
@@ -3552,607 +658,22 @@ fn golden_parser_summary(root: &Path) -> Result<ExitCode, Box<dyn std::error::Er
     Ok(ExitCode::SUCCESS)
 }
 
-pub(crate) fn resolve_maybe_absolute(root: &Path, path: &str) -> PathBuf {
-    let path = PathBuf::from(path);
-    if path.is_absolute() {
-        path
-    } else {
-        root.join(path)
-    }
-}
-
-fn import_pair_frame_summary(
-    pmx_path: &Path,
-    vmd_path: &Path,
-    frame: f32,
-) -> Result<ExitCode, Box<dyn std::error::Error>> {
-    let pmx = mmd_anim_format::import_pmx_runtime(&fs::read(pmx_path)?)?;
-    let vmd = mmd_anim_format::import_vmd_motion(&fs::read(vmd_path)?)?;
-
-    let bone_count = pmx.model.bone_count();
-    let solver_count = pmx.model.ik_count();
-    let morph_count = pmx
-        .morph_name_to_index
-        .values()
-        .map(|index| index.as_usize() + 1)
-        .max()
-        .unwrap_or(0);
-
-    let clip = mmd_anim_format::build_pair_clip(
-        &vmd,
-        &pmx.bone_name_to_index,
-        &pmx.morph_name_to_index,
-        &pmx.ik_solver_bone_name_to_index,
-        solver_count,
-    );
-
-    let model = Arc::new(pmx.model);
-    let mut runtime = RuntimeInstance::new_with_counts(model, morph_count, solver_count);
-
-    runtime.evaluate_clip_frame(&clip, frame);
-
-    let world_matrices = runtime.world_matrices();
-
-    let first_translation = if let Some(m) = world_matrices.first() {
-        Vec3A::new(m.w_axis.x, m.w_axis.y, m.w_axis.z)
-    } else {
-        Vec3A::ZERO
-    };
-
-    let checksum = translation_checksum(world_matrices);
-    let morph_weights = runtime.morph_weights();
-    let nonzero_morphs = morph_weights
-        .iter()
-        .filter(|weight| weight.abs() > f32::EPSILON)
-        .count();
-    let morph_checksum = f32_checksum(morph_weights);
-
-    println!(
-        "PMX/VMD frame {:.3}: bones={} ik={} clipBoneTracks={} clipMorphTracks={} worldMatrices={} firstTranslation=({:.6},{:.6},{:.6}) translationChecksum={:08x} nonzeroMorphs={} morphChecksum={:08x}",
-        frame,
-        bone_count,
-        solver_count,
-        clip.bone_track_count(),
-        clip.morph_track_count(),
-        world_matrices.len(),
-        first_translation.x,
-        first_translation.y,
-        first_translation.z,
-        checksum,
-        nonzero_morphs,
-        morph_checksum,
-    );
-
-    Ok(ExitCode::SUCCESS)
-}
-
-#[derive(Debug)]
-struct BenchPairConfig {
-    pmx_path: PathBuf,
-    vmd_path: PathBuf,
-    start_frame: f32,
-    frame_count: usize,
-    step: f32,
-    solve_ik: bool,
-    ik_options: IkSolveOptions,
-}
-
-fn bench_pair(cfg: BenchPairConfig) -> Result<ExitCode, Box<dyn std::error::Error>> {
-    let total_start = Instant::now();
-
-    let read_start = Instant::now();
-    let pmx_bytes = fs::read(&cfg.pmx_path)?;
-    let vmd_bytes = fs::read(&cfg.vmd_path)?;
-    let read_elapsed = read_start.elapsed();
-
-    let pmx_start = Instant::now();
-    let pmx = mmd_anim_format::import_pmx_runtime(&pmx_bytes)?;
-    let pmx_elapsed = pmx_start.elapsed();
-
-    let vmd_start = Instant::now();
-    let vmd = mmd_anim_format::import_vmd_motion(&vmd_bytes)?;
-    let vmd_elapsed = vmd_start.elapsed();
-
-    let bone_count = pmx.model.bone_count();
-    let append_count = pmx.model.append_transforms().len();
-    let fixed_axis_count = pmx.model.fixed_axis_count();
-    let solver_count = pmx.model.ik_count();
-    let ik_solver_summaries = pmx
-        .model
-        .ik_solvers()
-        .iter()
-        .enumerate()
-        .map(|(index, solver)| {
-            let name = pmx
-                .bone_names
-                .get(solver.ik_bone.as_usize())
-                .cloned()
-                .unwrap_or_else(|| "<unknown>".to_owned());
-            (
-                index,
-                solver.ik_bone.as_usize(),
-                name,
-                solver.iteration_count,
-                solver.links.len(),
-            )
-        })
-        .collect::<Vec<_>>();
-    let morph_count = pmx
-        .morph_name_to_index
-        .values()
-        .map(|index| index.as_usize() + 1)
-        .max()
-        .unwrap_or(0);
-
-    let clip_start = Instant::now();
-    let clip = mmd_anim_format::build_pair_clip(
-        &vmd,
-        &pmx.bone_name_to_index,
-        &pmx.morph_name_to_index,
-        &pmx.ik_solver_bone_name_to_index,
-        solver_count,
-    );
-    let clip_elapsed = clip_start.elapsed();
-
-    let model = Arc::new(pmx.model);
-    let mut runtime = RuntimeInstance::new_with_counts(model, morph_count, solver_count);
-    runtime.reset_ik_runtime_stats();
-
-    let eval_start = Instant::now();
-    let mut checksum = 0u32;
-    let mut morph_checksum = 0u32;
-    for i in 0..cfg.frame_count {
-        let frame = cfg.start_frame + cfg.step * i as f32;
-        if cfg.solve_ik {
-            runtime.evaluate_clip_frame_with_ik_options(&clip, frame, cfg.ik_options);
-        } else {
-            runtime.evaluate_clip_frame_without_ik(&clip, frame);
-        }
-        checksum = checksum.rotate_left(1) ^ translation_checksum(runtime.world_matrices());
-        morph_checksum = morph_checksum.rotate_left(1) ^ f32_checksum(runtime.morph_weights());
-    }
-    let eval_elapsed = eval_start.elapsed();
-    let total_elapsed = total_start.elapsed();
-
-    let frame_range = clip
-        .frame_range()
-        .map(|(first, last)| format!("{first}..{last}"))
-        .unwrap_or_else(|| "none".to_owned());
-    let eval_ms = eval_elapsed.as_secs_f64() * 1000.0;
-    let ms_per_frame = eval_ms / cfg.frame_count as f64;
-    let fps = cfg.frame_count as f64 / eval_elapsed.as_secs_f64();
-
-    println!(
-        "bench-pair: bones={} ik={} ikTolerance={:.8} ikMaxIterationsCap={} append={} fixedAxis={} vmdBoneKeys={} vmdMorphKeys={} clipBoneTracks={} clipMorphTracks={} propertyTrack={} clipFrameRange={} frames={} startFrame={:.3} step={:.3} readMs={:.3} pmxImportMs={:.3} vmdImportMs={:.3} clipBuildMs={:.3} evalMs={:.3} msPerFrame={:.6} fps={:.1} totalMs={:.3} checksum={:08x} morphChecksum={:08x}",
-        bone_count,
-        if cfg.solve_ik {
-            solver_count.to_string()
-        } else {
-            "disabled".to_owned()
-        },
-        cfg.ik_options.tolerance,
-        cfg.ik_options
-            .max_iterations_cap
-            .map(|value| value.to_string())
-            .unwrap_or_else(|| "none".to_owned()),
-        append_count,
-        fixed_axis_count,
-        vmd.bone_keyframes.len(),
-        vmd.morph_keyframes.len(),
-        clip.bone_track_count(),
-        clip.morph_track_count(),
-        clip.has_property_track(),
-        frame_range,
-        cfg.frame_count,
-        cfg.start_frame,
-        cfg.step,
-        read_elapsed.as_secs_f64() * 1000.0,
-        pmx_elapsed.as_secs_f64() * 1000.0,
-        vmd_elapsed.as_secs_f64() * 1000.0,
-        clip_elapsed.as_secs_f64() * 1000.0,
-        eval_ms,
-        ms_per_frame,
-        fps,
-        total_elapsed.as_secs_f64() * 1000.0,
-        checksum,
-        morph_checksum,
-    );
-    if cfg.solve_ik {
-        let stats = runtime.ik_runtime_stats();
-        let total_evaluations = stats
-            .iter()
-            .map(|stats| stats.solver_evaluations)
-            .sum::<u64>();
-        let configured_iterations = stats
-            .iter()
-            .map(|stats| stats.configured_iterations)
-            .sum::<u64>();
-        let executed_iterations = stats
-            .iter()
-            .map(|stats| stats.executed_iterations)
-            .sum::<u64>();
-        let skipped_iterations = configured_iterations.saturating_sub(executed_iterations);
-        let tolerance_precheck_breaks = stats
-            .iter()
-            .map(|stats| stats.tolerance_precheck_breaks)
-            .sum::<u64>();
-        let tolerance_post_iteration_breaks = stats
-            .iter()
-            .map(|stats| stats.tolerance_post_iteration_breaks)
-            .sum::<u64>();
-        let rollback_breaks = stats.iter().map(|stats| stats.rollback_breaks).sum::<u64>();
-        let max_iteration_exhaustions = stats
-            .iter()
-            .map(|stats| stats.max_iteration_exhaustions)
-            .sum::<u64>();
-        let link_steps = stats.iter().map(|stats| stats.link_steps).sum::<u64>();
-        let skip_ratio = if configured_iterations == 0 {
-            0.0
-        } else {
-            skipped_iterations as f64 / configured_iterations as f64
-        };
-        println!(
-            "bench-pair-ik-stats: solverEvaluations={} configuredIterations={} executedIterations={} skippedIterations={} skippedRatio={:.3} tolerancePrecheckBreaks={} tolerancePostIterationBreaks={} rollbackBreaks={} maxIterationExhaustions={} linkSteps={}",
-            total_evaluations,
-            configured_iterations,
-            executed_iterations,
-            skipped_iterations,
-            skip_ratio,
-            tolerance_precheck_breaks,
-            tolerance_post_iteration_breaks,
-            rollback_breaks,
-            max_iteration_exhaustions,
-            link_steps,
-        );
-
-        let mut ranked = stats
-            .iter()
-            .enumerate()
-            .map(|(index, stats)| (index, *stats))
-            .collect::<Vec<_>>();
-        ranked.sort_by_key(|(_, stats)| {
-            std::cmp::Reverse((stats.executed_iterations, stats.configured_iterations))
-        });
-        for (index, stats) in ranked.into_iter().take(8) {
-            let (solver_index, bone_index, name, max_iterations, links) =
-                &ik_solver_summaries[index];
-            let skipped = stats
-                .configured_iterations
-                .saturating_sub(stats.executed_iterations);
-            let avg_final_distance = if stats.solver_evaluations == 0 {
-                0.0
-            } else {
-                stats.final_distance_sum / stats.solver_evaluations as f64
-            };
-            let avg_exhausted_final_distance = if stats.max_iteration_exhaustions == 0 {
-                0.0
-            } else {
-                stats.exhausted_final_distance_sum / stats.max_iteration_exhaustions as f64
-            };
-            println!(
-                "bench-pair-ik-solver: solver={} bone={} name={} maxIterations={} links={} evaluations={} configuredIterations={} executedIterations={} skippedIterations={} precheckBreaks={} postBreaks={} rollbackBreaks={} exhausted={} avgFinalDistance={:.8} maxFinalDistance={:.8} avgExhaustedFinalDistance={:.8} maxExhaustedFinalDistance={:.8}",
-                solver_index,
-                bone_index,
-                name,
-                max_iterations,
-                links,
-                stats.solver_evaluations,
-                stats.configured_iterations,
-                stats.executed_iterations,
-                skipped,
-                stats.tolerance_precheck_breaks,
-                stats.tolerance_post_iteration_breaks,
-                stats.rollback_breaks,
-                stats.max_iteration_exhaustions,
-                avg_final_distance,
-                stats.final_distance_max,
-                avg_exhausted_final_distance,
-                stats.exhausted_final_distance_max,
-            );
-        }
-    }
-
-    Ok(ExitCode::SUCCESS)
-}
-
-#[derive(Debug)]
-struct BenchSyntheticConfig {
-    models: usize,
-    bones: usize,
-    frames: u32,
-    use_json: bool,
-}
-
-fn bench_synthetic(cfg: BenchSyntheticConfig) -> Result<ExitCode, Box<dyn std::error::Error>> {
-    let model_count = cfg.models;
-    let bone_count = cfg.bones;
-    let frame_count = cfg.frames;
-    let use_json = cfg.use_json;
-    if model_count == 0 || bone_count == 0 || frame_count == 0 {
-        return Err("models, bones, and frames must be positive".into());
-    }
-
-    // Build chain of bones: bone 0 = root, each child parented to previous
-    let mut bones = Vec::with_capacity(bone_count);
-    for i in 0..bone_count {
-        let parent = if i == 0 {
-            None
-        } else {
-            Some(BoneIndex(i as u32 - 1))
-        };
-        bones.push(BoneInit::new(parent, Vec3A::new(0.0, i as f32 * 5.0, 0.0)));
-    }
-    let model = Arc::new(ModelArena::new(bones)?);
-
-    // Build clip with two keyframes per bone (linear interpolation)
-    let mut bone_tracks = Vec::with_capacity(bone_count);
-    for i in 0..bone_count {
-        let angle = 0.1 + (i as f32) * 0.02;
-        let track = MovableBoneTrack::from_keyframes(vec![
-            MovableBoneKeyframe::new(0, Vec3A::ZERO, Quat::IDENTITY),
-            MovableBoneKeyframe::new(
-                30,
-                Vec3A::new(1.0, 0.0, 0.0),
-                Quat::from_axis_angle(Vec3A::Y.into(), angle),
-            ),
-        ]);
-        bone_tracks.push(BoneAnimationBinding {
-            bone: BoneIndex(i as u32),
-            track,
-        });
-    }
-    let clip = AnimationClip::new(bone_tracks);
-
-    // Create model_count independent RuntimeInstances
-    let mut runtimes: Vec<RuntimeInstance> = (0..model_count)
-        .map(|_| RuntimeInstance::new(Arc::clone(&model)))
-        .collect();
-    let mut matrix_scratch = vec![0.0f32; bone_count * 16];
-
-    // Warm-up: one call to ensure any lazy init is done
-    for runtime in &mut runtimes {
-        runtime.evaluate_clip_frame(&clip, 0.0);
-        copy_world_matrices_to_f32(runtime.world_matrices(), &mut matrix_scratch);
-    }
-
-    // Timed loop
-    let mut rolling_checksum: u32 = 0;
-    let start = Instant::now();
-    for frame in 0..frame_count {
-        let frame_f = frame as f32;
-        for runtime in &mut runtimes {
-            runtime.evaluate_clip_frame(&clip, frame_f);
-            copy_world_matrices_to_f32(runtime.world_matrices(), &mut matrix_scratch);
-            rolling_checksum = rolling_checksum.wrapping_add(f32_checksum(&matrix_scratch));
-        }
-    }
-    let elapsed = start.elapsed();
-
-    // Accumulate checksum from final state (prevents dead-code elimination)
-    let mut final_checksum: u32 = 0;
-    for runtime in &runtimes {
-        final_checksum =
-            final_checksum.wrapping_add(translation_checksum(runtime.world_matrices()));
-    }
-    final_checksum ^= rolling_checksum;
-
-    let total_frames = frame_count as u64 * model_count as u64;
-    let elapsed_ms = elapsed.as_secs_f64() * 1000.0;
-    let fps = total_frames as f64 / elapsed.as_secs_f64();
-
-    if use_json {
-        println!(
-            r#"{{"models":{},"bones":{},"frames":{},"elapsedMs":{:.3},"totalFrames":{},"fps":{:.1},"checksum":"{:08x}"}}"#,
-            model_count, bone_count, frame_count, elapsed_ms, total_frames, fps, final_checksum
-        );
-    } else {
-        println!(
-            "bench-synthetic: models={} bones={} frames={} elapsedMs={:.3} totalFrames={} fps={:.1} checksum={:08x}",
-            model_count, bone_count, frame_count, elapsed_ms, total_frames, fps, final_checksum
-        );
-    }
-
-    Ok(ExitCode::SUCCESS)
-}
-
-fn parse_bench_synthetic_args(
-    args: &mut impl Iterator<Item = String>,
-) -> Result<BenchSyntheticConfig, Box<dyn std::error::Error>> {
-    let raw: Vec<String> = args.collect();
-    let mut use_json = false;
-    let mut positional = Vec::new();
-
-    for token in &raw {
-        if token == "--json" {
-            use_json = true;
-        } else if token.starts_with("--") {
-            return Err(format!("unknown flag: {token}").into());
-        } else {
-            positional.push(token.clone());
-        }
-    }
-
-    let mut pos_iter = positional.into_iter();
-    let models = optional_positive_usize_arg(&mut pos_iter, 1, "models")?;
-    let bones = optional_positive_usize_arg(&mut pos_iter, 32, "bones")?;
-    let frames = optional_positive_u32_arg(&mut pos_iter, 1000, "frames")?;
-    if let Some(extra) = pos_iter.next() {
-        return Err(format!("unexpected extra argument: {extra}").into());
-    }
-
-    Ok(BenchSyntheticConfig {
-        models,
-        bones,
-        frames,
-        use_json,
-    })
-}
-
-fn parse_bench_pair_args(
-    args: &mut impl Iterator<Item = String>,
-) -> Result<BenchPairConfig, Box<dyn std::error::Error>> {
-    let raw: Vec<String> = args.collect();
-    let mut solve_ik = true;
-    let mut ik_tolerance = IkSolveOptions::default().tolerance;
-    let mut ik_max_iterations_cap = None;
-    let mut positional = Vec::new();
-
-    let mut raw_iter = raw.into_iter();
-    while let Some(token) = raw_iter.next() {
-        match token.as_str() {
-            "--no-ik" => solve_ik = false,
-            "--ik-tolerance" => {
-                let value = raw_iter.next().ok_or("missing value for --ik-tolerance")?;
-                ik_tolerance = parse_finite_f32(&value, "ik-tolerance")?;
-                if ik_tolerance < 0.0 {
-                    return Err("ik-tolerance must be non-negative".into());
-                }
-            }
-            "--ik-max-iterations-cap" => {
-                let value = raw_iter
-                    .next()
-                    .ok_or("missing value for --ik-max-iterations-cap")?;
-                ik_max_iterations_cap = Some(parse_positive_u32(&value, "ik-max-iterations-cap")?);
-            }
-            _ if token.starts_with("--") => {
-                return Err(format!("unknown flag: {token}").into());
-            }
-            _ => positional.push(token),
-        }
-    }
-
-    let mut pos_iter = positional.into_iter();
-    let pmx_path = PathBuf::from(pos_iter.next().ok_or(BENCH_PAIR_USAGE)?);
-    let vmd_path = PathBuf::from(pos_iter.next().ok_or(BENCH_PAIR_USAGE)?);
-    let start_frame = optional_f32_parse_arg(&mut pos_iter, 0.0, "start-frame")?;
-    let frame_count = optional_positive_usize_arg(&mut pos_iter, 1000, "frame-count")?;
-    let step = optional_f32_parse_arg(&mut pos_iter, 1.0, "step")?;
-    if step <= 0.0 {
-        return Err("step must be positive".into());
-    }
-    if let Some(extra) = pos_iter.next() {
-        return Err(format!("unexpected extra argument: {extra}").into());
-    }
-
-    Ok(BenchPairConfig {
-        pmx_path,
-        vmd_path,
-        start_frame,
-        frame_count,
-        step,
-        solve_ik,
-        ik_options: IkSolveOptions {
-            tolerance: ik_tolerance,
-            max_iterations_cap: ik_max_iterations_cap,
-        },
-    })
-}
-
-fn optional_positive_usize_arg(
-    args: &mut impl Iterator<Item = String>,
-    default: usize,
-    label: &str,
-) -> Result<usize, Box<dyn std::error::Error>> {
-    let Some(value) = args.next() else {
-        return Ok(default);
-    };
-    let parsed = value
-        .parse::<usize>()
-        .map_err(|_| format!("invalid {label}: {value}"))?;
-    if parsed == 0 {
-        return Err(format!("{label} must be positive").into());
-    }
-    Ok(parsed)
-}
-
-fn optional_positive_u32_arg(
-    args: &mut impl Iterator<Item = String>,
-    default: u32,
-    label: &str,
-) -> Result<u32, Box<dyn std::error::Error>> {
-    let Some(value) = args.next() else {
-        return Ok(default);
-    };
-    let parsed = value
-        .parse::<u32>()
-        .map_err(|_| format!("invalid {label}: {value}"))?;
-    if parsed == 0 {
-        return Err(format!("{label} must be positive").into());
-    }
-    Ok(parsed)
-}
-
-fn parse_positive_u32(value: &str, label: &str) -> Result<u32, Box<dyn std::error::Error>> {
-    let parsed = value
-        .parse::<u32>()
-        .map_err(|_| format!("invalid {label}: {value}"))?;
-    if parsed == 0 {
-        return Err(format!("{label} must be positive").into());
-    }
-    Ok(parsed)
-}
-
-fn optional_f32_parse_arg(
-    args: &mut impl Iterator<Item = String>,
-    default: f32,
-    label: &str,
-) -> Result<f32, Box<dyn std::error::Error>> {
-    let Some(value) = args.next() else {
-        return Ok(default);
-    };
-    let parsed = value
-        .parse::<f32>()
-        .map_err(|_| format!("invalid {label}: {value}"))?;
-    if !parsed.is_finite() {
-        return Err(format!("{label} must be finite").into());
-    }
-    Ok(parsed)
-}
-
-fn parse_finite_f32(value: &str, label: &str) -> Result<f32, Box<dyn std::error::Error>> {
-    let parsed = value
-        .parse::<f32>()
-        .map_err(|_| format!("invalid {label}: {value}"))?;
-    if !parsed.is_finite() {
-        return Err(format!("{label} must be finite").into());
-    }
-    Ok(parsed)
-}
-
-fn copy_world_matrices_to_f32(matrices: &[glam::Mat4], out: &mut [f32]) {
-    debug_assert!(out.len() >= matrices.len() * 16);
-    for (index, matrix) in matrices.iter().enumerate() {
-        let offset = index * 16;
-        out[offset..offset + 16].copy_from_slice(&matrix.to_cols_array());
-    }
-}
-
-fn f32_checksum(values: &[f32]) -> u32 {
-    let mut hash: u32 = 0x811c_9dc5;
-    for value in values {
-        hash ^= value.to_bits();
-        hash = hash.wrapping_mul(0x0100_0193);
-    }
-    hash
-}
-
-fn translation_checksum(matrices: &[glam::Mat4]) -> u32 {
-    let mut hash: u32 = 0x811c_9dc5;
-    for m in matrices {
-        hash ^= m.w_axis.x.to_bits();
-        hash = hash.wrapping_mul(0x0100_0193);
-        hash ^= m.w_axis.y.to_bits();
-        hash = hash.wrapping_mul(0x0100_0193);
-        hash ^= m.w_axis.z.to_bits();
-        hash = hash.wrapping_mul(0x0100_0193);
-    }
-    hash
-}
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::time::{SystemTime, UNIX_EPOCH};
+    use std::{env, fs, sync::Arc, time::{SystemTime, UNIX_EPOCH}};
+
+    use glam::{Quat, Vec3A};
+    use mmd_anim_runtime::{
+        AnimationClip, BoneAnimationBinding, BoneIndex, BoneInit, ModelArena,
+        MovableBoneKeyframe, MovableBoneTrack, RuntimeInstance,
+    };
+
+    use crate::commands::{bench, compare, export, patch};
 
     fn unique_test_dir(name: &str) -> PathBuf {
         let nanos = SystemTime::now()
@@ -4244,7 +765,7 @@ mod tests {
     #[test]
     fn bench_synthetic_args_use_defaults() {
         let mut args = Vec::<String>::new().into_iter();
-        let cfg = parse_bench_synthetic_args(&mut args).unwrap();
+        let cfg = bench::parse_bench_synthetic_args(&mut args).unwrap();
         assert_eq!(cfg.models, 1);
         assert_eq!(cfg.bones, 32);
         assert_eq!(cfg.frames, 1000);
@@ -4254,7 +775,7 @@ mod tests {
     #[test]
     fn bench_synthetic_args_json_flag() {
         let mut args = vec!["--json".to_owned()].into_iter();
-        let cfg = parse_bench_synthetic_args(&mut args).unwrap();
+        let cfg = bench::parse_bench_synthetic_args(&mut args).unwrap();
         assert_eq!(cfg.models, 1);
         assert_eq!(cfg.bones, 32);
         assert_eq!(cfg.frames, 1000);
@@ -4270,7 +791,7 @@ mod tests {
             "50".to_owned(),
         ]
         .into_iter();
-        let cfg = parse_bench_synthetic_args(&mut args).unwrap();
+        let cfg = bench::parse_bench_synthetic_args(&mut args).unwrap();
         assert_eq!(cfg.models, 4);
         assert_eq!(cfg.bones, 16);
         assert_eq!(cfg.frames, 50);
@@ -4286,7 +807,7 @@ mod tests {
             "--json".to_owned(),
         ]
         .into_iter();
-        let cfg = parse_bench_synthetic_args(&mut args).unwrap();
+        let cfg = bench::parse_bench_synthetic_args(&mut args).unwrap();
         assert_eq!(cfg.models, 2);
         assert_eq!(cfg.bones, 8);
         assert_eq!(cfg.frames, 200);
@@ -4296,21 +817,21 @@ mod tests {
     #[test]
     fn bench_synthetic_args_reject_unknown_flag() {
         let mut args = vec!["--unknown".to_owned()].into_iter();
-        let error = parse_bench_synthetic_args(&mut args).unwrap_err();
+        let error = bench::parse_bench_synthetic_args(&mut args).unwrap_err();
         assert!(error.to_string().contains("unknown flag"));
     }
 
     #[test]
     fn bench_synthetic_args_reject_invalid_models() {
         let mut args = vec!["nope".to_owned()].into_iter();
-        let error = parse_bench_synthetic_args(&mut args).unwrap_err();
+        let error = bench::parse_bench_synthetic_args(&mut args).unwrap_err();
         assert!(error.to_string().contains("invalid models"));
     }
 
     #[test]
     fn bench_synthetic_args_reject_zero_models() {
         let mut args = vec!["0".to_owned()].into_iter();
-        let error = parse_bench_synthetic_args(&mut args).unwrap_err();
+        let error = bench::parse_bench_synthetic_args(&mut args).unwrap_err();
         assert!(error.to_string().contains("models must be positive"));
     }
 
@@ -4323,7 +844,7 @@ mod tests {
             "extra".to_owned(),
         ]
         .into_iter();
-        let error = parse_bench_synthetic_args(&mut args).unwrap_err();
+        let error = bench::parse_bench_synthetic_args(&mut args).unwrap_err();
         assert!(error.to_string().contains("unexpected extra argument"));
     }
 
@@ -4381,7 +902,7 @@ mod tests {
         )
         .unwrap();
 
-        let error = compare_numeric_manifest(&temp.join("manifest.json")).unwrap_err();
+        let error = compare::compare_numeric_manifest(&temp.join("manifest.json")).unwrap_err();
         let error = error.to_string();
         assert!(error.contains("cameraMismatches=0"));
         assert!(error.contains("motionMissing=1"));
@@ -4392,13 +913,13 @@ mod tests {
 
     #[test]
     fn numeric_compare_failure_count_includes_motion_mismatches() {
-        let camera = CameraNumericCompareStats::default();
-        let motion = MotionNumericCompareStats {
+        let camera = compare::CameraNumericCompareStats::default();
+        let motion = compare::MotionNumericCompareStats {
             mismatch_count: 1,
-            ..MotionNumericCompareStats::default()
+            ..compare::MotionNumericCompareStats::default()
         };
 
-        assert_eq!(numeric_compare_failure_count(&camera, &motion), 1);
+        assert_eq!(compare::numeric_compare_failure_count(&camera, &motion), 1);
     }
 
     #[test]
@@ -4413,7 +934,7 @@ mod tests {
         let defaults = vec!["左ひざ".to_owned()];
 
         assert_eq!(
-            motion_case_focus_bones(&case, Some(&defaults)),
+            compare::motion_case_focus_bones(&case, Some(&defaults)),
             vec!["右袖".to_owned(), "左袖".to_owned()]
         );
     }
@@ -4423,7 +944,7 @@ mod tests {
         let case = serde_json::json!({});
         let defaults = vec!["右腕".to_owned(), "左腕".to_owned()];
 
-        assert_eq!(motion_case_focus_bones(&case, Some(&defaults)), defaults);
+        assert_eq!(compare::motion_case_focus_bones(&case, Some(&defaults)), defaults);
     }
 
     #[test]
@@ -4434,7 +955,7 @@ mod tests {
             }
         });
 
-        assert_eq!(json_f32(&value, "/compare/evalFrameOffset"), Some(1.25));
+        assert_eq!(compare::json_f32(&value, "/compare/evalFrameOffset"), Some(1.25));
     }
 
     #[test]
@@ -4462,7 +983,7 @@ mod tests {
             self_shadow_frames: Vec::new(),
             property_frames: Vec::new(),
         };
-        let value = vmd_roundtrip_json(
+        let value = export::vmd_roundtrip_json(
             Path::new("motion.vmd"),
             "parse-json-export-parse",
             10,
@@ -4491,7 +1012,7 @@ mod tests {
             bones: Vec::new(),
             diagnostics: Vec::new(),
         };
-        let value = vpd_roundtrip_json(
+        let value = export::vpd_roundtrip_json(
             Path::new("pose.vpd"),
             "parse-export-parse",
             11,
@@ -4546,7 +1067,7 @@ mod tests {
             texture_references: vec!["tex.png".to_owned()],
             diagnostics: Vec::new(),
         };
-        let value = accessory_roundtrip_json(
+        let value = export::accessory_roundtrip_json(
             Path::new("stage.x"),
             "parse-json-export-parse",
             100,
@@ -4600,7 +1121,7 @@ mod tests {
         let mut actual = expected.clone();
         actual.text = true;
 
-        let error = ensure_accessory_roundtrip(&expected, &actual).unwrap_err();
+        let error = export::ensure_accessory_roundtrip(&expected, &actual).unwrap_err();
         assert!(error.contains("text flag changed"));
     }
 
@@ -4665,7 +1186,7 @@ mod tests {
         };
         let actual = expected.clone();
 
-        ensure_accessory_roundtrip(&expected, &actual).unwrap();
+        export::ensure_accessory_roundtrip(&expected, &actual).unwrap();
     }
 
     #[test]
@@ -4686,7 +1207,7 @@ mod tests {
         let mut actual = expected.clone();
         actual.texture_references.clear();
 
-        let error = ensure_accessory_json_roundtrip(&expected, &actual).unwrap_err();
+        let error = export::ensure_accessory_json_roundtrip(&expected, &actual).unwrap_err();
         assert_eq!(error, "Accessory JSON DTO changed before export");
     }
 
@@ -4734,7 +1255,7 @@ mod tests {
             joints: Vec::new(),
             diagnostics: Vec::new(),
         };
-        let value = pmd_roundtrip_json(
+        let value = export::pmd_roundtrip_json(
             Path::new("model.pmd"),
             "parse-json-export-parse",
             10,
@@ -4808,7 +1329,7 @@ mod tests {
             soft_bodies: Vec::new(),
             diagnostics: Vec::new(),
         };
-        let value = pmx_roundtrip_json(
+        let value = export::pmx_roundtrip_json(
             Path::new("model.pmx"),
             "parse-json-export-parse",
             10,
@@ -4834,16 +1355,13 @@ mod tests {
 
     #[test]
     fn resolve_pmx_path_for_pmm_makes_relative_existing_path_absolute() {
-        // Use a repository-local file that always exists at the workspace root
-        // when tests are executed via `cargo test -p mmd-anim-cli`.
-        // This keeps the test self-contained and independent of MMDDumper/MMD fixtures.
         let relative = Path::new("Cargo.toml");
         assert!(
             relative.exists(),
             "Cargo.toml must exist for this repository-local test"
         );
 
-        let resolved = resolve_pmx_path_for_pmm(relative)
+        let resolved = export::resolve_pmx_path_for_pmm(relative)
             .expect("canonicalize must succeed for an existing repository file");
 
         let resolved_path = Path::new(&resolved);
@@ -4866,7 +1384,7 @@ mod tests {
         let vmd_path = format_crate.join("fixtures/vmd/ik_multi_bone_nondefault.vmd");
 
         let model_path_text =
-            resolve_pmx_path_for_pmm(&pmx_path).expect("PMX fixture path must resolve");
+            export::resolve_pmx_path_for_pmm(&pmx_path).expect("PMX fixture path must resolve");
         let model_bytes = fs::read(&pmx_path).expect("PMX fixture must exist");
         let motion_bytes = fs::read(&vmd_path).expect("VMD fixture must exist");
         let model = mmd_anim_format::parse_pmx_model(&model_bytes).expect("PMX fixture parses");
@@ -4908,7 +1426,7 @@ mod tests {
             .expect("existing PMM fixture must be readable for helper shape test");
         let parsed = mmd_anim_format::parse_pmm_manifest(&data)
             .expect("existing PMM fixture must parse for helper shape test");
-        let value = pmm_roundtrip_json(
+        let value = export::pmm_roundtrip_json(
             Path::new("scene.pmm"),
             "parse-export-parse-lossless",
             data.len(),
@@ -4933,7 +1451,7 @@ mod tests {
     fn ensure_pmm_lossless_roundtrip_rejects_non_identical_bytes() {
         let original: &[u8] = b"Polygon Movie maker 0002\0dummy";
         let exported: &[u8] = b"different-bytes";
-        let error = ensure_pmm_lossless_roundtrip(original, exported).unwrap_err();
+        let error = export::ensure_pmm_lossless_roundtrip(original, exported).unwrap_err();
         let msg = error.to_string();
         assert!(
             msg.contains("byte") || msg.contains("lossless") || msg.contains("preserve"),
@@ -4944,9 +1462,6 @@ mod tests {
 
     #[test]
     fn pmm_parse_export_parse_lossless_roundtrip_via_helpers() {
-        // Integration-like unit test exercising the PMM lossless parse->export->parse path
-        // and the CLI helpers directly. Uses only repository-local fixture, no subprocess,
-        // and does not depend on external MMDDumper.
         let format_crate = Path::new(env!("CARGO_MANIFEST_DIR")).join("../mmd-anim-format");
         let pmm_path = format_crate.join("fixtures/pmm/ik_multi_bone_from_pmx_vmd.pmm");
         let data = fs::read(&pmm_path).expect("existing PMM fixture must be readable");
@@ -4954,9 +1469,8 @@ mod tests {
         let exported = mmd_anim_format::export_pmm_manifest(&parsed);
         let reparsed = mmd_anim_format::parse_pmm_manifest(&exported).expect("exported reparses");
 
-        ensure_pmm_lossless_roundtrip(&data, &exported)
+        export::ensure_pmm_lossless_roundtrip(&data, &exported)
             .expect("PMM parse-export-parse must be byte-for-byte lossless for parsed source");
-        // reparsed is exercised to match the CLI branch (even though byte equality is the gate)
         assert_eq!(reparsed.version, parsed.version);
         assert_eq!(
             exported, data,
@@ -4966,11 +1480,9 @@ mod tests {
 
     #[test]
     fn export_roundtrip_summary_calls_pmm_lossless_branch_successfully() {
-        // Direct unit test of the CLI entrypoint for PMM parse-export-parse-lossless.
-        // Uses only the repository-local fixture; no MMDDumper dependency.
         let format_crate = Path::new(env!("CARGO_MANIFEST_DIR")).join("../mmd-anim-format");
         let pmm_path = format_crate.join("fixtures/pmm/ik_multi_bone_from_pmx_vmd.pmm");
-        let result = export_roundtrip_summary(&pmm_path);
+        let result = export::export_roundtrip_summary(&pmm_path);
         assert!(
             result.is_ok(),
             "export_roundtrip_summary on repo-local PMM fixture must succeed (lossless branch)"
@@ -4981,11 +1493,9 @@ mod tests {
 
     #[test]
     fn export_roundtrip_json_calls_pmm_lossless_branch_successfully() {
-        // Direct unit test of the CLI JSON entrypoint for PMM parse-export-parse-lossless.
-        // Uses only the repository-local fixture; no MMDDumper dependency.
         let format_crate = Path::new(env!("CARGO_MANIFEST_DIR")).join("../mmd-anim-format");
         let pmm_path = format_crate.join("fixtures/pmm/ik_multi_bone_from_pmx_vmd.pmm");
-        let result = export_roundtrip_json(&pmm_path);
+        let result = export::export_roundtrip_json(&pmm_path);
         assert!(
             result.is_ok(),
             "export_roundtrip_json on repo-local PMM fixture must succeed (lossless branch)"
@@ -4996,12 +1506,9 @@ mod tests {
 
     #[test]
     fn export_json_roundtrip_summary_rejects_pmm_as_unsupported() {
-        // Confirms that export-json-roundtrip-* remains unsupported for PMM.
-        // This is by design: the JSON serialization path intentionally omits source bytes
-        // required for the lossless parsed-byte roundtrip.
         let format_crate = Path::new(env!("CARGO_MANIFEST_DIR")).join("../mmd-anim-format");
         let pmm_path = format_crate.join("fixtures/pmm/ik_multi_bone_from_pmx_vmd.pmm");
-        let result = export_json_roundtrip_summary(&pmm_path);
+        let result = export::export_json_roundtrip_summary(&pmm_path);
         let err = result
             .expect_err("export_json_roundtrip_summary on PMM fixture must remain unsupported");
         let msg = err.to_string();
@@ -5014,14 +1521,10 @@ mod tests {
 
     #[test]
     fn patch_pmm_document_model_path_replaces_path_and_preserves_length() {
-        // Focused, MMDDumper-independent unit test for the new CLI path-patch helper.
-        // Uses only repo-local fixture, calls helper directly (no subprocess), writes
-        // temp under target/, re-parses, asserts path replacement + unchanged length.
         let format_crate = Path::new(env!("CARGO_MANIFEST_DIR")).join("../mmd-anim-format");
         let pmm_path = format_crate.join("fixtures/pmm/ik_multi_bone_from_pmx_vmd.pmm");
         let data = fs::read(&pmm_path).expect("existing PMM fixture must be readable");
 
-        // target/ based unique-ish temp to satisfy task (best-effort cleanup)
         let nanos = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap()
@@ -5032,7 +1535,7 @@ mod tests {
         let out_path = out_dir.join(format!("patched-doc0-{}.pmm", nanos));
 
         let replacement = "UserFile\\Model\\override_for_cli_patch_test.pmx";
-        let result = patch_pmm_document_model_path(&pmm_path, "0", replacement, &out_path);
+        let result = patch::patch_pmm_document_model_path(&pmm_path, "0", replacement, &out_path);
         assert!(
             result.is_ok(),
             "patch_pmm_document_model_path on repo-local fixture must succeed: {:?}",
@@ -5064,7 +1567,6 @@ mod tests {
             "document model 0 path must equal replacement after patch"
         );
 
-        // best-effort cleanup (dir may be shared by nanos but file unique)
         let _ = fs::remove_file(&out_path);
     }
 
@@ -5097,7 +1599,7 @@ mod tests {
             "--end-frame".to_string(),
             "240".to_string(),
         ];
-        let result = patch_pmm_scene_frame_range(&pmm_path, &out_path, &options);
+        let result = patch::patch_pmm_scene_frame_range(&pmm_path, &out_path, &options);
         assert!(
             result.is_ok(),
             "patch_pmm_scene_frame_range on repo-local fixture must succeed: {:?}",
@@ -5131,7 +1633,7 @@ mod tests {
 
     #[test]
     fn parse_pmm_scene_frame_range_patch_options_requires_at_least_one_option() {
-        let err = parse_pmm_scene_frame_range_patch_options(&[]).unwrap_err();
+        let err = patch::parse_pmm_scene_frame_range_patch_options(&[]).unwrap_err();
         assert!(
             err.contains("at least one patch option is required"),
             "unexpected error: {err}"
@@ -5141,7 +1643,7 @@ mod tests {
     #[test]
     fn parse_pmm_scene_frame_range_patch_options_rejects_unknown_and_invalid_values() {
         let unknown =
-            parse_pmm_scene_frame_range_patch_options(&["--unknown".to_string(), "1".to_string()])
+            patch::parse_pmm_scene_frame_range_patch_options(&["--unknown".to_string(), "1".to_string()])
                 .unwrap_err();
         assert!(
             unknown.contains("unknown option"),
@@ -5149,13 +1651,13 @@ mod tests {
         );
 
         let missing_value =
-            parse_pmm_scene_frame_range_patch_options(&["--begin-frame".to_string()]).unwrap_err();
+            patch::parse_pmm_scene_frame_range_patch_options(&["--begin-frame".to_string()]).unwrap_err();
         assert!(
             missing_value.contains("missing value"),
             "unexpected missing-value error: {missing_value}"
         );
 
-        let invalid_bool = parse_pmm_scene_frame_range_patch_options(&[
+        let invalid_bool = patch::parse_pmm_scene_frame_range_patch_options(&[
             "--begin-frame-enabled".to_string(),
             "maybe".to_string(),
         ])

--- a/crates/mmd-anim-cli/src/main.rs
+++ b/crates/mmd-anim-cli/src/main.rs
@@ -30,7 +30,7 @@ struct Cli {
 enum Commands {
     /// Inspect an MMD asset without changing it.
     #[command(
-        long_about = "Parse an MMD asset and print a compact summary by default.\nUse this for quick format triage, JSON dumps, or PMX IK solver inspection.",
+        long_about = "Parse an MMD asset and print a compact summary by default.\nUse this for quick format triage, JSON dumps, or PMX IK solver inspection.\nFor detailed rig structure (IK chains, grants, bone hierarchy), use the rig command instead.\n\nSupported formats: .pmx, .pmd, .vmd, .pmm",
         after_help = "Examples:\n  mmd-anim inspect model.pmx\n  mmd-anim inspect motion.vmd --json\n  mmd-anim inspect model.pmx --ik"
     )]
     Inspect {
@@ -49,7 +49,7 @@ enum Commands {
 
     /// Import model and optional motion into runtime structures.
     #[command(
-        long_about = "Run the runtime importer for a model, or a model/motion pair.\nUse this when checking runtime names, clip build stats, or a single evaluated frame.",
+        long_about = "Run the runtime importer for a model, or a model/motion pair.\nUse this when checking runtime names, clip build stats, or a single evaluated frame.\n\nSupported formats: .pmx + .vmd, .pmd + .vmd",
         after_help = "Examples:\n  mmd-anim import model.pmx\n  mmd-anim import model.pmx motion.vmd --clip\n  mmd-anim import model.pmx motion.vmd --frame 120\n    (unit: MMD coordinate)"
     )]
     Import {
@@ -70,7 +70,7 @@ enum Commands {
 
     /// Verify parse/export/re-parse stability.
     #[command(
-        long_about = "Parse an asset, export it, then re-parse the exported bytes.\nUse this before changing readers, writers, or JSON DTO conversion paths.\nJSON reports use jsonBytes for the JSON serialized byte count when --via-json is set.",
+        long_about = "Parse an asset, export it, then re-parse the exported bytes.\nUse this to verify that the parser and exporter produce consistent output.\nJSON reports use jsonBytes for the JSON serialized byte count when --via-json is set.\n\nSupported formats: .pmx, .pmd, .vmd, .pmm",
         after_help = "Examples:\n  mmd-anim roundtrip model.pmx\n  mmd-anim roundtrip motion.vmd --json\n  mmd-anim roundtrip model.pmx --via-json"
     )]
     Roundtrip {
@@ -86,7 +86,7 @@ enum Commands {
 
     /// Inspect PMX rig structure.
     #[command(
-        long_about = "Inspect IK chains, grant/append transforms, and deform layer distribution.\nUse this for rig debugging before runtime import or solver comparison.",
+        long_about = "Inspect IK chains, grant/append transforms, and deform layer distribution.\nUse this for detailed rig analysis; for a quick file overview, use inspect instead.\n\nSupported formats: .pmx only",
         after_help = "Examples:\n  mmd-anim rig model.pmx\n  mmd-anim rig model.pmx --bones\n  mmd-anim rig model.pmx --json --bones"
     )]
     Rig {
@@ -102,7 +102,7 @@ enum Commands {
 
     /// Benchmark runtime evaluation.
     #[command(
-        long_about = "Benchmark a PMX/VMD pair by default, or synthetic runtime data with --synthetic.\nUse this for local performance checks around import, clip build, and evaluation.\nPair mode positional arguments: <model.pmx> <motion.vmd> [start-frame] [frame-count] [step]. Pair flags: --no-ik, --ik-tolerance <value>, --ik-max-iterations-cap <count>.\nSynthetic mode arguments: [models] [bones] [frames] [--json]. Defaults are models=1, bones=32, frames=1000.",
+        long_about = "Benchmark a PMX/VMD pair by default, or synthetic runtime data with --synthetic.\nUse this for local performance checks around import, clip build, and evaluation.\n\nPair mode: <model.pmx> <motion.vmd> [start-frame] [frame-count] [step]\n  Flags: --no-ik, --ik-tolerance <value>, --ik-max-iterations-cap <count>\n\nSynthetic mode: --synthetic [models] [bones] [frames] [--json]\n  Defaults: models=1, bones=32, frames=1000\n\nSupported formats: .pmx + .vmd",
         after_help = "Examples:\n  mmd-anim bench model.pmx motion.vmd\n  mmd-anim bench model.pmx motion.vmd 0 240 1 --no-ik\n  mmd-anim bench --synthetic\n  mmd-anim bench --synthetic 4 64 2000\n  mmd-anim bench --synthetic 4 64 2000 --json"
     )]
     Bench {
@@ -186,7 +186,7 @@ enum Commands {
 
     /// Export an asset to another binary file.
     #[command(
-        long_about = "Write an MMD asset to an output path, optionally starting from JSON.\nWith --from-json, the input must be UTF-8 JSON text and the output extension selects the binary format.\nUse this for parser/exporter smoke checks and JSON-to-binary conversion.",
+        long_about = "Write an MMD asset to an output path, optionally starting from JSON.\nWith --from-json, the input must be UTF-8 JSON text and the output extension selects the binary format.\nUse this for parser/exporter smoke checks and JSON-to-binary conversion.\n\nSupported formats: .pmx, .pmd, .vmd",
         after_help = "Examples:\n  mmd-anim export input.vmd output.vmd\n  mmd-anim export input.json output.vmd --from-json"
     )]
     Export {
@@ -202,7 +202,7 @@ enum Commands {
     /// Build a PMM scene from a model and motion.
     #[command(
         name = "build-pmm",
-        long_about = "Create a PMM scene from a PMX model and VMD motion.\nUse this when preparing MMD GUI-compatible scenes from runtime fixtures.",
+        long_about = "Create a PMM scene from a PMX model and VMD motion.\nUse this when preparing MMD GUI-compatible scenes from runtime fixtures.\n\nSupported formats: .pmx + .vmd → .pmm",
         after_help = "Examples:\n  mmd-anim build-pmm model.pmx motion.vmd scene.pmm\n  mmd-anim build-pmm ./model.pmx ./motion.vmd ./out/scene.pmm"
     )]
     BuildPmm {
@@ -1561,7 +1561,7 @@ mod tests {
         actual.texture_references.clear();
 
         let error = export::ensure_accessory_json_roundtrip(&expected, &actual).unwrap_err();
-        assert_eq!(error, "Accessory JSON DTO changed before export");
+        assert_eq!(error, "Accessory JSON data differs after re-encoding");
     }
 
     #[test]

--- a/crates/mmd-anim-ffi/include/mmd_runtime.h
+++ b/crates/mmd-anim-ffi/include/mmd_runtime.h
@@ -23,6 +23,9 @@ typedef struct mmd_runtime_model_t    mmd_runtime_model_t;
 typedef struct mmd_runtime_instance_t mmd_runtime_instance_t;
 typedef struct mmd_runtime_clip_t     mmd_runtime_clip_t;
 typedef struct mmd_runtime_pmx_material_split_t mmd_runtime_pmx_material_split_t;
+typedef struct mmd_runtime_pmx_rig_spec_t mmd_runtime_pmx_rig_spec_t;
+typedef struct mmd_runtime_ik_chain_t mmd_runtime_ik_chain_t;
+typedef struct mmd_runtime_append_solver_t mmd_runtime_append_solver_t;
 
 /* ------------------------------------------------------------------ */
 /*  Flag constants                                                    */
@@ -35,6 +38,9 @@ typedef struct mmd_runtime_pmx_material_split_t mmd_runtime_pmx_material_split_t
 
 /* IK link flags           (bitmask) */
 #define MMD_RUNTIME_IK_LINK_ANGLE_LIMIT (1u << 0)
+
+/* Rig primitive bone flags (bitmask) */
+#define MMD_RUNTIME_RIG_BONE_FIXED_AXIS (1u << 0)
 
 /* ------------------------------------------------------------------ */
 /*  Descriptor structs                                                */
@@ -91,6 +97,33 @@ typedef struct mmd_runtime_ffi_ik_link {
     float    angle_limit_min_xyz[3];
     float    angle_limit_max_xyz[3];
 } mmd_runtime_ffi_ik_link_t;
+
+typedef struct mmd_runtime_ffi_rig_ik_link {
+    uint32_t bone_slot;
+    bool     has_angle_limit;
+    float    angle_limit_min_xyz[3];
+    float    angle_limit_max_xyz[3];
+} mmd_runtime_ffi_rig_ik_link_t;
+
+typedef struct mmd_runtime_ffi_rig_bone {
+    int32_t  parent_slot;
+    float    rest_position_xyz[3];
+    uint32_t flags;
+    float    fixed_axis_xyz[3];
+} mmd_runtime_ffi_rig_bone_t;
+
+typedef struct mmd_runtime_ffi_ik_solve_stats {
+    uint32_t executed_iterations;
+    uint32_t link_steps;
+    float    final_distance;
+    uint32_t break_reason; /* 0=tolerance, 1=max_iterations, 2=rollback */
+} mmd_runtime_ffi_ik_solve_stats_t;
+
+typedef struct mmd_runtime_ffi_append_config {
+    float ratio;
+    bool  affect_rotation;
+    bool  affect_translation;
+} mmd_runtime_ffi_append_config_t;
 
 typedef struct mmd_runtime_ffi_bone_morph_offset {
     uint32_t morph_index;
@@ -206,6 +239,76 @@ mmd_runtime_ffi_byte_buffer_t mmd_runtime_parse_pmx_skinning_modes_json(
     const uint8_t* data,
     size_t         len);
 
+/* Rig primitive API.
+   Coordinates use the MMD convention: left-handed, Y-up, xyz vectors.
+   Quaternions are xyzw. Matrices are column-major f32[16].
+   Create functions return NULL on invalid input. Solve functions return false
+   on invalid input, NULL required pointers, non-finite values, or short output
+   buffers. Free functions accept NULL and otherwise release the owned opaque
+   handle created by the matching create function. */
+
+/* Creates an owned IK-chain primitive.
+   bones is a bone_count-sized rig-bone array; parent_slot < 0 means no parent.
+   target_bone_slot selects the effector bone in bones. links is a link_count-
+   sized array ordered the same way PMX IK links are solved. iteration_count
+   and limit_angle are the per-chain solve settings. bones and links are
+   borrowed only for the call. Returns NULL if required arrays are NULL,
+   indices are out of range, values are non-finite, or counts are invalid. */
+mmd_runtime_ik_chain_t* mmd_runtime_ik_chain_create(
+    const mmd_runtime_ffi_rig_bone_t*    bones,
+    size_t                               bone_count,
+    uint32_t                             target_bone_slot,
+    const mmd_runtime_ffi_rig_ik_link_t* links,
+    size_t                               link_count,
+    uint32_t                             iteration_count,
+    float                                limit_angle);
+
+void mmd_runtime_ik_chain_free(
+    mmd_runtime_ik_chain_t* chain);
+
+/* Solves an IK-chain primitive.
+   chain must be a live handle. parent_world_matrix may be NULL, which means
+   identity; when provided it points to one column-major f32[16] matrix.
+   local_position_offsets_xyz and local_rotations_xyzw are required arrays with
+   bone_count * 3 and bone_count * 4 f32 values. goal_position_xyz is a required
+   xyz vector in MMD coordinates. max_iterations_cap == 0 means no cap.
+   out_link_rotations_xyzw receives link_count xyzw quaternions and
+   out_link_rotation_f32_len must be at least link_count * 4. out_stats may be
+   NULL; when provided it receives solve diagnostics. Input and output arrays
+   are caller-owned and are not retained after the call. */
+bool mmd_runtime_ik_chain_solve(
+    mmd_runtime_ik_chain_t*              chain,
+    const float*                         parent_world_matrix,
+    const float*                         local_position_offsets_xyz,
+    const float*                         local_rotations_xyzw,
+    const float*                         goal_position_xyz,
+    float                                tolerance,
+    uint32_t                             max_iterations_cap,
+    float*                               out_link_rotations_xyzw,
+    size_t                               out_link_rotation_f32_len,
+    mmd_runtime_ffi_ik_solve_stats_t*    out_stats);
+
+/* Creates an owned append-transform primitive.
+   config is borrowed for the call and must not be NULL. ratio and channel flags
+   are copied into the handle. Returns NULL on invalid or non-finite input. */
+mmd_runtime_append_solver_t* mmd_runtime_append_solver_create(
+    const mmd_runtime_ffi_append_config_t* config);
+
+void mmd_runtime_append_solver_free(
+    mmd_runtime_append_solver_t* solver);
+
+/* Solves an append-transform primitive.
+   solver must be a live handle. source_position_offset_xyz and
+   source_rotation_xyzw are required caller-owned inputs. out_position_offset_xyz
+   and out_rotation_xyzw are required caller-owned outputs. The output rotation
+   is an xyzw quaternion. Returns false on NULL pointers or non-finite input. */
+bool mmd_runtime_append_solver_solve(
+    const mmd_runtime_append_solver_t* solver,
+    const float*                      source_position_offset_xyz,
+    const float*                      source_rotation_xyzw,
+    float*                            out_position_offset_xyz,
+    float*                            out_rotation_xyzw);
+
 /* PMX material split handle API.
    mmd_runtime_pmx_material_split_create parses PMX bytes once and returns an
    owned opaque handle. Free it with mmd_runtime_pmx_material_split_free.
@@ -288,6 +391,34 @@ mmd_runtime_ffi_byte_buffer_t mmd_runtime_pmx_material_split_sdef_rw1_buffer(
 mmd_runtime_ffi_byte_buffer_t mmd_runtime_pmx_material_split_qdef_enabled_buffer(
     const mmd_runtime_pmx_material_split_t* split,
     size_t                                  mesh_index);
+
+/* PMX rig-spec handle API.
+   PMX rig data is reported in MMD coordinates: left-handed, Y-up, xyz vectors.
+   Quaternions in any rig payload are xyzw. Matrices in any rig payload are
+   column-major f32[16].
+   mmd_runtime_pmx_rig_spec_create parses PMX bytes once and returns an owned
+   opaque handle. Free it with mmd_runtime_pmx_rig_spec_free. The manifest JSON
+   byte buffer is owned by Rust and must be freed with
+   mmd_runtime_byte_buffer_free. Invalid input or invalid handles return null
+   handles or empty buffers. */
+
+/* Creates an owned PMX rig-spec handle from data[0..len].
+   data is borrowed only for the call and must not be NULL when len > 0.
+   Returns NULL when the bytes are invalid, empty, or unsupported. */
+mmd_runtime_pmx_rig_spec_t* mmd_runtime_pmx_rig_spec_create(
+    const uint8_t* data,
+    size_t         len);
+
+/* Releases an owned PMX rig-spec handle. Passing NULL is allowed. */
+void mmd_runtime_pmx_rig_spec_free(
+    mmd_runtime_pmx_rig_spec_t* spec);
+
+/* Returns the rig-spec manifest JSON for spec.
+   spec must be a live handle. The returned byte buffer is Rust-owned and must
+   be freed with mmd_runtime_byte_buffer_free. Invalid or NULL spec returns an
+   empty buffer. */
+mmd_runtime_ffi_byte_buffer_t mmd_runtime_pmx_rig_spec_manifest_json(
+    const mmd_runtime_pmx_rig_spec_t* spec);
 
 mmd_runtime_model_t* mmd_runtime_model_create(
     const int32_t* parent_indices,

--- a/crates/mmd-anim-ffi/src/lib.rs
+++ b/crates/mmd-anim-ffi/src/lib.rs
@@ -5,11 +5,12 @@ use std::{ptr, slice, str, sync::Arc};
 
 use mmd_anim_runtime::ModelArena;
 use mmd_anim_runtime::{
-    AnimationClip, AppendTransformInit, BoneAnimationBinding, BoneIndex, BoneInit, BoneMorphOffset,
-    GroupMorphOffset, IkAngleLimit, IkLinkInit, IkSolveOptions, IkSolverInit,
-    MorphAnimationBinding, MorphIndex, MorphInit, MorphKeyframe, MorphOffsetSpan, MorphTrack,
-    MovableBoneKeyframe, MovableBoneTrack, PropertyAnimationBinding, PropertyKeyframe,
-    RuntimeInstance,
+    solve_append_transform, AnimationClip, AppendPrimitiveInput, AppendTransformInit,
+    BoneAnimationBinding, BoneIndex, BoneInit, BoneMorphOffset, GroupMorphOffset, IkAngleLimit,
+    IkChainDefinition, IkChainLinkDefinition, IkChainPoseInput, IkChainSolver, IkLinkInit,
+    IkSolveOptions, IkSolverInit, MorphAnimationBinding, MorphIndex, MorphInit, MorphKeyframe,
+    MorphOffsetSpan, MorphTrack, MovableBoneKeyframe, MovableBoneTrack, PropertyAnimationBinding,
+    PropertyKeyframe, RuntimeInstance,
 };
 
 pub const ABI_VERSION: u32 = 1;
@@ -56,6 +57,23 @@ pub struct MmdRuntimeClip {
 pub struct MmdRuntimePmxMaterialSplit {
     split: mmd_anim_format::PmxMaterialSplitResult,
     manifest_json: Vec<u8>,
+}
+
+pub struct MmdRuntimePmxRigSpec {
+    spec: mmd_anim_format::PmxRigSpec,
+    manifest_json: Vec<u8>,
+}
+
+pub struct MmdRuntimeIkChain {
+    solver: IkChainSolver,
+    bone_count: usize,
+    link_count: usize,
+}
+
+pub struct MmdRuntimeAppendSolver {
+    ratio: f32,
+    affect_rotation: bool,
+    affect_translation: bool,
 }
 
 #[repr(C)]
@@ -119,6 +137,37 @@ pub struct MmdRuntimeFfiIkLink {
 }
 
 #[repr(C)]
+pub struct MmdRuntimeFfiRigIkLink {
+    pub bone_slot: u32,
+    pub has_angle_limit: bool,
+    pub angle_limit_min_xyz: [f32; 3],
+    pub angle_limit_max_xyz: [f32; 3],
+}
+
+#[repr(C)]
+pub struct MmdRuntimeFfiRigBone {
+    pub parent_slot: i32,
+    pub rest_position_xyz: [f32; 3],
+    pub flags: u32,
+    pub fixed_axis_xyz: [f32; 3],
+}
+
+#[repr(C)]
+pub struct MmdRuntimeFfiIkSolveStats {
+    pub executed_iterations: u32,
+    pub link_steps: u32,
+    pub final_distance: f32,
+    pub break_reason: u32,
+}
+
+#[repr(C)]
+pub struct MmdRuntimeFfiAppendConfig {
+    pub ratio: f32,
+    pub affect_rotation: bool,
+    pub affect_translation: bool,
+}
+
+#[repr(C)]
 pub struct MmdRuntimeFfiBoneMorphOffset {
     pub morph_index: u32,
     pub target_bone_index: u32,
@@ -143,6 +192,7 @@ const APPEND_FLAG_ROTATION: u32 = 1;
 const APPEND_FLAG_TRANSLATION: u32 = 1 << 1;
 const APPEND_FLAG_LOCAL: u32 = 1 << 2;
 const IK_LINK_FLAG_ANGLE_LIMIT: u32 = 1;
+const RIG_BONE_FIXED_AXIS: u32 = 1;
 
 #[unsafe(no_mangle)]
 pub extern "C" fn mmd_runtime_abi_version() -> u32 {
@@ -185,6 +235,271 @@ pub unsafe extern "C" fn mmd_runtime_byte_buffer_free(buffer: MmdRuntimeFfiByteB
             buffer.len,
         )));
     }
+}
+
+/// Creates a stateful per-chain IK primitive solver.
+///
+/// # Safety
+///
+/// `bones` must point to `bone_count` readable entries and `links` must point
+/// to `link_count` readable entries when their counts are non-zero.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn mmd_runtime_ik_chain_create(
+    bones: *const MmdRuntimeFfiRigBone,
+    bone_count: usize,
+    target_bone_slot: u32,
+    links: *const MmdRuntimeFfiRigIkLink,
+    link_count: usize,
+    iteration_count: u32,
+    limit_angle: f32,
+) -> *mut MmdRuntimeIkChain {
+    let definition = unsafe {
+        build_ik_chain_definition(
+            bones,
+            bone_count,
+            target_bone_slot,
+            links,
+            link_count,
+            iteration_count,
+            limit_angle,
+        )
+    };
+    let Some(definition) = definition else {
+        return ptr::null_mut();
+    };
+    let solver = IkChainSolver::new(definition);
+    Box::into_raw(Box::new(MmdRuntimeIkChain {
+        solver,
+        bone_count,
+        link_count,
+    }))
+}
+
+/// Frees an IK primitive solver handle.
+///
+/// # Safety
+///
+/// `chain` must be null or a pointer returned by `mmd_runtime_ik_chain_create`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn mmd_runtime_ik_chain_free(chain: *mut MmdRuntimeIkChain) {
+    if chain.is_null() {
+        return;
+    }
+    unsafe {
+        drop(Box::from_raw(chain));
+    }
+}
+
+/// Solves one IK chain into caller-owned link-rotation output.
+///
+/// # Safety
+///
+/// Required input and output pointers must point to readable/writable arrays
+/// matching the documented C header lengths.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn mmd_runtime_ik_chain_solve(
+    chain: *mut MmdRuntimeIkChain,
+    parent_world_matrix: *const f32,
+    local_position_offsets_xyz: *const f32,
+    local_rotations_xyzw: *const f32,
+    goal_position_xyz: *const f32,
+    tolerance: f32,
+    max_iterations_cap: u32,
+    out_link_rotations_xyzw: *mut f32,
+    out_link_rotation_f32_len: usize,
+    out_stats: *mut MmdRuntimeFfiIkSolveStats,
+) -> bool {
+    if chain.is_null()
+        || local_rotations_xyzw.is_null()
+        || goal_position_xyz.is_null()
+        || out_link_rotations_xyzw.is_null()
+    {
+        return false;
+    }
+    let chain = unsafe { &mut *chain };
+    let required_output_len = match chain.link_count.checked_mul(4) {
+        Some(len) => len,
+        None => return false,
+    };
+    if out_link_rotation_f32_len < required_output_len {
+        return false;
+    }
+
+    let parent_world_matrix = if parent_world_matrix.is_null() {
+        None
+    } else {
+        let raw = unsafe { slice::from_raw_parts(parent_world_matrix, 16) };
+        if !all_finite(raw) {
+            return false;
+        }
+        let Ok(raw) = raw.try_into() else {
+            return false;
+        };
+        Some(glam::Mat4::from_cols_array(raw))
+    };
+
+    let position_offsets = if local_position_offsets_xyz.is_null() {
+        vec![glam::Vec3A::ZERO; chain.bone_count]
+    } else {
+        let Some(len) = chain.bone_count.checked_mul(3) else {
+            return false;
+        };
+        let raw = unsafe { slice::from_raw_parts(local_position_offsets_xyz, len) };
+        if !all_finite(raw) {
+            return false;
+        }
+        raw.chunks_exact(3)
+            .map(|v| glam::Vec3A::new(v[0], v[1], v[2]))
+            .collect()
+    };
+
+    let Some(rotation_len) = chain.bone_count.checked_mul(4) else {
+        return false;
+    };
+    let raw_rotations = unsafe { slice::from_raw_parts(local_rotations_xyzw, rotation_len) };
+    if !all_finite(raw_rotations) {
+        return false;
+    }
+    let mut rotations = Vec::with_capacity(chain.bone_count);
+    for q in raw_rotations.chunks_exact(4) {
+        let rotation = glam::Quat::from_xyzw(q[0], q[1], q[2], q[3]);
+        if rotation.length_squared() <= f32::EPSILON {
+            return false;
+        }
+        rotations.push(rotation.normalize());
+    }
+
+    let goal = unsafe { slice::from_raw_parts(goal_position_xyz, 3) };
+    if !all_finite(goal) || !tolerance.is_finite() {
+        return false;
+    }
+    let max_iterations_cap = if max_iterations_cap == 0 {
+        None
+    } else {
+        Some(max_iterations_cap)
+    };
+
+    let output = chain.solver.solve(IkChainPoseInput {
+        parent_world_matrix,
+        local_position_offsets: &position_offsets,
+        local_rotations: &rotations,
+        goal_position: glam::Vec3A::new(goal[0], goal[1], goal[2]),
+        tolerance,
+        max_iterations_cap,
+    });
+    if output.solved_link_rotations.len() != chain.link_count {
+        return false;
+    }
+
+    let out = unsafe { slice::from_raw_parts_mut(out_link_rotations_xyzw, required_output_len) };
+    for (rotation, dst) in output
+        .solved_link_rotations
+        .iter()
+        .zip(out.chunks_exact_mut(4))
+    {
+        dst.copy_from_slice(&rotation.to_array());
+    }
+    if !out_stats.is_null() {
+        unsafe {
+            *out_stats = MmdRuntimeFfiIkSolveStats {
+                executed_iterations: output.executed_iterations,
+                link_steps: output.link_steps,
+                final_distance: output.final_distance,
+                break_reason: if output.final_distance <= tolerance.max(0.0) {
+                    0
+                } else {
+                    1
+                },
+            };
+        }
+    }
+    true
+}
+
+/// Creates a per-bone append/grant primitive solver.
+///
+/// # Safety
+///
+/// `config` must point to a readable config struct.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn mmd_runtime_append_solver_create(
+    config: *const MmdRuntimeFfiAppendConfig,
+) -> *mut MmdRuntimeAppendSolver {
+    if config.is_null() {
+        return ptr::null_mut();
+    }
+    let config = unsafe { &*config };
+    if !config.ratio.is_finite() {
+        return ptr::null_mut();
+    }
+    Box::into_raw(Box::new(MmdRuntimeAppendSolver {
+        ratio: config.ratio,
+        affect_rotation: config.affect_rotation,
+        affect_translation: config.affect_translation,
+    }))
+}
+
+/// Frees an append primitive solver handle.
+///
+/// # Safety
+///
+/// `solver` must be null or a pointer returned by
+/// `mmd_runtime_append_solver_create`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn mmd_runtime_append_solver_free(solver: *mut MmdRuntimeAppendSolver) {
+    if solver.is_null() {
+        return;
+    }
+    unsafe {
+        drop(Box::from_raw(solver));
+    }
+}
+
+/// Solves one append/grant primitive into caller-owned output arrays.
+///
+/// # Safety
+///
+/// Pointers must reference readable/writable arrays matching the documented
+/// C header lengths.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn mmd_runtime_append_solver_solve(
+    solver: *const MmdRuntimeAppendSolver,
+    source_position_offset_xyz: *const f32,
+    source_rotation_xyzw: *const f32,
+    out_position_offset_xyz: *mut f32,
+    out_rotation_xyzw: *mut f32,
+) -> bool {
+    if solver.is_null()
+        || source_position_offset_xyz.is_null()
+        || source_rotation_xyzw.is_null()
+        || out_position_offset_xyz.is_null()
+        || out_rotation_xyzw.is_null()
+    {
+        return false;
+    }
+    let solver = unsafe { &*solver };
+    let position = unsafe { slice::from_raw_parts(source_position_offset_xyz, 3) };
+    let rotation = unsafe { slice::from_raw_parts(source_rotation_xyzw, 4) };
+    if !all_finite(position) || !all_finite(rotation) {
+        return false;
+    }
+    let source_rotation = glam::Quat::from_xyzw(rotation[0], rotation[1], rotation[2], rotation[3]);
+    if source_rotation.length_squared() <= f32::EPSILON {
+        return false;
+    }
+
+    let output = solve_append_transform(AppendPrimitiveInput {
+        source_position_offset: glam::Vec3A::new(position[0], position[1], position[2]),
+        source_rotation: source_rotation.normalize(),
+        ratio: solver.ratio,
+        affect_rotation: solver.affect_rotation,
+        affect_translation: solver.affect_translation,
+    });
+    let out_position = unsafe { slice::from_raw_parts_mut(out_position_offset_xyz, 3) };
+    out_position.copy_from_slice(&output.position_offset.to_array());
+    let out_rotation = unsafe { slice::from_raw_parts_mut(out_rotation_xyzw, 4) };
+    out_rotation.copy_from_slice(&output.rotation.to_array());
+    true
 }
 
 /// Parses VMD bytes and returns the serialized `VmdParsedAnimation` JSON.
@@ -891,6 +1206,33 @@ pub unsafe extern "C" fn mmd_runtime_pmx_material_split_create(
     }))
 }
 
+/// Parses PMX bytes once and creates an opaque rig-spec handle.
+///
+/// # Safety
+/// `data` must point to `len` readable bytes when `len` is non-zero.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn mmd_runtime_pmx_rig_spec_create(
+    data: *const u8,
+    len: usize,
+) -> *mut MmdRuntimePmxRigSpec {
+    if data.is_null() || len == 0 {
+        return ptr::null_mut();
+    }
+    let bytes = unsafe { slice::from_raw_parts(data, len) };
+    let spec = match mmd_anim_format::parse_pmx_rig_spec(bytes) {
+        Ok(spec) => spec,
+        Err(_) => return ptr::null_mut(),
+    };
+    let manifest_json = match serde_json::to_vec(&spec) {
+        Ok(json) => json,
+        Err(_) => return ptr::null_mut(),
+    };
+    Box::into_raw(Box::new(MmdRuntimePmxRigSpec {
+        spec,
+        manifest_json,
+    }))
+}
+
 /// Frees a PMX material-split handle.
 ///
 /// # Safety
@@ -905,6 +1247,21 @@ pub unsafe extern "C" fn mmd_runtime_pmx_material_split_free(
     }
     unsafe {
         drop(Box::from_raw(split));
+    }
+}
+
+/// Frees a PMX rig-spec handle.
+///
+/// # Safety
+/// `spec` must be null or a handle returned by
+/// `mmd_runtime_pmx_rig_spec_create` that has not already been freed.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn mmd_runtime_pmx_rig_spec_free(spec: *mut MmdRuntimePmxRigSpec) {
+    if spec.is_null() {
+        return;
+    }
+    unsafe {
+        drop(Box::from_raw(spec));
     }
 }
 
@@ -939,6 +1296,24 @@ pub unsafe extern "C" fn mmd_runtime_pmx_material_split_manifest_json(
         return empty_byte_buffer();
     };
     byte_buffer_from_vec(split.manifest_json.clone())
+}
+
+/// Returns the serialized rig-spec manifest JSON.
+///
+/// # Safety
+/// `spec` must be null or a valid handle returned by
+/// `mmd_runtime_pmx_rig_spec_create`. Passing any other pointer is undefined
+/// behavior. The returned buffer is owned by the caller and must be freed with
+/// `mmd_runtime_byte_buffer_free`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn mmd_runtime_pmx_rig_spec_manifest_json(
+    spec: *const MmdRuntimePmxRigSpec,
+) -> MmdRuntimeFfiByteBuffer {
+    let Some(spec) = (unsafe { spec.as_ref() }) else {
+        return empty_byte_buffer();
+    };
+    debug_assert_eq!(spec.spec.bone_count, spec.spec.bones.len());
+    byte_buffer_from_vec(spec.manifest_json.clone())
 }
 
 /// Returns split mesh vertex positions as a native-endian byte buffer.
@@ -2543,6 +2918,109 @@ unsafe fn checked_slice<'a, T>(ptr: *const T, len: usize) -> Option<&'a [T]> {
     Some(unsafe { slice::from_raw_parts(ptr, len) })
 }
 
+fn all_finite(values: &[f32]) -> bool {
+    values.iter().all(|value| value.is_finite())
+}
+
+unsafe fn build_ik_chain_definition(
+    bones: *const MmdRuntimeFfiRigBone,
+    bone_count: usize,
+    target_bone_slot: u32,
+    links: *const MmdRuntimeFfiRigIkLink,
+    link_count: usize,
+    iteration_count: u32,
+    limit_angle: f32,
+) -> Option<IkChainDefinition> {
+    if bone_count == 0
+        || link_count == 0
+        || target_bone_slot as usize >= bone_count
+        || !limit_angle.is_finite()
+    {
+        return None;
+    }
+    let bones = unsafe { checked_slice(bones, bone_count) }?;
+    let links = unsafe { checked_slice(links, link_count) }?;
+    let mut parent_slots = Vec::with_capacity(bone_count);
+    let mut rest_positions = Vec::with_capacity(bone_count);
+    let mut fixed_axes = Vec::with_capacity(bone_count);
+    for (slot, bone) in bones.iter().enumerate() {
+        if !all_finite(&bone.rest_position_xyz) {
+            return None;
+        }
+        let parent = match bone.parent_slot {
+            -1 => None,
+            parent if parent >= 0 && (parent as usize) < slot => Some(parent as usize),
+            _ => return None,
+        };
+        let fixed_axis = if bone.flags & RIG_BONE_FIXED_AXIS != 0 {
+            if !all_finite(&bone.fixed_axis_xyz) {
+                return None;
+            }
+            let axis = glam::Vec3A::new(
+                bone.fixed_axis_xyz[0],
+                bone.fixed_axis_xyz[1],
+                bone.fixed_axis_xyz[2],
+            );
+            if axis.length_squared() <= f32::EPSILON {
+                return None;
+            }
+            Some(axis.normalize())
+        } else {
+            None
+        };
+        parent_slots.push(parent);
+        rest_positions.push(glam::Vec3A::new(
+            bone.rest_position_xyz[0],
+            bone.rest_position_xyz[1],
+            bone.rest_position_xyz[2],
+        ));
+        fixed_axes.push(fixed_axis);
+    }
+
+    let links = links
+        .iter()
+        .map(|link| {
+            if link.bone_slot as usize >= bone_count {
+                return None;
+            }
+            let angle_limit = if link.has_angle_limit {
+                if !all_finite(&link.angle_limit_min_xyz) || !all_finite(&link.angle_limit_max_xyz)
+                {
+                    return None;
+                }
+                Some(IkAngleLimit::new(
+                    glam::Vec3A::new(
+                        link.angle_limit_min_xyz[0],
+                        link.angle_limit_min_xyz[1],
+                        link.angle_limit_min_xyz[2],
+                    ),
+                    glam::Vec3A::new(
+                        link.angle_limit_max_xyz[0],
+                        link.angle_limit_max_xyz[1],
+                        link.angle_limit_max_xyz[2],
+                    ),
+                ))
+            } else {
+                None
+            };
+            Some(IkChainLinkDefinition {
+                bone_slot: link.bone_slot as usize,
+                angle_limit,
+            })
+        })
+        .collect::<Option<Vec<_>>>()?;
+
+    Some(IkChainDefinition {
+        parent_slots,
+        rest_positions,
+        fixed_axes,
+        target_slot: target_bone_slot as usize,
+        links,
+        iteration_count,
+        limit_angle,
+    })
+}
+
 fn checked_range<T>(slice: &[T], offset: usize, count: usize) -> Option<&[T]> {
     let end = offset.checked_add(count)?;
     slice.get(offset..end)
@@ -2776,6 +3254,258 @@ fn build_morph_init_from_ffi(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn assert_near(actual: f32, expected: f32, tolerance: f32) {
+        assert!(
+            (actual - expected).abs() <= tolerance,
+            "actual={actual} expected={expected} tolerance={tolerance}"
+        );
+    }
+
+    fn assert_slice_near(actual: &[f32], expected: &[f32], tolerance: f32) {
+        assert_eq!(actual.len(), expected.len());
+        for (index, (actual, expected)) in actual.iter().zip(expected).enumerate() {
+            assert!(
+                (*actual - *expected).abs() <= tolerance,
+                "index={index} actual={actual} expected={expected} tolerance={tolerance}"
+            );
+        }
+    }
+
+    fn simple_ik_chain() -> *mut MmdRuntimeIkChain {
+        let bones = [
+            MmdRuntimeFfiRigBone {
+                parent_slot: -1,
+                rest_position_xyz: [0.0, 0.0, 0.0],
+                flags: 0,
+                fixed_axis_xyz: [0.0, 0.0, 0.0],
+            },
+            MmdRuntimeFfiRigBone {
+                parent_slot: 0,
+                rest_position_xyz: [1.0, 0.0, 0.0],
+                flags: 0,
+                fixed_axis_xyz: [0.0, 0.0, 0.0],
+            },
+        ];
+        let links = [MmdRuntimeFfiRigIkLink {
+            bone_slot: 0,
+            has_angle_limit: false,
+            angle_limit_min_xyz: [0.0, 0.0, 0.0],
+            angle_limit_max_xyz: [0.0, 0.0, 0.0],
+        }];
+        unsafe {
+            mmd_runtime_ik_chain_create(
+                bones.as_ptr(),
+                bones.len(),
+                1,
+                links.as_ptr(),
+                links.len(),
+                4,
+                0.0,
+            )
+        }
+    }
+
+    #[test]
+    fn append_solver_lifecycle_and_expected_output_use_xyzw_quaternion() {
+        let config = MmdRuntimeFfiAppendConfig {
+            ratio: 0.5,
+            affect_rotation: true,
+            affect_translation: true,
+        };
+        let solver = unsafe { mmd_runtime_append_solver_create(&config) };
+        assert!(!solver.is_null());
+
+        let source_position = [2.0, 4.0, -6.0];
+        let source_rotation = glam::Quat::from_rotation_z(std::f32::consts::FRAC_PI_2).to_array();
+        let mut out_position = [0.0; 3];
+        let mut out_rotation = [0.0; 4];
+        assert!(unsafe {
+            mmd_runtime_append_solver_solve(
+                solver,
+                source_position.as_ptr(),
+                source_rotation.as_ptr(),
+                out_position.as_mut_ptr(),
+                out_rotation.as_mut_ptr(),
+            )
+        });
+
+        assert_slice_near(&out_position, &[1.0, 2.0, -3.0], 1.0e-5);
+        let solved = glam::Quat::from_xyzw(
+            out_rotation[0],
+            out_rotation[1],
+            out_rotation[2],
+            out_rotation[3],
+        );
+        let rotated_x = solved.mul_vec3(glam::Vec3::X);
+        assert_near(rotated_x.x, std::f32::consts::FRAC_1_SQRT_2, 1.0e-5);
+        assert_near(rotated_x.y, std::f32::consts::FRAC_1_SQRT_2, 1.0e-5);
+        assert_near(out_rotation[3], solved.w, 0.0);
+
+        unsafe { mmd_runtime_append_solver_free(solver) };
+    }
+
+    #[test]
+    fn append_solver_rejects_null_inputs() {
+        let config = MmdRuntimeFfiAppendConfig {
+            ratio: 1.0,
+            affect_rotation: true,
+            affect_translation: true,
+        };
+        assert!(unsafe { mmd_runtime_append_solver_create(ptr::null()) }.is_null());
+        let solver = unsafe { mmd_runtime_append_solver_create(&config) };
+        assert!(!solver.is_null());
+
+        let source_position = [0.0; 3];
+        let source_rotation = [0.0, 0.0, 0.0, 1.0];
+        let mut out_position = [0.0; 3];
+        let mut out_rotation = [0.0; 4];
+        assert!(!unsafe {
+            mmd_runtime_append_solver_solve(
+                ptr::null(),
+                source_position.as_ptr(),
+                source_rotation.as_ptr(),
+                out_position.as_mut_ptr(),
+                out_rotation.as_mut_ptr(),
+            )
+        });
+        assert!(!unsafe {
+            mmd_runtime_append_solver_solve(
+                solver,
+                ptr::null(),
+                source_rotation.as_ptr(),
+                out_position.as_mut_ptr(),
+                out_rotation.as_mut_ptr(),
+            )
+        });
+        assert!(!unsafe {
+            mmd_runtime_append_solver_solve(
+                solver,
+                source_position.as_ptr(),
+                ptr::null(),
+                out_position.as_mut_ptr(),
+                out_rotation.as_mut_ptr(),
+            )
+        });
+
+        unsafe { mmd_runtime_append_solver_free(solver) };
+    }
+
+    #[test]
+    fn ik_chain_lifecycle_solve_converges_and_uses_column_major_parent_matrix() {
+        let chain = simple_ik_chain();
+        assert!(!chain.is_null());
+
+        let parent_world =
+            glam::Mat4::from_translation(glam::Vec3::new(2.0, 0.0, 0.0)).to_cols_array();
+        let local_rotations = [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0];
+        let goal = [2.0, 1.0, 0.0];
+        let mut out_rotations = [0.0; 4];
+        let mut stats = MmdRuntimeFfiIkSolveStats {
+            executed_iterations: 0,
+            link_steps: 0,
+            final_distance: f32::MAX,
+            break_reason: u32::MAX,
+        };
+
+        assert!(unsafe {
+            mmd_runtime_ik_chain_solve(
+                chain,
+                parent_world.as_ptr(),
+                ptr::null(),
+                local_rotations.as_ptr(),
+                goal.as_ptr(),
+                1.0e-3,
+                0,
+                out_rotations.as_mut_ptr(),
+                out_rotations.len(),
+                &mut stats,
+            )
+        });
+        assert!(
+            stats.final_distance <= 1.0e-3,
+            "IK should converge to the goal, stats={:?}",
+            (
+                stats.executed_iterations,
+                stats.link_steps,
+                stats.final_distance,
+                stats.break_reason
+            )
+        );
+        assert_eq!(stats.break_reason, 0);
+
+        let solved = glam::Quat::from_xyzw(
+            out_rotations[0],
+            out_rotations[1],
+            out_rotations[2],
+            out_rotations[3],
+        );
+        let rotated_x = solved.mul_vec3(glam::Vec3::X);
+        assert_near(rotated_x.x, 0.0, 1.0e-3);
+        assert_near(rotated_x.y, 1.0, 1.0e-3);
+        assert_near(out_rotations[3], solved.w, 0.0);
+
+        unsafe { mmd_runtime_ik_chain_free(chain) };
+    }
+
+    #[test]
+    fn ik_chain_rejects_null_and_short_buffer_inputs() {
+        let chain = simple_ik_chain();
+        assert!(!chain.is_null());
+
+        let local_rotations = [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0];
+        let goal = [0.0, 1.0, 0.0];
+        let mut out_rotations = [0.0; 4];
+
+        assert!(
+            unsafe { mmd_runtime_ik_chain_create(ptr::null(), 2, 1, ptr::null(), 1, 1, 0.0) }
+                .is_null()
+        );
+        assert!(!unsafe {
+            mmd_runtime_ik_chain_solve(
+                ptr::null_mut(),
+                ptr::null(),
+                ptr::null(),
+                local_rotations.as_ptr(),
+                goal.as_ptr(),
+                1.0e-3,
+                0,
+                out_rotations.as_mut_ptr(),
+                out_rotations.len(),
+                ptr::null_mut(),
+            )
+        });
+        assert!(!unsafe {
+            mmd_runtime_ik_chain_solve(
+                chain,
+                ptr::null(),
+                ptr::null(),
+                ptr::null(),
+                goal.as_ptr(),
+                1.0e-3,
+                0,
+                out_rotations.as_mut_ptr(),
+                out_rotations.len(),
+                ptr::null_mut(),
+            )
+        });
+        assert!(!unsafe {
+            mmd_runtime_ik_chain_solve(
+                chain,
+                ptr::null(),
+                ptr::null(),
+                local_rotations.as_ptr(),
+                goal.as_ptr(),
+                1.0e-3,
+                0,
+                out_rotations.as_mut_ptr(),
+                out_rotations.len() - 1,
+                ptr::null_mut(),
+            )
+        });
+
+        unsafe { mmd_runtime_ik_chain_free(chain) };
+    }
 
     #[test]
     fn exports_pmx_from_parts_through_c_abi() {
@@ -4564,6 +5294,225 @@ mod tests {
         );
         serde_json::from_slice(&manifest_bytes)
             .unwrap_or_else(|err| panic!("{context}: manifest_json parse failed: {err}"))
+    }
+
+    fn rig_spec_manifest_json(
+        spec: *mut MmdRuntimePmxRigSpec,
+        context: &str,
+    ) -> serde_json::Value {
+        let manifest_bytes =
+            ffi_buffer_to_vec(unsafe { mmd_runtime_pmx_rig_spec_manifest_json(spec) });
+        assert!(
+            !manifest_bytes.is_empty(),
+            "{context}: manifest_json must not be empty"
+        );
+        serde_json::from_slice(&manifest_bytes)
+            .unwrap_or_else(|err| panic!("{context}: manifest_json parse failed: {err}"))
+    }
+
+    fn assert_json_array3(value: &serde_json::Value, context: &str) {
+        let array = value
+            .as_array()
+            .unwrap_or_else(|| panic!("{context}: must be an array"));
+        assert_eq!(array.len(), 3, "{context}: must have three elements");
+        assert!(
+            array.iter().all(|item| item.is_number()),
+            "{context}: elements must be numbers"
+        );
+    }
+
+    #[test]
+    fn rig_spec_manifest_json_has_expected_shape() {
+        let bytes: &[u8] =
+            include_bytes!("../../mmd-anim-format/fixtures/pmx/ik_multi_axis_limit.pmx");
+        let spec = unsafe { mmd_runtime_pmx_rig_spec_create(bytes.as_ptr(), bytes.len()) };
+        assert!(!spec.is_null(), "rig spec handle must not be null");
+
+        let manifest = rig_spec_manifest_json(spec, "fixture rig spec");
+        let bone_count = manifest
+            .get("boneCount")
+            .and_then(|v| v.as_u64())
+            .expect("fixture rig spec: boneCount must be a number");
+        let ik_chain_count = manifest
+            .get("ikChainCount")
+            .and_then(|v| v.as_u64())
+            .expect("fixture rig spec: ikChainCount must be a number");
+        let grant_count = manifest
+            .get("grantCount")
+            .and_then(|v| v.as_u64())
+            .expect("fixture rig spec: grantCount must be a number");
+
+        let bones = manifest
+            .get("bones")
+            .and_then(|v| v.as_array())
+            .expect("fixture rig spec: bones must be an array");
+        let ik_chains = manifest
+            .get("ikChains")
+            .and_then(|v| v.as_array())
+            .expect("fixture rig spec: ikChains must be an array");
+        let grants = manifest
+            .get("grants")
+            .and_then(|v| v.as_array())
+            .expect("fixture rig spec: grants must be an array");
+
+        assert_eq!(bones.len(), bone_count as usize, "boneCount mismatch");
+        assert_eq!(
+            ik_chains.len(),
+            ik_chain_count as usize,
+            "ikChainCount mismatch"
+        );
+        assert_eq!(grants.len(), grant_count as usize, "grantCount mismatch");
+        assert!(bone_count > 0, "fixture rig spec: boneCount must be positive");
+        assert!(
+            ik_chain_count > 0,
+            "fixture rig spec: ikChainCount must be positive"
+        );
+
+        for (bone_index, bone) in bones.iter().enumerate() {
+            let context = format!("fixture rig spec: bone {bone_index}");
+            assert!(bone.get("name").is_some_and(|v| v.is_string()), "{context}: name");
+            assert!(
+                bone.get("nameBytes").is_some_and(|v| v.is_string()),
+                "{context}: nameBytes"
+            );
+            assert!(
+                bone.get("parentIndex").is_some_and(|v| v.is_number()),
+                "{context}: parentIndex"
+            );
+            assert_json_array3(
+                bone.get("restPosition")
+                    .unwrap_or_else(|| panic!("{context}: restPosition missing")),
+                &format!("{context}: restPosition"),
+            );
+            assert!(
+                bone.get("deformLayer").is_some_and(|v| v.is_number()),
+                "{context}: deformLayer"
+            );
+            assert!(bone.get("fixedAxis").is_some(), "{context}: fixedAxis missing");
+            assert!(bone.get("localAxis").is_some(), "{context}: localAxis missing");
+            assert!(
+                bone.get("transformAfterPhysics")
+                    .is_some_and(|v| v.is_boolean()),
+                "{context}: transformAfterPhysics"
+            );
+            if let Some(local_axis) = bone.get("localAxis").filter(|v| !v.is_null()) {
+                assert_json_array3(
+                    local_axis
+                        .get("x")
+                        .unwrap_or_else(|| panic!("{context}: localAxis.x missing")),
+                    &format!("{context}: localAxis.x"),
+                );
+                assert_json_array3(
+                    local_axis
+                        .get("z")
+                        .unwrap_or_else(|| panic!("{context}: localAxis.z missing")),
+                    &format!("{context}: localAxis.z"),
+                );
+            }
+        }
+
+        for (chain_index, chain) in ik_chains.iter().enumerate() {
+            let context = format!("fixture rig spec: ik chain {chain_index}");
+            assert!(
+                chain
+                    .get("controllerBoneIndex")
+                    .is_some_and(|v| v.is_number()),
+                "{context}: controllerBoneIndex"
+            );
+            assert!(
+                chain.get("targetBoneIndex").is_some_and(|v| v.is_number()),
+                "{context}: targetBoneIndex"
+            );
+            assert!(
+                chain.get("iterationCount").is_some_and(|v| v.is_number()),
+                "{context}: iterationCount"
+            );
+            assert!(
+                chain.get("limitAngle").is_some_and(|v| v.is_number()),
+                "{context}: limitAngle"
+            );
+            let links = chain
+                .get("links")
+                .and_then(|v| v.as_array())
+                .unwrap_or_else(|| panic!("{context}: links must be an array"));
+            for (link_index, link) in links.iter().enumerate() {
+                let context = format!("{context}: link {link_index}");
+                assert!(
+                    link.get("boneIndex").is_some_and(|v| v.is_number()),
+                    "{context}: boneIndex"
+                );
+                assert!(
+                    link.get("hasAngleLimit").is_some_and(|v| v.is_boolean()),
+                    "{context}: hasAngleLimit"
+                );
+                assert_json_array3(
+                    link.get("angleLimitMin")
+                        .unwrap_or_else(|| panic!("{context}: angleLimitMin missing")),
+                    &format!("{context}: angleLimitMin"),
+                );
+                assert_json_array3(
+                    link.get("angleLimitMax")
+                        .unwrap_or_else(|| panic!("{context}: angleLimitMax missing")),
+                    &format!("{context}: angleLimitMax"),
+                );
+            }
+        }
+
+        for (grant_index, grant) in grants.iter().enumerate() {
+            let context = format!("fixture rig spec: grant {grant_index}");
+            assert!(
+                grant.get("targetBoneIndex").is_some_and(|v| v.is_number()),
+                "{context}: targetBoneIndex"
+            );
+            assert!(
+                grant.get("sourceBoneIndex").is_some_and(|v| v.is_number()),
+                "{context}: sourceBoneIndex"
+            );
+            assert!(
+                grant.get("ratio").is_some_and(|v| v.is_number()),
+                "{context}: ratio"
+            );
+            assert!(
+                grant.get("affectRotation").is_some_and(|v| v.is_boolean()),
+                "{context}: affectRotation"
+            );
+            assert!(
+                grant
+                    .get("affectTranslation")
+                    .is_some_and(|v| v.is_boolean()),
+                "{context}: affectTranslation"
+            );
+            assert!(
+                grant.get("local").is_some_and(|v| v.is_boolean()),
+                "{context}: local"
+            );
+        }
+
+        unsafe { mmd_runtime_pmx_rig_spec_free(spec) };
+    }
+
+    #[test]
+    fn rig_spec_rejects_null_and_invalid_input() {
+        let null_spec = unsafe { mmd_runtime_pmx_rig_spec_create(ptr::null(), 1) };
+        assert!(null_spec.is_null(), "null input must return null handle");
+
+        let byte = 0_u8;
+        let empty_spec = unsafe { mmd_runtime_pmx_rig_spec_create(&byte as *const u8, 0) };
+        assert!(empty_spec.is_null(), "empty input must return null handle");
+
+        let garbage = b"not a pmx";
+        let invalid_spec =
+            unsafe { mmd_runtime_pmx_rig_spec_create(garbage.as_ptr(), garbage.len()) };
+        assert!(
+            invalid_spec.is_null(),
+            "invalid input must return null handle"
+        );
+
+        assert_empty_ffi_buffer(
+            unsafe { mmd_runtime_pmx_rig_spec_manifest_json(ptr::null()) },
+            "null rig spec manifest",
+        );
+        unsafe { mmd_runtime_pmx_rig_spec_free(ptr::null_mut()) };
     }
 
     #[test]

--- a/crates/mmd-anim-format/src/format.rs
+++ b/crates/mmd-anim-format/src/format.rs
@@ -14,21 +14,28 @@ pub enum MmdFormatKind {
     Unknown,
 }
 
-pub fn detect_mmd_format(data: &[u8], file_name: Option<&str>) -> MmdFormatKind {
+pub fn sniff(data: &[u8]) -> Option<MmdFormatKind> {
     if data.starts_with(b"PMX ") {
-        return MmdFormatKind::Pmx;
+        return Some(MmdFormatKind::Pmx);
     }
     if data.starts_with(b"Pmd") {
-        return MmdFormatKind::Pmd;
+        return Some(MmdFormatKind::Pmd);
     }
     if data.starts_with(b"Vocaloid Motion Data") {
-        return MmdFormatKind::Vmd;
+        return Some(MmdFormatKind::Vmd);
+    }
+    if data.starts_with(b"Polygon Movie maker ") {
+        return Some(MmdFormatKind::Pmm);
+    }
+    None
+}
+
+pub fn detect_mmd_format(data: &[u8], file_name: Option<&str>) -> MmdFormatKind {
+    if let Some(kind) = sniff(data) {
+        return kind;
     }
     if data.starts_with(b"Vocaloid Pose Data") {
         return MmdFormatKind::Vpd;
-    }
-    if data.starts_with(b"Polygon Movie maker ") {
-        return MmdFormatKind::Pmm;
     }
     if data.starts_with(b"xof ") {
         return MmdFormatKind::X;
@@ -89,6 +96,22 @@ mod tests {
             detect_mmd_format(b"Nanoem Motion Data", None),
             MmdFormatKind::Nmd
         );
+    }
+
+    #[test]
+    fn sniffs_core_binary_formats_from_magic_bytes() {
+        assert_eq!(sniff(b"PMX test"), Some(MmdFormatKind::Pmx));
+        assert_eq!(sniff(b"Pmd\x00"), Some(MmdFormatKind::Pmd));
+        assert_eq!(
+            sniff(b"Vocaloid Motion Data 0002\0\0\0\0\0model"),
+            Some(MmdFormatKind::Vmd)
+        );
+        assert_eq!(
+            sniff(b"Polygon Movie maker 0002\0"),
+            Some(MmdFormatKind::Pmm)
+        );
+        assert_eq!(sniff(b"Vocaloid Pose Data file"), None);
+        assert_eq!(sniff(b""), None);
     }
 
     #[test]

--- a/crates/mmd-anim-format/src/lib.rs
+++ b/crates/mmd-anim-format/src/lib.rs
@@ -33,9 +33,10 @@ pub use pmx::{
     PmxPartsDisplayFrameItem, PmxPartsGroupMorphOffset, PmxPartsIndexSizes, PmxPartsInput,
     PmxPartsJointDescriptor, PmxPartsMaterialDescriptor, PmxPartsMaterialFlags,
     PmxPartsMorphDescriptor, PmxPartsRigidBodyDescriptor, PmxPartsVertexMorphOffset,
-    PmxRuntimeImport, build_pmx_model_from_parts, export_pmx_model, import_pmx_model,
-    import_pmx_runtime, parse_pmx_material_split, parse_pmx_model, split_pmx_model_by_material,
-    validate_pmx_export_model,
+    PmxRigSpec, PmxRigSpecBone, PmxRigSpecGrant, PmxRigSpecIkChain, PmxRigSpecIkLink,
+    PmxRigSpecLocalAxis, PmxRuntimeImport, build_pmx_model_from_parts, export_pmx_model,
+    import_pmx_model, import_pmx_runtime, parse_pmx_material_split, parse_pmx_model,
+    parse_pmx_rig_spec, split_pmx_model_by_material, validate_pmx_export_model,
 };
 pub use vmd::{
     VmdCameraState, VmdClipBuildOptions, VmdIkEntry, VmdImportResult, VmdParsedAnimation,

--- a/crates/mmd-anim-format/src/lib.rs
+++ b/crates/mmd-anim-format/src/lib.rs
@@ -16,7 +16,7 @@ pub mod vmd;
 pub mod vpd;
 pub mod xfile;
 
-pub use format::{MmdFormatKind, detect_mmd_format};
+pub use format::{MmdFormatKind, detect_mmd_format, sniff};
 pub use nmd::{NmdParsedManifest, parse_nmd_manifest};
 pub use normalize::normalize_vmd_name;
 pub use pmd::{

--- a/crates/mmd-anim-format/src/pmx/json_f32.rs
+++ b/crates/mmd-anim-format/src/pmx/json_f32.rs
@@ -1,0 +1,365 @@
+use std::fmt;
+
+use serde::{
+    de::{self, SeqAccess, Visitor},
+    ser::SerializeSeq,
+    Deserialize, Deserializer, Serialize, Serializer,
+};
+
+const NAN_TOKEN: &str = "NaN";
+const INFINITY_TOKEN: &str = "Infinity";
+const NEG_INFINITY_TOKEN: &str = "-Infinity";
+
+#[derive(Clone, Copy)]
+struct JsonF32(f32);
+
+impl Serialize for JsonF32 {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        if self.0.is_nan() {
+            serializer.serialize_str(NAN_TOKEN)
+        } else if self.0 == f32::INFINITY {
+            serializer.serialize_str(INFINITY_TOKEN)
+        } else if self.0 == f32::NEG_INFINITY {
+            serializer.serialize_str(NEG_INFINITY_TOKEN)
+        } else {
+            serializer.serialize_f32(self.0)
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for JsonF32 {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_any(JsonF32Visitor)
+    }
+}
+
+struct JsonF32Visitor;
+
+impl<'de> Visitor<'de> for JsonF32Visitor {
+    type Value = JsonF32;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("a finite f32 number or one of \"NaN\", \"Infinity\", \"-Infinity\"")
+    }
+
+    fn visit_f32<E>(self, value: f32) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(JsonF32(value))
+    }
+
+    fn visit_f64<E>(self, value: f64) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(JsonF32(value as f32))
+    }
+
+    fn visit_i64<E>(self, value: i64) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(JsonF32(value as f32))
+    }
+
+    fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(JsonF32(value as f32))
+    }
+
+    fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        parse_json_f32(value).map(JsonF32)
+    }
+
+    fn visit_string<E>(self, value: String) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        self.visit_str(&value)
+    }
+}
+
+fn parse_json_f32<E>(value: &str) -> Result<f32, E>
+where
+    E: de::Error,
+{
+    match value {
+        NAN_TOKEN => Ok(f32::NAN),
+        INFINITY_TOKEN => Ok(f32::INFINITY),
+        NEG_INFINITY_TOKEN => Ok(f32::NEG_INFINITY),
+        _ => {
+            let parsed = value
+                .parse::<f32>()
+                .map_err(|_| E::custom(format!("invalid f32 string {value:?}")))?;
+            if parsed.is_finite() {
+                Ok(parsed)
+            } else {
+                Err(E::custom(format!(
+                    "non-finite f32 string {value:?} must use one of \"NaN\", \"Infinity\", \"-Infinity\""
+                )))
+            }
+        }
+    }
+}
+
+pub fn serialize<S>(value: &f32, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    JsonF32(*value).serialize(serializer)
+}
+
+pub fn deserialize<'de, D>(deserializer: D) -> Result<f32, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    JsonF32::deserialize(deserializer).map(|value| value.0)
+}
+
+fn serialize_slice<S>(values: &[f32], serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    let mut seq = serializer.serialize_seq(Some(values.len()))?;
+    for value in values {
+        seq.serialize_element(&JsonF32(*value))?;
+    }
+    seq.end()
+}
+
+fn deserialize_vec<'de, D>(deserializer: D) -> Result<Vec<f32>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    Vec::<JsonF32>::deserialize(deserializer)
+        .map(|values| values.into_iter().map(|value| value.0).collect())
+}
+
+fn next_array_value<'de, A>(seq: &mut A, index: usize, len: usize) -> Result<f32, A::Error>
+where
+    A: SeqAccess<'de>,
+{
+    seq.next_element::<JsonF32>()?
+        .map(|value| value.0)
+        .ok_or_else(|| de::Error::invalid_length(index, &ArrayLength { len }))
+}
+
+struct ArrayLength {
+    len: usize,
+}
+
+impl de::Expected for ArrayLength {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "an array of {} f32 values", self.len)
+    }
+}
+
+pub mod vec_f32 {
+    use super::*;
+
+    pub fn serialize<S>(values: &[f32], serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serialize_slice(values, serializer)
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<f32>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserialize_vec(deserializer)
+    }
+}
+
+pub mod nested_vec {
+    use super::*;
+
+    struct JsonF32Slice<'a>(&'a [f32]);
+
+    impl Serialize for JsonF32Slice<'_> {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+        {
+            serialize_slice(self.0, serializer)
+        }
+    }
+
+    pub fn serialize<S>(values: &[Vec<f32>], serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut seq = serializer.serialize_seq(Some(values.len()))?;
+        for values in values {
+            seq.serialize_element(&JsonF32Slice(values))?;
+        }
+        seq.end()
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<Vec<f32>>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Vec::<Vec<JsonF32>>::deserialize(deserializer).map(|values| {
+            values
+                .into_iter()
+                .map(|values| values.into_iter().map(|value| value.0).collect())
+                .collect()
+        })
+    }
+}
+
+pub mod array3 {
+    use super::*;
+
+    pub fn serialize<S>(values: &[f32; 3], serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serialize_slice(values, serializer)
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<[f32; 3], D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct Array3Visitor;
+
+        impl<'de> Visitor<'de> for Array3Visitor {
+            type Value = [f32; 3];
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str("an array of 3 f32 values")
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: SeqAccess<'de>,
+            {
+                Ok([
+                    next_array_value(&mut seq, 0, 3)?,
+                    next_array_value(&mut seq, 1, 3)?,
+                    next_array_value(&mut seq, 2, 3)?,
+                ])
+            }
+        }
+
+        deserializer.deserialize_seq(Array3Visitor)
+    }
+}
+
+pub mod array4 {
+    use super::*;
+
+    pub fn serialize<S>(values: &[f32; 4], serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serialize_slice(values, serializer)
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<[f32; 4], D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct Array4Visitor;
+
+        impl<'de> Visitor<'de> for Array4Visitor {
+            type Value = [f32; 4];
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str("an array of 4 f32 values")
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: SeqAccess<'de>,
+            {
+                Ok([
+                    next_array_value(&mut seq, 0, 4)?,
+                    next_array_value(&mut seq, 1, 4)?,
+                    next_array_value(&mut seq, 2, 4)?,
+                    next_array_value(&mut seq, 3, 4)?,
+                ])
+            }
+        }
+
+        deserializer.deserialize_seq(Array4Visitor)
+    }
+}
+
+pub mod option_array3 {
+    use super::*;
+
+    pub fn serialize<S>(values: &Option<[f32; 3]>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        struct JsonF32Array3<'a>(&'a [f32; 3]);
+
+        impl Serialize for JsonF32Array3<'_> {
+            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            where
+                S: Serializer,
+            {
+                serialize_slice(self.0, serializer)
+            }
+        }
+
+        match values {
+            Some(values) => serializer.serialize_some(&JsonF32Array3(values)),
+            None => serializer.serialize_none(),
+        }
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<[f32; 3]>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct OptionArray3Visitor;
+
+        impl<'de> Visitor<'de> for OptionArray3Visitor {
+            type Value = Option<[f32; 3]>;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str("null or an array of 3 f32 values")
+            }
+
+            fn visit_none<E>(self) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(None)
+            }
+
+            fn visit_unit<E>(self) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(None)
+            }
+
+            fn visit_some<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                super::array3::deserialize(deserializer).map(Some)
+            }
+        }
+
+        deserializer.deserialize_option(OptionArray3Visitor)
+    }
+}

--- a/crates/mmd-anim-format/src/pmx/mod.rs
+++ b/crates/mmd-anim-format/src/pmx/mod.rs
@@ -10,6 +10,8 @@ use mmd_anim_runtime::{
 
 use crate::error::ImportError;
 
+mod json_f32;
+
 const PMX_MAGIC: [u8; 4] = [0x50, 0x4D, 0x58, 0x20];
 
 const BONE_FLAG_TAIL_INDEX: u16 = 0x0001;
@@ -829,6 +831,7 @@ pub struct PmxParsedModel {
 pub struct PmxParsedMetadata {
     #[serde(default = "default_pmx_format")]
     pub format: String,
+    #[serde(with = "json_f32")]
     pub version: f32,
     pub encoding: String,
     pub name: String,
@@ -868,30 +871,43 @@ pub struct PmxParsedIndexSizes {
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct PmxParsedSdef {
+    #[serde(with = "json_f32::vec_f32")]
     pub enabled: Vec<f32>,
+    #[serde(with = "json_f32::vec_f32")]
     pub c: Vec<f32>,
+    #[serde(with = "json_f32::vec_f32")]
     pub r0: Vec<f32>,
+    #[serde(with = "json_f32::vec_f32")]
     pub r1: Vec<f32>,
+    #[serde(with = "json_f32::vec_f32")]
     pub rw0: Vec<f32>,
+    #[serde(with = "json_f32::vec_f32")]
     pub rw1: Vec<f32>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct PmxParsedQdef {
+    #[serde(with = "json_f32::vec_f32")]
     pub enabled: Vec<f32>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PmxParsedGeometry {
+    #[serde(with = "json_f32::vec_f32")]
     pub positions: Vec<f32>,
+    #[serde(with = "json_f32::vec_f32")]
     pub normals: Vec<f32>,
+    #[serde(with = "json_f32::vec_f32")]
     pub uvs: Vec<f32>,
+    #[serde(with = "json_f32::nested_vec")]
     pub additional_uvs: Vec<Vec<f32>>,
     pub indices: Vec<u32>,
     pub skin_indices: Vec<u32>,
+    #[serde(with = "json_f32::vec_f32")]
     pub skin_weights: Vec<f32>,
+    #[serde(with = "json_f32::vec_f32")]
     pub edge_scale: Vec<f32>,
     pub material_groups: Vec<PmxParsedMaterialGroup>,
     pub sdef: PmxParsedSdef,
@@ -916,11 +932,17 @@ pub struct PmxParsedMaterial {
     pub sphere_mode: String,
     pub toon_texture_path: String,
     pub shared_toon_index: Option<u8>,
+    #[serde(with = "json_f32::array4")]
     pub diffuse: [f32; 4],
+    #[serde(with = "json_f32::array3")]
     pub specular: [f32; 3],
+    #[serde(with = "json_f32")]
     pub specular_power: f32,
+    #[serde(with = "json_f32::array3")]
     pub ambient: [f32; 3],
+    #[serde(with = "json_f32::array4")]
     pub edge_color: [f32; 4],
+    #[serde(with = "json_f32")]
     pub edge_size: f32,
     pub flags: PmxParsedMaterialFlags,
     pub face_count: i32,
@@ -951,11 +973,14 @@ pub struct PmxParsedBone {
     pub english_name: String,
     pub parent_index: i32,
     pub layer: i32,
+    #[serde(with = "json_f32::array3")]
     pub position: [f32; 3],
     pub tail_index: i32,
+    #[serde(with = "json_f32::option_array3")]
     pub tail_position: Option<[f32; 3]>,
     pub flags: PmxParsedBoneFlags,
     pub append_transform: Option<PmxParsedAppendTransform>,
+    #[serde(with = "json_f32::option_array3")]
     pub fixed_axis: Option<[f32; 3]>,
     pub local_axis: Option<PmxParsedLocalAxis>,
     pub external_parent_key: Option<i32>,
@@ -984,12 +1009,15 @@ pub struct PmxParsedBoneFlags {
 #[serde(rename_all = "camelCase")]
 pub struct PmxParsedAppendTransform {
     pub parent_index: i32,
+    #[serde(with = "json_f32")]
     pub weight: f32,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PmxParsedLocalAxis {
+    #[serde(with = "json_f32::array3")]
     pub x: [f32; 3],
+    #[serde(with = "json_f32::array3")]
     pub z: [f32; 3],
 }
 
@@ -998,6 +1026,7 @@ pub struct PmxParsedLocalAxis {
 pub struct PmxParsedIk {
     pub target_index: i32,
     pub loop_count: i32,
+    #[serde(with = "json_f32")]
     pub limit_angle: f32,
     pub links: Vec<PmxParsedIkLink>,
 }
@@ -1011,7 +1040,9 @@ pub struct PmxParsedIkLink {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PmxParsedIkLimit {
+    #[serde(with = "json_f32::array3")]
     pub lower: [f32; 3],
+    #[serde(with = "json_f32::array3")]
     pub upper: [f32; 3],
 }
 
@@ -1032,8 +1063,10 @@ pub struct PmxRigSpecBone {
     pub name: String,
     pub name_bytes: String,
     pub parent_index: i32,
+    #[serde(with = "json_f32::array3")]
     pub rest_position: [f32; 3],
     pub deform_layer: i32,
+    #[serde(with = "json_f32::option_array3")]
     pub fixed_axis: Option<[f32; 3]>,
     pub local_axis: Option<PmxRigSpecLocalAxis>,
     pub transform_after_physics: bool,
@@ -1041,7 +1074,9 @@ pub struct PmxRigSpecBone {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PmxRigSpecLocalAxis {
+    #[serde(with = "json_f32::array3")]
     pub x: [f32; 3],
+    #[serde(with = "json_f32::array3")]
     pub z: [f32; 3],
 }
 
@@ -1051,6 +1086,7 @@ pub struct PmxRigSpecIkChain {
     pub controller_bone_index: i32,
     pub target_bone_index: i32,
     pub iteration_count: u32,
+    #[serde(with = "json_f32")]
     pub limit_angle: f32,
     pub links: Vec<PmxRigSpecIkLink>,
 }
@@ -1060,7 +1096,9 @@ pub struct PmxRigSpecIkChain {
 pub struct PmxRigSpecIkLink {
     pub bone_index: i32,
     pub has_angle_limit: bool,
+    #[serde(with = "json_f32::array3")]
     pub angle_limit_min: [f32; 3],
+    #[serde(with = "json_f32::array3")]
     pub angle_limit_max: [f32; 3],
 }
 
@@ -1069,6 +1107,7 @@ pub struct PmxRigSpecIkLink {
 pub struct PmxRigSpecGrant {
     pub target_bone_index: i32,
     pub source_bone_index: i32,
+    #[serde(with = "json_f32")]
     pub ratio: f32,
     pub affect_rotation: bool,
     pub affect_translation: bool,
@@ -1183,6 +1222,7 @@ pub struct PmxParsedMorph {
 #[serde(rename_all = "camelCase")]
 pub struct PmxParsedVertexMorphOffset {
     pub vertex_index: u32,
+    #[serde(with = "json_f32::array3")]
     pub position: [f32; 3],
 }
 
@@ -1190,6 +1230,7 @@ pub struct PmxParsedVertexMorphOffset {
 #[serde(rename_all = "camelCase")]
 pub struct PmxParsedGroupMorphOffset {
     pub morph_index: i32,
+    #[serde(with = "json_f32")]
     pub weight: f32,
 }
 
@@ -1197,7 +1238,9 @@ pub struct PmxParsedGroupMorphOffset {
 #[serde(rename_all = "camelCase")]
 pub struct PmxParsedBoneMorphOffset {
     pub bone_index: i32,
+    #[serde(with = "json_f32::array3")]
     pub translation: [f32; 3],
+    #[serde(with = "json_f32::array4")]
     pub rotation: [f32; 4],
 }
 
@@ -1205,6 +1248,7 @@ pub struct PmxParsedBoneMorphOffset {
 #[serde(rename_all = "camelCase")]
 pub struct PmxParsedUvMorphOffset {
     pub vertex_index: u32,
+    #[serde(with = "json_f32::array4")]
     pub uv: [f32; 4],
 }
 
@@ -1213,6 +1257,7 @@ pub struct PmxParsedUvMorphOffset {
 pub struct PmxParsedAdditionalUvMorphOffset {
     pub vertex_index: u32,
     pub uv_index: u8,
+    #[serde(with = "json_f32::array4")]
     pub uv: [f32; 4],
 }
 
@@ -1221,14 +1266,23 @@ pub struct PmxParsedAdditionalUvMorphOffset {
 pub struct PmxParsedMaterialMorphOffset {
     pub material_index: i32,
     pub operation: String,
+    #[serde(with = "json_f32::array4")]
     pub diffuse: [f32; 4],
+    #[serde(with = "json_f32::array3")]
     pub specular: [f32; 3],
+    #[serde(with = "json_f32")]
     pub specular_power: f32,
+    #[serde(with = "json_f32::array3")]
     pub ambient: [f32; 3],
+    #[serde(with = "json_f32::array4")]
     pub edge_color: [f32; 4],
+    #[serde(with = "json_f32")]
     pub edge_size: f32,
+    #[serde(with = "json_f32::array4")]
     pub texture_factor: [f32; 4],
+    #[serde(with = "json_f32::array4")]
     pub sphere_texture_factor: [f32; 4],
+    #[serde(with = "json_f32::array4")]
     pub toon_texture_factor: [f32; 4],
 }
 
@@ -1237,7 +1291,9 @@ pub struct PmxParsedMaterialMorphOffset {
 pub struct PmxParsedImpulseMorphOffset {
     pub rigid_body_index: i32,
     pub local: bool,
+    #[serde(with = "json_f32::array3")]
     pub velocity: [f32; 3],
+    #[serde(with = "json_f32::array3")]
     pub torque: [f32; 3],
 }
 
@@ -1316,13 +1372,21 @@ pub struct PmxParsedRigidBody {
     pub group: u8,
     pub mask: u16,
     pub shape: String,
+    #[serde(with = "json_f32::array3")]
     pub size: [f32; 3],
+    #[serde(with = "json_f32::array3")]
     pub position: [f32; 3],
+    #[serde(with = "json_f32::array3")]
     pub rotation: [f32; 3],
+    #[serde(with = "json_f32")]
     pub mass: f32,
+    #[serde(with = "json_f32")]
     pub linear_damping: f32,
+    #[serde(with = "json_f32")]
     pub angular_damping: f32,
+    #[serde(with = "json_f32")]
     pub restitution: f32,
+    #[serde(with = "json_f32")]
     pub friction: f32,
     pub mode: String,
 }
@@ -1336,13 +1400,21 @@ pub struct PmxParsedJoint {
     pub kind: String,
     pub rigid_body_index_a: i32,
     pub rigid_body_index_b: i32,
+    #[serde(with = "json_f32::array3")]
     pub position: [f32; 3],
+    #[serde(with = "json_f32::array3")]
     pub rotation: [f32; 3],
+    #[serde(with = "json_f32::array3")]
     pub translation_lower_limit: [f32; 3],
+    #[serde(with = "json_f32::array3")]
     pub translation_upper_limit: [f32; 3],
+    #[serde(with = "json_f32::array3")]
     pub rotation_lower_limit: [f32; 3],
+    #[serde(with = "json_f32::array3")]
     pub rotation_upper_limit: [f32; 3],
+    #[serde(with = "json_f32::array3")]
     pub spring_translation_factor: [f32; 3],
+    #[serde(with = "json_f32::array3")]
     pub spring_rotation_factor: [f32; 3],
 }
 
@@ -1359,7 +1431,9 @@ pub struct PmxParsedSoftBody {
     pub flags: u8,
     pub bending_constraints_distance: i32,
     pub cluster_count: i32,
+    #[serde(with = "json_f32")]
     pub total_mass: f32,
+    #[serde(with = "json_f32")]
     pub collision_margin: f32,
 }
 
@@ -1374,6 +1448,7 @@ pub struct PmxParserDiagnostic {
 #[serde(rename_all = "camelCase")]
 pub struct PmxPartsDescriptor {
     #[serde(default = "default_pmx_parts_version")]
+    #[serde(with = "json_f32")]
     pub version: f32,
     #[serde(default = "default_pmx_parts_encoding")]
     pub encoding: String,
@@ -1423,16 +1498,22 @@ pub struct PmxPartsMaterialDescriptor {
     #[serde(default = "default_pmx_parts_shared_toon_index")]
     pub shared_toon_index: Option<u8>,
     #[serde(default = "default_pmx_parts_diffuse")]
+    #[serde(with = "json_f32::array4")]
     pub diffuse: [f32; 4],
     #[serde(default)]
+    #[serde(with = "json_f32::array3")]
     pub specular: [f32; 3],
     #[serde(default = "default_pmx_parts_specular_power")]
+    #[serde(with = "json_f32")]
     pub specular_power: f32,
     #[serde(default = "default_pmx_parts_ambient")]
+    #[serde(with = "json_f32::array3")]
     pub ambient: [f32; 3],
     #[serde(default = "default_pmx_parts_edge_color")]
+    #[serde(with = "json_f32::array4")]
     pub edge_color: [f32; 4],
     #[serde(default = "default_pmx_parts_edge_size")]
+    #[serde(with = "json_f32")]
     pub edge_size: f32,
     #[serde(default)]
     pub flags: PmxPartsMaterialFlags,
@@ -1488,10 +1569,12 @@ pub struct PmxPartsBoneDescriptor {
     #[serde(default)]
     pub layer: i32,
     #[serde(default)]
+    #[serde(with = "json_f32::array3")]
     pub position: [f32; 3],
     #[serde(default = "default_negative_index")]
     pub tail_index: i32,
     #[serde(default)]
+    #[serde(with = "json_f32::option_array3")]
     pub tail_position: Option<[f32; 3]>,
     #[serde(default)]
     pub rotatable: bool,
@@ -1522,6 +1605,7 @@ pub struct PmxPartsMorphDescriptor {
 #[serde(rename_all = "camelCase")]
 pub struct PmxPartsVertexMorphOffset {
     pub vertex_index: u32,
+    #[serde(with = "json_f32::array3")]
     pub position: [f32; 3],
 }
 
@@ -1529,6 +1613,7 @@ pub struct PmxPartsVertexMorphOffset {
 #[serde(rename_all = "camelCase")]
 pub struct PmxPartsGroupMorphOffset {
     pub morph_index: i32,
+    #[serde(with = "json_f32")]
     pub weight: f32,
 }
 
@@ -1570,20 +1655,28 @@ pub struct PmxPartsRigidBodyDescriptor {
     #[serde(default = "default_pmx_parts_rigid_body_shape")]
     pub shape: String,
     #[serde(default = "default_unit_vec3")]
+    #[serde(with = "json_f32::array3")]
     pub size: [f32; 3],
     #[serde(default)]
+    #[serde(with = "json_f32::array3")]
     pub position: [f32; 3],
     #[serde(default)]
+    #[serde(with = "json_f32::array3")]
     pub rotation: [f32; 3],
     #[serde(default = "default_pmx_parts_mass")]
+    #[serde(with = "json_f32")]
     pub mass: f32,
     #[serde(default)]
+    #[serde(with = "json_f32")]
     pub linear_damping: f32,
     #[serde(default)]
+    #[serde(with = "json_f32")]
     pub angular_damping: f32,
     #[serde(default)]
+    #[serde(with = "json_f32")]
     pub restitution: f32,
     #[serde(default)]
+    #[serde(with = "json_f32")]
     pub friction: f32,
     #[serde(default = "default_pmx_parts_rigid_body_mode")]
     pub mode: String,
@@ -1607,20 +1700,28 @@ pub struct PmxPartsJointDescriptor {
     #[serde(default = "default_negative_index")]
     pub rigid_body_index_b: i32,
     #[serde(default)]
+    #[serde(with = "json_f32::array3")]
     pub position: [f32; 3],
     #[serde(default)]
+    #[serde(with = "json_f32::array3")]
     pub rotation: [f32; 3],
     #[serde(default)]
+    #[serde(with = "json_f32::array3")]
     pub translation_lower_limit: [f32; 3],
     #[serde(default)]
+    #[serde(with = "json_f32::array3")]
     pub translation_upper_limit: [f32; 3],
     #[serde(default)]
+    #[serde(with = "json_f32::array3")]
     pub rotation_lower_limit: [f32; 3],
     #[serde(default)]
+    #[serde(with = "json_f32::array3")]
     pub rotation_upper_limit: [f32; 3],
     #[serde(default)]
+    #[serde(with = "json_f32::array3")]
     pub spring_translation_factor: [f32; 3],
     #[serde(default)]
+    #[serde(with = "json_f32::array3")]
     pub spring_rotation_factor: [f32; 3],
 }
 
@@ -5785,6 +5886,47 @@ mod tests {
         let reparsed = parse_pmx_model(&exported).unwrap();
 
         assert_pmx_roundtrip_eq(&parsed, &reparsed);
+    }
+
+    #[test]
+    fn pmx_json_dto_roundtrips_non_finite_f32_values() {
+        let mut parsed = parsed_pmx_fixture();
+        let finite_position = parsed.geometry.positions[1];
+        parsed.geometry.positions[0] = f32::NAN;
+        parsed.geometry.normals[1] = f32::INFINITY;
+        parsed.geometry.uvs[0] = f32::NEG_INFINITY;
+        parsed.materials[0].diffuse[0] = f32::INFINITY;
+        parsed.materials[0].edge_size = f32::NAN;
+        parsed.skeleton.bones[0].position[0] = f32::NEG_INFINITY;
+        parsed.morphs[0].vertex_offsets[0].position[1] = f32::NAN;
+
+        let json = serde_json::to_string(&parsed).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+
+        assert!(json.contains("\"NaN\""));
+        assert!(json.contains("\"Infinity\""));
+        assert!(json.contains("\"-Infinity\""));
+        assert_eq!(value["geometry"]["positions"][0], serde_json::json!("NaN"));
+        assert_eq!(
+            value["geometry"]["normals"][1],
+            serde_json::json!("Infinity")
+        );
+        assert_eq!(value["geometry"]["uvs"][0], serde_json::json!("-Infinity"));
+        assert_eq!(
+            value["geometry"]["positions"][1],
+            serde_json::json!(finite_position)
+        );
+
+        let from_json: PmxParsedModel = serde_json::from_str(&json).unwrap();
+
+        assert!(from_json.geometry.positions[0].is_nan());
+        assert_eq!(from_json.geometry.normals[1], f32::INFINITY);
+        assert_eq!(from_json.geometry.uvs[0], f32::NEG_INFINITY);
+        assert_eq!(from_json.materials[0].diffuse[0], f32::INFINITY);
+        assert!(from_json.materials[0].edge_size.is_nan());
+        assert_eq!(from_json.skeleton.bones[0].position[0], f32::NEG_INFINITY);
+        assert!(from_json.morphs[0].vertex_offsets[0].position[1].is_nan());
+        assert_eq!(from_json.geometry.positions[1], finite_position);
     }
 
     #[test]

--- a/crates/mmd-anim-format/src/pmx/mod.rs
+++ b/crates/mmd-anim-format/src/pmx/mod.rs
@@ -1017,6 +1017,153 @@ pub struct PmxParsedIkLimit {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+pub struct PmxRigSpec {
+    pub bone_count: usize,
+    pub ik_chain_count: usize,
+    pub grant_count: usize,
+    pub bones: Vec<PmxRigSpecBone>,
+    pub ik_chains: Vec<PmxRigSpecIkChain>,
+    pub grants: Vec<PmxRigSpecGrant>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PmxRigSpecBone {
+    pub name: String,
+    pub name_bytes: String,
+    pub parent_index: i32,
+    pub rest_position: [f32; 3],
+    pub deform_layer: i32,
+    pub fixed_axis: Option<[f32; 3]>,
+    pub local_axis: Option<PmxRigSpecLocalAxis>,
+    pub transform_after_physics: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PmxRigSpecLocalAxis {
+    pub x: [f32; 3],
+    pub z: [f32; 3],
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PmxRigSpecIkChain {
+    pub controller_bone_index: i32,
+    pub target_bone_index: i32,
+    pub iteration_count: u32,
+    pub limit_angle: f32,
+    pub links: Vec<PmxRigSpecIkLink>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PmxRigSpecIkLink {
+    pub bone_index: i32,
+    pub has_angle_limit: bool,
+    pub angle_limit_min: [f32; 3],
+    pub angle_limit_max: [f32; 3],
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PmxRigSpecGrant {
+    pub target_bone_index: i32,
+    pub source_bone_index: i32,
+    pub ratio: f32,
+    pub affect_rotation: bool,
+    pub affect_translation: bool,
+    pub local: bool,
+}
+
+pub fn parse_pmx_rig_spec(data: &[u8]) -> Result<PmxRigSpec, ImportError> {
+    let model = parse_pmx_model(data)?;
+    Ok(pmx_model_to_rig_spec(&model))
+}
+
+pub fn pmx_model_to_rig_spec(model: &PmxParsedModel) -> PmxRigSpec {
+    let mut bones = Vec::with_capacity(model.skeleton.bones.len());
+    let mut ik_chains = Vec::new();
+    let mut grants = Vec::new();
+
+    for (index, bone) in model.skeleton.bones.iter().enumerate() {
+        bones.push(PmxRigSpecBone {
+            name: bone.name.clone(),
+            name_bytes: shift_jis_hex(&bone.name),
+            parent_index: bone.parent_index,
+            rest_position: bone.position,
+            deform_layer: bone.layer,
+            fixed_axis: bone.fixed_axis,
+            local_axis: bone.local_axis.as_ref().map(|axis| PmxRigSpecLocalAxis {
+                x: axis.x,
+                z: axis.z,
+            }),
+            transform_after_physics: bone.flags.transform_after_physics,
+        });
+
+        if let Some(ik) = &bone.ik {
+            ik_chains.push(PmxRigSpecIkChain {
+                controller_bone_index: index as i32,
+                target_bone_index: ik.target_index,
+                iteration_count: ik.loop_count.max(0) as u32,
+                limit_angle: ik.limit_angle,
+                links: ik
+                    .links
+                    .iter()
+                    .map(|link| {
+                        let (angle_limit_min, angle_limit_max) =
+                            link.limits.as_ref().map_or(([0.0; 3], [0.0; 3]), |limit| {
+                                (limit.lower, limit.upper)
+                            });
+                        PmxRigSpecIkLink {
+                            bone_index: link.bone_index,
+                            has_angle_limit: link.limits.is_some(),
+                            angle_limit_min,
+                            angle_limit_max,
+                        }
+                    })
+                    .collect(),
+            });
+        }
+
+        if let Some(append) = &bone.append_transform {
+            grants.push(PmxRigSpecGrant {
+                target_bone_index: index as i32,
+                source_bone_index: append.parent_index,
+                ratio: append.weight,
+                affect_rotation: bone.flags.append_rotate,
+                affect_translation: bone.flags.append_translate,
+                local: bone.flags.append_local,
+            });
+        }
+    }
+
+    PmxRigSpec {
+        bone_count: bones.len(),
+        ik_chain_count: ik_chains.len(),
+        grant_count: grants.len(),
+        bones,
+        ik_chains,
+        grants,
+    }
+}
+
+fn shift_jis_hex(text: &str) -> String {
+    let (encoded, _, _) = encoding_rs::SHIFT_JIS.encode(text);
+    bytes_to_hex(&encoded)
+}
+
+fn bytes_to_hex(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for &byte in bytes {
+        out.push(HEX[(byte >> 4) as usize] as char);
+        out.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    out
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct PmxParsedMorph {
     pub name: String,
     pub english_name: String,

--- a/crates/mmd-anim-runtime/src/append_primitive.rs
+++ b/crates/mmd-anim-runtime/src/append_primitive.rs
@@ -1,0 +1,160 @@
+use glam::{Quat, Vec3A};
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct AppendPrimitiveInput {
+    pub source_position_offset: Vec3A,
+    pub source_rotation: Quat,
+    pub ratio: f32,
+    pub affect_rotation: bool,
+    pub affect_translation: bool,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct AppendPrimitiveOutput {
+    pub position_offset: Vec3A,
+    pub rotation: Quat,
+}
+
+impl Default for AppendPrimitiveOutput {
+    fn default() -> Self {
+        Self {
+            position_offset: Vec3A::ZERO,
+            rotation: Quat::IDENTITY,
+        }
+    }
+}
+
+pub fn solve_append_transform(input: AppendPrimitiveInput) -> AppendPrimitiveOutput {
+    let rotation = if input.affect_rotation {
+        Quat::IDENTITY
+            .slerp(input.source_rotation, input.ratio)
+            .normalize()
+    } else {
+        Quat::IDENTITY
+    };
+    let position_offset = if input.affect_translation {
+        input.source_position_offset * input.ratio
+    } else {
+        Vec3A::ZERO
+    };
+
+    AppendPrimitiveOutput {
+        position_offset,
+        rotation,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn assert_vec3a_near(actual: Vec3A, expected: Vec3A) {
+        let delta = (actual - expected).abs();
+        assert!(
+            delta.x < 1.0e-5 && delta.y < 1.0e-5 && delta.z < 1.0e-5,
+            "actual={actual:?} expected={expected:?} delta={delta:?}"
+        );
+    }
+
+    #[test]
+    fn solves_rotation_translation_and_ratio() {
+        let output = solve_append_transform(AppendPrimitiveInput {
+            source_position_offset: Vec3A::new(2.0, 4.0, -6.0),
+            source_rotation: Quat::from_rotation_z(std::f32::consts::FRAC_PI_2),
+            ratio: 0.5,
+            affect_rotation: true,
+            affect_translation: true,
+        });
+
+        assert_vec3a_near(output.position_offset, Vec3A::new(1.0, 2.0, -3.0));
+        assert_vec3a_near(
+            output.rotation.mul_vec3a(Vec3A::X),
+            Vec3A::new(
+                std::f32::consts::FRAC_1_SQRT_2,
+                std::f32::consts::FRAC_1_SQRT_2,
+                0.0,
+            ),
+        );
+    }
+
+    #[test]
+    fn disabled_channels_return_identity_offsets() {
+        let output = solve_append_transform(AppendPrimitiveInput {
+            source_position_offset: Vec3A::new(2.0, 0.0, 0.0),
+            source_rotation: Quat::from_rotation_y(1.0),
+            ratio: 1.0,
+            affect_rotation: false,
+            affect_translation: false,
+        });
+
+        assert_vec3a_near(output.position_offset, Vec3A::ZERO);
+        assert_eq!(output.rotation, Quat::IDENTITY);
+    }
+
+    #[test]
+    fn dependency_order_characterization_keeps_known_append_delta_bounded() {
+        let source_local = Quat::from_rotation_z(0.8);
+        let upstream = solve_append_transform(AppendPrimitiveInput {
+            source_position_offset: Vec3A::new(2.0, 0.0, 0.0),
+            source_rotation: source_local,
+            ratio: 0.5,
+            affect_rotation: true,
+            affect_translation: true,
+        });
+
+        let correct_order = solve_append_transform(AppendPrimitiveInput {
+            source_position_offset: upstream.position_offset,
+            source_rotation: upstream.rotation,
+            ratio: 0.5,
+            affect_rotation: true,
+            affect_translation: true,
+        });
+        let dependency_order = solve_append_transform(AppendPrimitiveInput {
+            source_position_offset: Vec3A::new(2.0, 0.0, 0.0),
+            source_rotation: source_local,
+            ratio: 0.5,
+            affect_rotation: true,
+            affect_translation: true,
+        });
+
+        let position_delta =
+            (correct_order.position_offset - dependency_order.position_offset).length();
+        let angular_delta = correct_order
+            .rotation
+            .angle_between(dependency_order.rotation);
+
+        assert!(
+            position_delta > 0.0 && angular_delta > 0.0,
+            "fixture must characterize a non-zero strict-order vs dependency-order delta"
+        );
+        assert!(
+            position_delta <= 0.5 && angular_delta <= 0.21,
+            "characterization budget widened unexpectedly: position_delta={position_delta} angular_delta={angular_delta}"
+        );
+    }
+
+    #[test]
+    fn append_primitive_is_bit_deterministic_in_current_process_profile() {
+        // The workspace currently enables glam fast-math; this test claims bit
+        // identity only for repeated solves in the same process/build profile.
+        let input = AppendPrimitiveInput {
+            source_position_offset: Vec3A::new(0.25, -0.5, 1.25),
+            source_rotation: Quat::from_rotation_y(0.7),
+            ratio: 0.375,
+            affect_rotation: true,
+            affect_translation: true,
+        };
+        let expected = solve_append_transform(input);
+        for _ in 0..32 {
+            let actual = solve_append_transform(input);
+            assert_eq!(
+                actual.position_offset.to_array().map(f32::to_bits),
+                expected.position_offset.to_array().map(f32::to_bits)
+            );
+            assert_eq!(
+                actual.rotation.to_array().map(f32::to_bits),
+                expected.rotation.to_array().map(f32::to_bits)
+            );
+        }
+    }
+}

--- a/crates/mmd-anim-runtime/src/ik_primitive.rs
+++ b/crates/mmd-anim-runtime/src/ik_primitive.rs
@@ -1,0 +1,1092 @@
+use glam::{Mat4, Quat, Vec3A};
+
+use crate::IkAngleLimit;
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct IkChainLinkDefinition {
+    pub bone_slot: usize,
+    pub angle_limit: Option<IkAngleLimit>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct IkChainDefinition {
+    pub parent_slots: Vec<Option<usize>>,
+    pub rest_positions: Vec<Vec3A>,
+    pub fixed_axes: Vec<Option<Vec3A>>,
+    pub target_slot: usize,
+    pub links: Vec<IkChainLinkDefinition>,
+    pub iteration_count: u32,
+    pub limit_angle: f32,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct IkChainPoseInput<'a> {
+    pub parent_world_matrix: Option<Mat4>,
+    pub local_position_offsets: &'a [Vec3A],
+    pub local_rotations: &'a [Quat],
+    pub goal_position: Vec3A,
+    pub tolerance: f32,
+    pub max_iterations_cap: Option<u32>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct IkChainSolveOutput {
+    pub solved_link_rotations: Vec<Quat>,
+    pub final_distance: f32,
+    pub executed_iterations: u32,
+    pub link_steps: u32,
+}
+
+#[derive(Debug)]
+pub struct IkChainSolver {
+    definition: IkChainDefinition,
+    world_matrices: Vec<Mat4>,
+    local_rotations: Vec<Quat>,
+    base_rotations: Vec<Quat>,
+    ik_rotations: Vec<Quat>,
+    best_ik_rotations: Vec<Quat>,
+    chain_states: Vec<ChainLinkState>,
+}
+
+impl IkChainSolver {
+    pub fn new(definition: IkChainDefinition) -> Self {
+        let bone_count = definition.rest_positions.len();
+        let link_count = definition.links.len();
+        Self {
+            definition,
+            world_matrices: vec![Mat4::IDENTITY; bone_count],
+            local_rotations: vec![Quat::IDENTITY; bone_count],
+            base_rotations: Vec::with_capacity(link_count),
+            ik_rotations: Vec::with_capacity(link_count),
+            best_ik_rotations: Vec::with_capacity(link_count),
+            chain_states: Vec::with_capacity(link_count),
+        }
+    }
+
+    pub fn solve(&mut self, input: IkChainPoseInput<'_>) -> IkChainSolveOutput {
+        let tolerance = input.tolerance.max(0.0);
+        let iteration_count = input
+            .max_iterations_cap
+            .map(|cap| self.definition.iteration_count.min(cap))
+            .unwrap_or(self.definition.iteration_count)
+            .max(1) as usize;
+        let limit_angle = self.definition.limit_angle.max(0.0);
+        let link_count = self.definition.links.len();
+
+        self.local_rotations.copy_from_slice(input.local_rotations);
+        self.update_world_matrices(input);
+
+        self.base_rotations.clear();
+        self.base_rotations.extend(
+            self.definition
+                .links
+                .iter()
+                .map(|link| self.local_rotations[link.bone_slot]),
+        );
+        self.ik_rotations.clear();
+        self.ik_rotations.resize(link_count, Quat::IDENTITY);
+        self.best_ik_rotations.clear();
+        self.best_ik_rotations.resize(link_count, Quat::IDENTITY);
+        self.chain_states.clear();
+        self.chain_states
+            .resize_with(link_count, ChainLinkState::default);
+
+        self.apply_link_rotations();
+        self.update_world_matrices(input);
+
+        let mut final_distance = f32::MAX;
+        let mut best_distance = f32::MAX;
+        let mut executed_iterations = 0u32;
+        let mut link_steps = 0u32;
+
+        for iteration in 0..iteration_count {
+            let eff_pos = translation(self.world_matrices[self.definition.target_slot]);
+            final_distance = (eff_pos - input.goal_position).length();
+            if final_distance <= tolerance {
+                break;
+            }
+            executed_iterations += 1;
+
+            for link_index in 0..link_count {
+                let link = &self.definition.links[link_index];
+                let link_slot = link.bone_slot;
+
+                if link_slot == self.definition.target_slot {
+                    continue;
+                }
+
+                let link_world = self.world_matrices[link_slot];
+                let link_pos = translation(link_world);
+                let eff_pos = translation(self.world_matrices[self.definition.target_slot]);
+                let link_world_rot = rotation(link_world);
+                let local_effector = link_world_rot.inverse().mul_vec3a(eff_pos - link_pos);
+                let local_target = link_world_rot
+                    .inverse()
+                    .mul_vec3a(input.goal_position - link_pos);
+
+                if local_effector.length_squared() <= f32::EPSILON
+                    || local_target.length_squared() <= f32::EPSILON
+                {
+                    continue;
+                }
+
+                solve_link_step(LinkStepInput {
+                    local_effector: &local_effector,
+                    local_target: &local_target,
+                    link_index,
+                    base_rotations: &self.base_rotations,
+                    ik_rotations: &mut self.ik_rotations,
+                    chain_states: &mut self.chain_states,
+                    angle_limit: link.angle_limit,
+                    iteration,
+                    limit_angle,
+                });
+
+                self.apply_link_rotations();
+                self.update_world_matrices(input);
+                link_steps += 1;
+            }
+
+            let current_distance = {
+                let eff = translation(self.world_matrices[self.definition.target_slot]);
+                (eff - input.goal_position).length()
+            };
+            final_distance = current_distance;
+            if current_distance < best_distance {
+                best_distance = current_distance;
+                self.best_ik_rotations.copy_from_slice(&self.ik_rotations);
+                if current_distance <= tolerance {
+                    break;
+                }
+            } else {
+                self.ik_rotations.copy_from_slice(&self.best_ik_rotations);
+                self.apply_link_rotations();
+                self.update_world_matrices(input);
+                break;
+            }
+        }
+
+        self.ik_rotations.copy_from_slice(&self.best_ik_rotations);
+        self.apply_link_rotations();
+        self.update_world_matrices(input);
+
+        let solved_link_rotations = self
+            .definition
+            .links
+            .iter()
+            .map(|link| self.local_rotations[link.bone_slot])
+            .collect();
+
+        IkChainSolveOutput {
+            solved_link_rotations,
+            final_distance,
+            executed_iterations,
+            link_steps,
+        }
+    }
+
+    pub(crate) fn update_world_matrices(&mut self, input: IkChainPoseInput<'_>) {
+        update_mini_chain_world_matrices(
+            &self.definition,
+            input.parent_world_matrix.unwrap_or(Mat4::IDENTITY),
+            input.local_position_offsets,
+            &self.local_rotations,
+            &mut self.world_matrices,
+        );
+    }
+
+    fn apply_link_rotations(&mut self) {
+        for (i, link) in self.definition.links.iter().enumerate() {
+            let effective = (self.ik_rotations[i] * self.base_rotations[i]).normalize();
+            self.local_rotations[link.bone_slot] = constrain_rotation_to_axis_if_needed(
+                effective,
+                self.definition.fixed_axes[link.bone_slot],
+            );
+        }
+    }
+}
+
+pub(crate) fn update_mini_chain_world_matrices(
+    definition: &IkChainDefinition,
+    parent_world_matrix: Mat4,
+    local_position_offsets: &[Vec3A],
+    local_rotations: &[Quat],
+    world_matrices: &mut [Mat4],
+) {
+    for slot in 0..definition.rest_positions.len() {
+        let local_position = definition.rest_positions[slot] + local_position_offsets[slot];
+        let local_rotation = constrain_rotation_to_axis_if_needed(
+            local_rotations[slot],
+            definition.fixed_axes[slot],
+        );
+        let local_matrix = Mat4::from_scale_rotation_translation(
+            Vec3A::ONE.into(),
+            local_rotation,
+            local_position.into(),
+        );
+        world_matrices[slot] = match definition.parent_slots[slot] {
+            Some(parent) => world_matrices[parent] * local_matrix,
+            None => parent_world_matrix * local_matrix,
+        };
+    }
+}
+
+pub(crate) fn solve_link_step(input: LinkStepInput<'_>) {
+    let single_axis = get_single_axis_limit(input.angle_limit);
+    if let (Some(angle_limit), Some(axis_index)) = (input.angle_limit, single_axis) {
+        solve_plane_link_step(PlaneLinkStepInput {
+            local_effector: input.local_effector,
+            local_target: input.local_target,
+            link_index: input.link_index,
+            base_rotations: input.base_rotations,
+            ik_rotations: input.ik_rotations,
+            chain_states: input.chain_states,
+            axis_index,
+            limits: angle_limit,
+            iteration: input.iteration,
+            limit_angle: input.limit_angle,
+        });
+    } else if let Some(angle_limit) = input.angle_limit {
+        solve_limited_axes_link_step(LimitedAxesLinkStepInput {
+            local_effector: input.local_effector,
+            local_target: input.local_target,
+            link_index: input.link_index,
+            base_rotations: input.base_rotations,
+            ik_rotations: input.ik_rotations,
+            chain_states: input.chain_states,
+            limits: angle_limit,
+            limit_angle: input.limit_angle,
+        });
+    } else {
+        solve_unconstrained_link_step(UnconstrainedLinkStepInput {
+            local_effector: input.local_effector,
+            local_target: input.local_target,
+            link_index: input.link_index,
+            base_rotations: input.base_rotations,
+            ik_rotations: input.ik_rotations,
+            limit_angle: input.limit_angle,
+        });
+    }
+}
+
+pub(crate) struct LinkStepInput<'a> {
+    pub local_effector: &'a Vec3A,
+    pub local_target: &'a Vec3A,
+    pub link_index: usize,
+    pub base_rotations: &'a [Quat],
+    pub ik_rotations: &'a mut [Quat],
+    pub chain_states: &'a mut [ChainLinkState],
+    pub angle_limit: Option<IkAngleLimit>,
+    pub iteration: usize,
+    pub limit_angle: f32,
+}
+
+struct UnconstrainedLinkStepInput<'a> {
+    local_effector: &'a Vec3A,
+    local_target: &'a Vec3A,
+    link_index: usize,
+    base_rotations: &'a [Quat],
+    ik_rotations: &'a mut [Quat],
+    limit_angle: f32,
+}
+
+fn solve_unconstrained_link_step(input: UnconstrainedLinkStepInput<'_>) {
+    let local_eff_n = input.local_effector.normalize();
+    let local_tgt_n = input.local_target.normalize();
+    let dot = local_eff_n.dot(local_tgt_n).clamp(-1.0, 1.0);
+    let mut angle = dot.acos();
+
+    let tiny_angle = 1e-3 * std::f32::consts::PI / 180.0;
+    if angle < tiny_angle {
+        return;
+    }
+
+    if input.limit_angle > 0.0 {
+        angle = angle.min(input.limit_angle);
+    }
+
+    let axis = local_eff_n.cross(local_tgt_n);
+    let axis_vec = if axis.length() < 1e-5 {
+        if dot > -1.0 + 1e-5 {
+            return;
+        }
+        let basis = if local_eff_n.x.abs() < 0.9 {
+            Vec3A::new(1.0, 0.0, 0.0)
+        } else {
+            Vec3A::new(0.0, 1.0, 0.0)
+        };
+        local_eff_n.cross(basis).normalize()
+    } else {
+        axis.normalize()
+    };
+
+    let delta = Quat::from_axis_angle(axis_vec.into(), angle);
+    let base = input.base_rotations[input.link_index];
+    let ik = input.ik_rotations[input.link_index];
+    let chain_rotation = (ik * base * delta).normalize();
+
+    input.ik_rotations[input.link_index] = (chain_rotation * base.inverse()).normalize();
+}
+
+pub(crate) fn translation(matrix: Mat4) -> Vec3A {
+    Vec3A::from_vec4(matrix.w_axis)
+}
+
+pub(crate) fn rotation(matrix: Mat4) -> Quat {
+    matrix.to_scale_rotation_translation().1
+}
+
+pub(crate) fn constrain_rotation_to_axis(rotation: Quat, axis: Vec3A) -> Quat {
+    let axis = axis.normalize();
+    let vector = Vec3A::new(rotation.x, rotation.y, rotation.z);
+    let projected = axis * vector.dot(axis);
+    let twist = Quat::from_xyzw(projected.x, projected.y, projected.z, rotation.w);
+    if twist.length_squared() <= f32::EPSILON {
+        Quat::IDENTITY
+    } else {
+        twist.normalize()
+    }
+}
+
+fn constrain_rotation_to_axis_if_needed(rotation: Quat, axis: Option<Vec3A>) -> Quat {
+    axis.map_or(rotation, |axis| constrain_rotation_to_axis(rotation, axis))
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub(crate) struct ChainLinkState {
+    pub previous_euler: [f32; 3],
+    pub plane_mode_angle: f32,
+}
+
+pub(crate) fn get_single_axis_limit(limit: Option<IkAngleLimit>) -> Option<usize> {
+    let limit = limit?;
+    let has = [
+        limit.min.x != 0.0 || limit.max.x != 0.0,
+        limit.min.y != 0.0 || limit.max.y != 0.0,
+        limit.min.z != 0.0 || limit.max.z != 0.0,
+    ];
+    if has[0]
+        && limit.min.y == 0.0
+        && limit.max.y == 0.0
+        && limit.min.z == 0.0
+        && limit.max.z == 0.0
+    {
+        return Some(0);
+    }
+    if has[1]
+        && limit.min.x == 0.0
+        && limit.max.x == 0.0
+        && limit.min.z == 0.0
+        && limit.max.z == 0.0
+    {
+        return Some(1);
+    }
+    if has[2]
+        && limit.min.x == 0.0
+        && limit.max.x == 0.0
+        && limit.min.y == 0.0
+        && limit.max.y == 0.0
+    {
+        return Some(2);
+    }
+    None
+}
+
+pub(crate) fn quat_to_rotation_mat3(rotation: Quat) -> [f32; 9] {
+    let [x, y, z, w] = rotation.normalize().to_array();
+    let x2 = x + x;
+    let y2 = y + y;
+    let z2 = z + z;
+    let xx = x * x2;
+    let xy = x * y2;
+    let xz = x * z2;
+    let yy = y * y2;
+    let yz = y * z2;
+    let zz = z * z2;
+    let wx = w * x2;
+    let wy = w * y2;
+    let wz = w * z2;
+    [
+        1.0 - (yy + zz),
+        xy + wz,
+        xz - wy,
+        xy - wz,
+        1.0 - (xx + zz),
+        yz + wx,
+        xz + wy,
+        yz - wx,
+        1.0 - (xx + yy),
+    ]
+}
+
+pub(crate) fn decompose_euler_xyz(mat: &[f32; 9], before: &[f32; 3]) -> [f32; 3] {
+    let sy = -mat[2];
+    let mut result: [f32; 3];
+    if 1.0 - sy.abs() < 1e-6 {
+        let y = sy.asin();
+        let sx = before[0].sin();
+        let sz = before[2].sin();
+        if sx.abs() < sz.abs() {
+            let cx = before[0].cos();
+            result = if cx > 0.0 {
+                [0.0, y, (-mat[3]).asin()]
+            } else {
+                [std::f32::consts::PI, y, mat[3].asin()]
+            };
+        } else {
+            let cz = before[2].cos();
+            result = if cz > 0.0 {
+                [(-mat[7]).asin(), y, 0.0]
+            } else {
+                [mat[7].asin(), y, std::f32::consts::PI]
+            };
+        }
+    } else {
+        result = [mat[5].atan2(mat[8]), (-mat[2]).asin(), mat[1].atan2(mat[0])];
+    }
+
+    let pi = std::f32::consts::PI;
+    let candidates: [[f32; 3]; 8] = [
+        [result[0] + pi, pi - result[1], result[2] + pi],
+        [result[0] + pi, pi - result[1], result[2] - pi],
+        [result[0] + pi, -pi - result[1], result[2] + pi],
+        [result[0] + pi, -pi - result[1], result[2] - pi],
+        [result[0] - pi, pi - result[1], result[2] + pi],
+        [result[0] - pi, pi - result[1], result[2] - pi],
+        [result[0] - pi, -pi - result[1], result[2] + pi],
+        [result[0] - pi, -pi - result[1], result[2] - pi],
+    ];
+    let mut min_error = diff_angle(result[0], before[0]).abs()
+        + diff_angle(result[1], before[1]).abs()
+        + diff_angle(result[2], before[2]).abs();
+    for candidate in &candidates {
+        let error = diff_angle(candidate[0], before[0]).abs()
+            + diff_angle(candidate[1], before[1]).abs()
+            + diff_angle(candidate[2], before[2]).abs();
+        if error < min_error {
+            min_error = error;
+            result = *candidate;
+        }
+    }
+    result
+}
+
+fn diff_angle(a: f32, b: f32) -> f32 {
+    let diff = normalize_angle(a) - normalize_angle(b);
+    if diff > std::f32::consts::PI {
+        diff - std::f32::consts::TAU
+    } else if diff < -std::f32::consts::PI {
+        diff + std::f32::consts::TAU
+    } else {
+        diff
+    }
+}
+
+fn normalize_angle(angle: f32) -> f32 {
+    let mut result = angle;
+    while result >= std::f32::consts::TAU {
+        result -= std::f32::consts::TAU;
+    }
+    while result < 0.0 {
+        result += std::f32::consts::TAU;
+    }
+    result
+}
+
+pub(crate) fn euler_xyz_to_quat(euler: &[f32; 3]) -> Quat {
+    let [x, y, z] = *euler;
+    let c1 = (x / 2.0).cos();
+    let c2 = (y / 2.0).cos();
+    let c3 = (z / 2.0).cos();
+    let s1 = (x / 2.0).sin();
+    let s2 = (y / 2.0).sin();
+    let s3 = (z / 2.0).sin();
+    Quat::from_xyzw(
+        s1 * c2 * c3 + c1 * s2 * s3,
+        c1 * s2 * c3 - s1 * c2 * s3,
+        c1 * c2 * s3 + s1 * s2 * c3,
+        c1 * c2 * c3 - s1 * s2 * s3,
+    )
+}
+
+pub(crate) struct LimitedAxesLinkStepInput<'a> {
+    pub local_effector: &'a Vec3A,
+    pub local_target: &'a Vec3A,
+    pub link_index: usize,
+    pub base_rotations: &'a [Quat],
+    pub ik_rotations: &'a mut [Quat],
+    pub chain_states: &'a mut [ChainLinkState],
+    pub limits: IkAngleLimit,
+    pub limit_angle: f32,
+}
+
+pub(crate) fn solve_limited_axes_link_step(input: LimitedAxesLinkStepInput<'_>) {
+    let state = &mut input.chain_states[input.link_index];
+    let base = input.base_rotations[input.link_index];
+    let current = (input.ik_rotations[input.link_index] * base).normalize();
+    let current_mat = quat_to_rotation_mat3(current);
+    let mut total_euler = decompose_euler_xyz(&current_mat, &state.previous_euler);
+    let mut working_effector = *input.local_effector;
+    let target = input.local_target.normalize();
+
+    // PMX local_axis is intentionally not used as an angle-limit basis in v1.
+    // It remains rig metadata / host control orientation only to preserve the
+    // existing whole-runtime IK behavior.
+    for axis_index in [2usize, 1, 0] {
+        let (lower, upper) = limit_axis_bounds(input.limits, axis_index);
+        if lower == 0.0 && upper == 0.0 {
+            let next = total_euler[axis_index].clamp(lower, upper);
+            let applied = next - total_euler[axis_index];
+            total_euler[axis_index] = next;
+            if applied.abs() > 0.0 {
+                working_effector = Quat::from_axis_angle(axis_vec(axis_index).into(), applied)
+                    .mul_vec3a(working_effector);
+            }
+            continue;
+        }
+
+        let axis = axis_vec(axis_index);
+        let signed_angle = signed_projected_angle(working_effector, target, axis);
+        if signed_angle.abs() <= 1.0e-6 {
+            continue;
+        }
+        let step = if input.limit_angle > 0.0 {
+            signed_angle.clamp(-input.limit_angle, input.limit_angle)
+        } else {
+            signed_angle
+        };
+        let next = (total_euler[axis_index] + step).clamp(lower, upper);
+        let applied = next - total_euler[axis_index];
+        total_euler[axis_index] = next;
+        if applied.abs() > 0.0 {
+            working_effector =
+                Quat::from_axis_angle(axis.into(), applied).mul_vec3a(working_effector);
+        }
+    }
+
+    state.previous_euler = total_euler;
+    let chain_rotation = euler_xyz_to_quat(&total_euler).normalize();
+    input.ik_rotations[input.link_index] = (chain_rotation * base.inverse()).normalize();
+}
+
+pub(crate) fn limit_axis_bounds(limits: IkAngleLimit, axis_index: usize) -> (f32, f32) {
+    match axis_index {
+        0 => (limits.min.x, limits.max.x),
+        1 => (limits.min.y, limits.max.y),
+        _ => (limits.min.z, limits.max.z),
+    }
+}
+
+pub(crate) fn axis_vec(axis_index: usize) -> Vec3A {
+    match axis_index {
+        0 => Vec3A::new(1.0, 0.0, 0.0),
+        1 => Vec3A::new(0.0, 1.0, 0.0),
+        _ => Vec3A::new(0.0, 0.0, 1.0),
+    }
+}
+
+pub(crate) fn signed_projected_angle(from: Vec3A, to: Vec3A, axis: Vec3A) -> f32 {
+    let projected_from = from - axis * from.dot(axis);
+    let projected_to = to - axis * to.dot(axis);
+    if projected_from.length_squared() <= f32::EPSILON
+        || projected_to.length_squared() <= f32::EPSILON
+    {
+        return 0.0;
+    }
+    let from_n = projected_from.normalize();
+    let to_n = projected_to.normalize();
+    let dot = from_n.dot(to_n).clamp(-1.0, 1.0);
+    let angle = dot.acos();
+    let sign = axis.dot(from_n.cross(to_n)).signum();
+    angle * if sign == 0.0 { 1.0 } else { sign }
+}
+
+pub(crate) struct PlaneLinkStepInput<'a> {
+    pub local_effector: &'a Vec3A,
+    pub local_target: &'a Vec3A,
+    pub link_index: usize,
+    pub base_rotations: &'a [Quat],
+    pub ik_rotations: &'a mut [Quat],
+    pub chain_states: &'a mut [ChainLinkState],
+    pub axis_index: usize,
+    pub limits: IkAngleLimit,
+    pub iteration: usize,
+    pub limit_angle: f32,
+}
+
+pub(crate) fn solve_plane_link_step(input: PlaneLinkStepInput<'_>) {
+    let rotate_axis = match input.axis_index {
+        0 => Vec3A::new(1.0, 0.0, 0.0),
+        1 => Vec3A::new(0.0, 1.0, 0.0),
+        _ => Vec3A::new(0.0, 0.0, 1.0),
+    };
+    let local_eff_n = input.local_effector.normalize();
+    let local_tgt_n = input.local_target.normalize();
+
+    let dot = local_eff_n.dot(local_tgt_n).clamp(-1.0, 1.0);
+    let raw_angle = dot.acos();
+    let capped_angle = if input.limit_angle > 0.0 {
+        raw_angle.min(input.limit_angle)
+    } else {
+        raw_angle
+    };
+
+    let target_vec1 =
+        Quat::from_axis_angle(rotate_axis.into(), capped_angle).mul_vec3a(local_eff_n);
+    let target_vec2 =
+        Quat::from_axis_angle(rotate_axis.into(), -capped_angle).mul_vec3a(local_eff_n);
+    let signed_angle = if target_vec1.dot(local_tgt_n) > target_vec2.dot(local_tgt_n) {
+        capped_angle
+    } else {
+        -capped_angle
+    };
+
+    let state = &mut input.chain_states[input.link_index];
+    let mut next_angle = state.plane_mode_angle + signed_angle;
+    let (lower, upper) = match input.axis_index {
+        0 => (input.limits.min.x, input.limits.max.x),
+        1 => (input.limits.min.y, input.limits.max.y),
+        _ => (input.limits.min.z, input.limits.max.z),
+    };
+    let base = input.base_rotations[input.link_index];
+
+    if input.iteration == 0 && (next_angle < lower || next_angle > upper) {
+        if -next_angle > lower && -next_angle < upper {
+            next_angle = -next_angle;
+        } else {
+            let half = (lower + upper) * 0.5;
+            if (half - next_angle).abs() > (half + next_angle).abs() {
+                next_angle = -next_angle;
+            }
+        }
+    }
+
+    state.plane_mode_angle = next_angle.clamp(lower, upper);
+    let chain_rotation = Quat::from_axis_angle(rotate_axis.into(), state.plane_mode_angle);
+    input.ik_rotations[input.link_index] = (chain_rotation * base.inverse()).normalize();
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::*;
+    use crate::{BoneIndex, BoneInit, IkLinkInit, IkSolverInit, ModelArena, RuntimeInstance};
+
+    fn assert_vec3a_near(actual: Vec3A, expected: Vec3A) {
+        let delta = (actual - expected).abs();
+        assert!(
+            delta.x < 1.0e-5 && delta.y < 1.0e-5 && delta.z < 1.0e-5,
+            "actual={actual:?} expected={expected:?} delta={delta:?}"
+        );
+    }
+
+    fn assert_quat_near(actual: Quat, expected: Quat) {
+        let actual = actual.to_array();
+        let expected = expected.to_array();
+        let delta = [
+            (actual[0] - expected[0]).abs(),
+            (actual[1] - expected[1]).abs(),
+            (actual[2] - expected[2]).abs(),
+            (actual[3] - expected[3]).abs(),
+        ];
+        assert!(
+            delta[0] < 1.0e-5 && delta[1] < 1.0e-5 && delta[2] < 1.0e-5 && delta[3] < 1.0e-5,
+            "actual={actual:?} expected={expected:?} delta={delta:?}"
+        );
+    }
+
+    fn one_link_definition(angle_limit: Option<IkAngleLimit>) -> IkChainDefinition {
+        IkChainDefinition {
+            parent_slots: vec![None, Some(0)],
+            rest_positions: vec![Vec3A::ZERO, Vec3A::X],
+            fixed_axes: vec![None, None],
+            target_slot: 1,
+            links: vec![IkChainLinkDefinition {
+                bone_slot: 0,
+                angle_limit,
+            }],
+            iteration_count: 1,
+            limit_angle: 0.0,
+        }
+    }
+
+    #[test]
+    fn mini_chain_world_update_uses_identity_when_parent_world_is_unspecified() {
+        let definition = one_link_definition(None);
+        let mut world = vec![Mat4::IDENTITY; 2];
+        update_mini_chain_world_matrices(
+            &definition,
+            Mat4::IDENTITY,
+            &[Vec3A::ZERO, Vec3A::new(0.0, 2.0, 0.0)],
+            &[
+                Quat::from_rotation_z(std::f32::consts::FRAC_PI_2),
+                Quat::IDENTITY,
+            ],
+            &mut world,
+        );
+
+        assert_vec3a_near(translation(world[1]), Vec3A::new(-2.0, 1.0, 0.0));
+    }
+
+    #[test]
+    fn primitive_matches_full_runtime_for_unconstrained_chain() {
+        let model = Arc::new(
+            ModelArena::new_with_ik(
+                vec![
+                    BoneInit::new(None, Vec3A::ZERO),
+                    BoneInit::new(Some(BoneIndex(0)), Vec3A::X),
+                    BoneInit::new(None, Vec3A::Y),
+                ],
+                vec![IkSolverInit {
+                    ik_bone: BoneIndex(2),
+                    target_bone: BoneIndex(1),
+                    links: vec![IkLinkInit::new(BoneIndex(0))],
+                    iteration_count: 1,
+                    limit_angle: 0.0,
+                }],
+            )
+            .unwrap(),
+        );
+        let mut runtime = RuntimeInstance::new(model);
+        runtime.evaluate_current_pose();
+
+        let mut solver = IkChainSolver::new(one_link_definition(None));
+        let local_position_offsets = [Vec3A::ZERO; 2];
+        let local_rotations = [Quat::IDENTITY; 2];
+        let output = solver.solve(IkChainPoseInput {
+            parent_world_matrix: None,
+            local_position_offsets: &local_position_offsets,
+            local_rotations: &local_rotations,
+            goal_position: Vec3A::Y,
+            tolerance: 1.0e-2,
+            max_iterations_cap: None,
+        });
+
+        assert_quat_near(
+            output.solved_link_rotations[0],
+            runtime.pose().local_rotation(BoneIndex(0)),
+        );
+    }
+
+    #[test]
+    fn primitive_matches_full_runtime_for_two_link_unconstrained_chain() {
+        let model = Arc::new(
+            ModelArena::new_with_ik(
+                vec![
+                    BoneInit::new(None, Vec3A::ZERO),
+                    BoneInit::new(Some(BoneIndex(0)), Vec3A::X),
+                    BoneInit::new(Some(BoneIndex(1)), Vec3A::X),
+                    BoneInit::new(None, Vec3A::new(1.0, 1.0, 0.0)),
+                ],
+                vec![IkSolverInit {
+                    ik_bone: BoneIndex(3),
+                    target_bone: BoneIndex(2),
+                    links: vec![IkLinkInit::new(BoneIndex(1)), IkLinkInit::new(BoneIndex(0))],
+                    iteration_count: 4,
+                    limit_angle: 0.0,
+                }],
+            )
+            .unwrap(),
+        );
+        let mut runtime = RuntimeInstance::new(model);
+        runtime.evaluate_current_pose();
+
+        let definition = IkChainDefinition {
+            parent_slots: vec![None, Some(0), Some(1)],
+            rest_positions: vec![Vec3A::ZERO, Vec3A::X, Vec3A::X],
+            fixed_axes: vec![None, None, None],
+            target_slot: 2,
+            links: vec![
+                IkChainLinkDefinition {
+                    bone_slot: 1,
+                    angle_limit: None,
+                },
+                IkChainLinkDefinition {
+                    bone_slot: 0,
+                    angle_limit: None,
+                },
+            ],
+            iteration_count: 4,
+            limit_angle: 0.0,
+        };
+        let mut solver = IkChainSolver::new(definition);
+        let local_position_offsets = [Vec3A::ZERO; 3];
+        let local_rotations = [Quat::IDENTITY; 3];
+        let output = solver.solve(IkChainPoseInput {
+            parent_world_matrix: None,
+            local_position_offsets: &local_position_offsets,
+            local_rotations: &local_rotations,
+            goal_position: Vec3A::new(1.0, 1.0, 0.0),
+            tolerance: 1.0e-2,
+            max_iterations_cap: None,
+        });
+
+        assert_quat_near(
+            output.solved_link_rotations[0],
+            runtime.pose().local_rotation(BoneIndex(1)),
+        );
+        assert_quat_near(
+            output.solved_link_rotations[1],
+            runtime.pose().local_rotation(BoneIndex(0)),
+        );
+    }
+
+    #[test]
+    fn deform_order_characterization_keeps_known_ik_delta_bounded() {
+        fn solve_one_pass(
+            definition: &IkChainDefinition,
+            goal_position: Vec3A,
+            strict: bool,
+        ) -> Vec<Quat> {
+            let local_position_offsets = vec![Vec3A::ZERO; definition.rest_positions.len()];
+            let mut local_rotations = vec![Quat::IDENTITY; definition.rest_positions.len()];
+            let base_rotations = vec![Quat::IDENTITY; definition.links.len()];
+            let mut ik_rotations = vec![Quat::IDENTITY; definition.links.len()];
+            let mut chain_states = vec![ChainLinkState::default(); definition.links.len()];
+            let mut world_matrices = vec![Mat4::IDENTITY; definition.rest_positions.len()];
+
+            update_mini_chain_world_matrices(
+                definition,
+                Mat4::IDENTITY,
+                &local_position_offsets,
+                &local_rotations,
+                &mut world_matrices,
+            );
+
+            for link_index in 0..definition.links.len() {
+                let link = &definition.links[link_index];
+                let link_slot = link.bone_slot;
+                let link_world = world_matrices[link_slot];
+                let link_pos = translation(link_world);
+                let eff_pos = translation(world_matrices[definition.target_slot]);
+                let link_world_rot = rotation(link_world);
+                let local_effector = link_world_rot.inverse().mul_vec3a(eff_pos - link_pos);
+                let local_target = link_world_rot.inverse().mul_vec3a(goal_position - link_pos);
+
+                solve_link_step(LinkStepInput {
+                    local_effector: &local_effector,
+                    local_target: &local_target,
+                    link_index,
+                    base_rotations: &base_rotations,
+                    ik_rotations: &mut ik_rotations,
+                    chain_states: &mut chain_states,
+                    angle_limit: link.angle_limit,
+                    iteration: 0,
+                    limit_angle: definition.limit_angle,
+                });
+
+                if strict {
+                    local_rotations[link_slot] = ik_rotations[link_index].normalize();
+                    update_mini_chain_world_matrices(
+                        definition,
+                        Mat4::IDENTITY,
+                        &local_position_offsets,
+                        &local_rotations,
+                        &mut world_matrices,
+                    );
+                }
+            }
+
+            if !strict {
+                for (link_index, link) in definition.links.iter().enumerate() {
+                    local_rotations[link.bone_slot] = ik_rotations[link_index].normalize();
+                }
+                update_mini_chain_world_matrices(
+                    definition,
+                    Mat4::IDENTITY,
+                    &local_position_offsets,
+                    &local_rotations,
+                    &mut world_matrices,
+                );
+            }
+
+            definition
+                .links
+                .iter()
+                .map(|link| local_rotations[link.bone_slot])
+                .collect()
+        }
+
+        let definition = IkChainDefinition {
+            parent_slots: vec![None, Some(0), Some(1)],
+            rest_positions: vec![Vec3A::ZERO, Vec3A::X, Vec3A::X],
+            fixed_axes: vec![None, None, None],
+            target_slot: 2,
+            links: vec![
+                IkChainLinkDefinition {
+                    bone_slot: 1,
+                    angle_limit: None,
+                },
+                IkChainLinkDefinition {
+                    bone_slot: 0,
+                    angle_limit: None,
+                },
+            ],
+            iteration_count: 1,
+            limit_angle: 0.0,
+        };
+        let goal_position = Vec3A::new(1.0, 1.0, 0.0);
+
+        let correct_order = solve_one_pass(&definition, goal_position, true);
+        let dependency_order = solve_one_pass(&definition, goal_position, false);
+        let max_angular_delta = correct_order
+            .iter()
+            .zip(&dependency_order)
+            .map(|(correct, dependency)| correct.angle_between(*dependency))
+            .fold(0.0f32, f32::max);
+
+        assert!(
+            max_angular_delta > 0.0,
+            "fixture must characterize a non-zero strict-order vs dependency-order IK delta"
+        );
+        assert!(
+            max_angular_delta <= 0.79,
+            "characterization budget widened unexpectedly: max_angular_delta={max_angular_delta}"
+        );
+    }
+
+    #[test]
+    fn primitive_matches_full_runtime_for_knee_plane_limit() {
+        let limit = IkAngleLimit::new(
+            Vec3A::new(0.0, 0.0, 0.0),
+            Vec3A::new(0.0, 0.0, std::f32::consts::FRAC_PI_4),
+        );
+        let model = Arc::new(
+            ModelArena::new_with_ik(
+                vec![
+                    BoneInit::new(None, Vec3A::ZERO),
+                    BoneInit::new(Some(BoneIndex(0)), Vec3A::X),
+                    BoneInit::new(None, Vec3A::Y),
+                ],
+                vec![IkSolverInit {
+                    ik_bone: BoneIndex(2),
+                    target_bone: BoneIndex(1),
+                    links: vec![IkLinkInit::new(BoneIndex(0)).with_angle_limit(limit)],
+                    iteration_count: 1,
+                    limit_angle: 0.0,
+                }],
+            )
+            .unwrap(),
+        );
+        let mut runtime = RuntimeInstance::new(model);
+        runtime.evaluate_current_pose();
+
+        let mut solver = IkChainSolver::new(one_link_definition(Some(limit)));
+        let local_position_offsets = [Vec3A::ZERO; 2];
+        let local_rotations = [Quat::IDENTITY; 2];
+        let output = solver.solve(IkChainPoseInput {
+            parent_world_matrix: None,
+            local_position_offsets: &local_position_offsets,
+            local_rotations: &local_rotations,
+            goal_position: Vec3A::Y,
+            tolerance: 1.0e-2,
+            max_iterations_cap: None,
+        });
+
+        assert_quat_near(
+            output.solved_link_rotations[0],
+            runtime.pose().local_rotation(BoneIndex(0)),
+        );
+    }
+
+    #[test]
+    fn primitive_matches_full_runtime_for_limited_axes_chain() {
+        let limit = IkAngleLimit::new(Vec3A::new(0.0, -0.6, -0.6), Vec3A::new(0.0, 0.6, 0.6));
+        let goal = Vec3A::new(0.25, 0.55, 0.80).normalize();
+        let model = Arc::new(
+            ModelArena::new_with_ik(
+                vec![
+                    BoneInit::new(None, Vec3A::ZERO),
+                    BoneInit::new(Some(BoneIndex(0)), Vec3A::X),
+                    BoneInit::new(None, goal),
+                ],
+                vec![IkSolverInit {
+                    ik_bone: BoneIndex(2),
+                    target_bone: BoneIndex(1),
+                    links: vec![IkLinkInit::new(BoneIndex(0)).with_angle_limit(limit)],
+                    iteration_count: 1,
+                    limit_angle: 0.0,
+                }],
+            )
+            .unwrap(),
+        );
+        let mut runtime = RuntimeInstance::new(model);
+        runtime.evaluate_current_pose();
+
+        let mut solver = IkChainSolver::new(one_link_definition(Some(limit)));
+        let local_position_offsets = [Vec3A::ZERO; 2];
+        let local_rotations = [Quat::IDENTITY; 2];
+        let output = solver.solve(IkChainPoseInput {
+            parent_world_matrix: None,
+            local_position_offsets: &local_position_offsets,
+            local_rotations: &local_rotations,
+            goal_position: goal,
+            tolerance: 1.0e-2,
+            max_iterations_cap: None,
+        });
+
+        assert_quat_near(
+            output.solved_link_rotations[0],
+            runtime.pose().local_rotation(BoneIndex(0)),
+        );
+    }
+
+    #[test]
+    fn primitive_is_bit_deterministic_in_current_process_profile() {
+        // The workspace currently enables glam fast-math; this test asserts
+        // bit identity only across repeated solves in this same build profile.
+        let definition = IkChainDefinition {
+            parent_slots: vec![None, Some(0), Some(1)],
+            rest_positions: vec![Vec3A::ZERO, Vec3A::X, Vec3A::X],
+            fixed_axes: vec![None, None, None],
+            target_slot: 2,
+            links: vec![
+                IkChainLinkDefinition {
+                    bone_slot: 1,
+                    angle_limit: None,
+                },
+                IkChainLinkDefinition {
+                    bone_slot: 0,
+                    angle_limit: None,
+                },
+            ],
+            iteration_count: 4,
+            limit_angle: 0.0,
+        };
+        let local_position_offsets = [Vec3A::ZERO; 3];
+        let local_rotations = [Quat::IDENTITY; 3];
+        let input = IkChainPoseInput {
+            parent_world_matrix: None,
+            local_position_offsets: &local_position_offsets,
+            local_rotations: &local_rotations,
+            goal_position: Vec3A::new(1.0, 1.0, 0.0),
+            tolerance: 1.0e-2,
+            max_iterations_cap: None,
+        };
+        let mut baseline_solver = IkChainSolver::new(definition.clone());
+        let expected = baseline_solver.solve(input);
+
+        for _ in 0..32 {
+            let mut solver = IkChainSolver::new(definition.clone());
+            let actual = solver.solve(input);
+            assert_eq!(
+                actual.final_distance.to_bits(),
+                expected.final_distance.to_bits()
+            );
+            assert_eq!(actual.executed_iterations, expected.executed_iterations);
+            assert_eq!(actual.link_steps, expected.link_steps);
+            let actual_bits: Vec<_> = actual
+                .solved_link_rotations
+                .iter()
+                .map(|q| q.to_array().map(f32::to_bits))
+                .collect();
+            let expected_bits: Vec<_> = expected
+                .solved_link_rotations
+                .iter()
+                .map(|q| q.to_array().map(f32::to_bits))
+                .collect();
+            assert_eq!(actual_bits, expected_bits);
+        }
+    }
+}

--- a/crates/mmd-anim-runtime/src/lib.rs
+++ b/crates/mmd-anim-runtime/src/lib.rs
@@ -5,6 +5,8 @@
 //! crate and read contiguous output buffers back.
 
 mod animation;
+pub mod append_primitive;
+pub mod ik_primitive;
 mod model;
 mod pose;
 mod runtime;
@@ -13,6 +15,10 @@ pub use animation::{
     AnimationClip, BoneAnimationBinding, InterpolationScalar, InterpolationVector3,
     MorphAnimationBinding, MorphKeyframe, MorphTrack, MovableBoneKeyframe, MovableBoneTrack,
     PropertyAnimationBinding, PropertyKeyframe,
+};
+pub use append_primitive::{AppendPrimitiveInput, AppendPrimitiveOutput, solve_append_transform};
+pub use ik_primitive::{
+    IkChainDefinition, IkChainLinkDefinition, IkChainPoseInput, IkChainSolveOutput, IkChainSolver,
 };
 pub use model::{
     AppendTransform, AppendTransformInit, BoneIndex, BoneInit, BoneMorphOffset, GroupMorphOffset,

--- a/crates/mmd-anim-runtime/src/runtime.rs
+++ b/crates/mmd-anim-runtime/src/runtime.rs
@@ -1,8 +1,22 @@
 use std::sync::Arc;
 
-use glam::{Mat4, Quat, Vec3A};
+use glam::{Mat4, Quat};
 
 use crate::{AnimationClip, ModelArena, MorphIndex, PoseArena};
+use crate::{
+    append_primitive::{AppendPrimitiveInput, solve_append_transform},
+    ik_primitive::{
+        ChainLinkState, LinkStepInput, constrain_rotation_to_axis, rotation, solve_link_step,
+        translation,
+    },
+};
+
+#[cfg(test)]
+use crate::ik_primitive::{
+    LimitedAxesLinkStepInput, PlaneLinkStepInput, axis_vec, decompose_euler_xyz, euler_xyz_to_quat,
+    limit_axis_bounds, quat_to_rotation_mat3, signed_projected_angle, solve_limited_axes_link_step,
+    solve_plane_link_step,
+};
 
 #[derive(Debug)]
 struct IkScratch {
@@ -178,39 +192,36 @@ impl RuntimeInstance {
 
             if let Some(append_index) = self.model.append_transform_index(*bone) {
                 let append = self.model.append_transform(append_index);
+                let use_source_append = !append.local
+                    && self
+                        .model
+                        .append_transform_index(append.source_bone)
+                        .is_some();
+                let source_rotation = if use_source_append {
+                    self.pose.append_rotation(append.source_bone)
+                } else {
+                    self.pose.local_rotation(append.source_bone)
+                };
+                let source_position_offset = if use_source_append {
+                    self.pose.append_position_offset(append.source_bone)
+                } else {
+                    self.pose.local_position_offset(append.source_bone)
+                };
+                let append_output = solve_append_transform(AppendPrimitiveInput {
+                    source_position_offset,
+                    source_rotation,
+                    ratio: append.ratio,
+                    affect_rotation: append.affect_rotation,
+                    affect_translation: append.affect_translation,
+                });
+                self.pose.set_append_rotation(*bone, append_output.rotation);
+                self.pose
+                    .set_append_position_offset(*bone, append_output.position_offset);
                 if append.affect_rotation {
-                    let source_rotation = if !append.local
-                        && self
-                            .model
-                            .append_transform_index(append.source_bone)
-                            .is_some()
-                    {
-                        self.pose.append_rotation(append.source_bone)
-                    } else {
-                        self.pose.local_rotation(append.source_bone)
-                    };
-                    let append_rotation = Quat::IDENTITY
-                        .slerp(source_rotation, append.ratio)
-                        .normalize();
-                    self.pose.set_append_rotation(*bone, append_rotation);
-                    local_rotation = (local_rotation * append_rotation).normalize();
+                    local_rotation = (local_rotation * append_output.rotation).normalize();
                 }
-
                 if append.affect_translation {
-                    let source_position_offset = if !append.local
-                        && self
-                            .model
-                            .append_transform_index(append.source_bone)
-                            .is_some()
-                    {
-                        self.pose.append_position_offset(append.source_bone)
-                    } else {
-                        self.pose.local_position_offset(append.source_bone)
-                    };
-                    let append_position_offset = source_position_offset * append.ratio;
-                    self.pose
-                        .set_append_position_offset(*bone, append_position_offset);
-                    local_position += append_position_offset;
+                    local_position += append_output.position_offset;
                 }
             }
 
@@ -349,69 +360,17 @@ impl RuntimeInstance {
                         continue;
                     }
 
-                    let single_axis = get_single_axis_limit(link.angle_limit);
-
-                    if let (Some(angle_limit), Some(axis_index)) = (link.angle_limit, single_axis) {
-                        solve_plane_link_step(PlaneLinkStepInput {
-                            local_effector: &local_effector,
-                            local_target: &local_target,
-                            link_index,
-                            base_rotations: &base_rotations,
-                            ik_rotations: &mut ik_rotations,
-                            chain_states: &mut chain_states,
-                            axis_index,
-                            limits: angle_limit,
-                            iteration: _iteration,
-                            limit_angle,
-                        });
-                    } else if let Some(angle_limit) = link.angle_limit {
-                        solve_limited_axes_link_step(LimitedAxesLinkStepInput {
-                            local_effector: &local_effector,
-                            local_target: &local_target,
-                            link_index,
-                            base_rotations: &base_rotations,
-                            ik_rotations: &mut ik_rotations,
-                            chain_states: &mut chain_states,
-                            limits: angle_limit,
-                            limit_angle,
-                        });
-                    } else {
-                        let local_eff_n = local_effector.normalize();
-                        let local_tgt_n = local_target.normalize();
-                        let dot = local_eff_n.dot(local_tgt_n).clamp(-1.0, 1.0);
-                        let mut angle = dot.acos();
-
-                        let tiny_angle = 1e-3 * std::f32::consts::PI / 180.0;
-                        if angle < tiny_angle {
-                            continue;
-                        }
-
-                        if limit_angle > 0.0 {
-                            angle = angle.min(limit_angle);
-                        }
-
-                        let axis = local_eff_n.cross(local_tgt_n);
-                        let axis_vec = if axis.length() < 1e-5 {
-                            if dot > -1.0 + 1e-5 {
-                                continue;
-                            }
-                            let basis = if local_eff_n.x.abs() < 0.9 {
-                                Vec3A::new(1.0, 0.0, 0.0)
-                            } else {
-                                Vec3A::new(0.0, 1.0, 0.0)
-                            };
-                            local_eff_n.cross(basis).normalize()
-                        } else {
-                            axis.normalize()
-                        };
-
-                        let delta = Quat::from_axis_angle(axis_vec.into(), angle);
-                        let base = base_rotations[link_index];
-                        let ik = ik_rotations[link_index];
-                        let chain_rotation = (ik * base * delta).normalize();
-
-                        ik_rotations[link_index] = (chain_rotation * base.inverse()).normalize();
-                    }
+                    solve_link_step(LinkStepInput {
+                        local_effector: &local_effector,
+                        local_target: &local_target,
+                        link_index,
+                        base_rotations: &base_rotations,
+                        ik_rotations: &mut ik_rotations,
+                        chain_states: &mut chain_states,
+                        angle_limit: link.angle_limit,
+                        iteration: _iteration,
+                        limit_angle,
+                    });
 
                     self.apply_ik_link_rotations(&links, &base_rotations, &ik_rotations);
                     self.update_world_matrices_from_bone(link_bone);
@@ -642,337 +601,6 @@ fn expand_group_morph_weight(
             expand_group_morph_weight(child, contribution, spans, offsets, expanded_weights);
         }
     }
-}
-
-fn translation(matrix: Mat4) -> Vec3A {
-    Vec3A::from_vec4(matrix.w_axis)
-}
-
-fn rotation(matrix: Mat4) -> Quat {
-    matrix.to_scale_rotation_translation().1
-}
-
-fn constrain_rotation_to_axis(rotation: Quat, axis: Vec3A) -> Quat {
-    let axis = axis.normalize();
-    let vector = Vec3A::new(rotation.x, rotation.y, rotation.z);
-    let projected = axis * vector.dot(axis);
-    let twist = Quat::from_xyzw(projected.x, projected.y, projected.z, rotation.w);
-    if twist.length_squared() <= f32::EPSILON {
-        Quat::IDENTITY
-    } else {
-        twist.normalize()
-    }
-}
-
-#[derive(Debug)]
-struct ChainLinkState {
-    previous_euler: [f32; 3],
-    plane_mode_angle: f32,
-}
-
-fn get_single_axis_limit(limit: Option<crate::IkAngleLimit>) -> Option<usize> {
-    let limit = limit?;
-    let has = [
-        limit.min.x != 0.0 || limit.max.x != 0.0,
-        limit.min.y != 0.0 || limit.max.y != 0.0,
-        limit.min.z != 0.0 || limit.max.z != 0.0,
-    ];
-    if has[0]
-        && limit.min.y == 0.0
-        && limit.max.y == 0.0
-        && limit.min.z == 0.0
-        && limit.max.z == 0.0
-    {
-        return Some(0);
-    }
-    if has[1]
-        && limit.min.x == 0.0
-        && limit.max.x == 0.0
-        && limit.min.z == 0.0
-        && limit.max.z == 0.0
-    {
-        return Some(1);
-    }
-    if has[2]
-        && limit.min.x == 0.0
-        && limit.max.x == 0.0
-        && limit.min.y == 0.0
-        && limit.max.y == 0.0
-    {
-        return Some(2);
-    }
-    None
-}
-
-fn quat_to_rotation_mat3(rotation: Quat) -> [f32; 9] {
-    let [x, y, z, w] = rotation.normalize().to_array();
-    let x2 = x + x;
-    let y2 = y + y;
-    let z2 = z + z;
-    let xx = x * x2;
-    let xy = x * y2;
-    let xz = x * z2;
-    let yy = y * y2;
-    let yz = y * z2;
-    let zz = z * z2;
-    let wx = w * x2;
-    let wy = w * y2;
-    let wz = w * z2;
-    [
-        1.0 - (yy + zz),
-        xy + wz,
-        xz - wy,
-        xy - wz,
-        1.0 - (xx + zz),
-        yz + wx,
-        xz + wy,
-        yz - wx,
-        1.0 - (xx + yy),
-    ]
-}
-
-fn decompose_euler_xyz(mat: &[f32; 9], before: &[f32; 3]) -> [f32; 3] {
-    let sy = -mat[2];
-    let mut result: [f32; 3];
-    if 1.0 - sy.abs() < 1e-6 {
-        let y = sy.asin();
-        let sx = before[0].sin();
-        let sz = before[2].sin();
-        if sx.abs() < sz.abs() {
-            let cx = before[0].cos();
-            result = if cx > 0.0 {
-                [0.0, y, (-mat[3]).asin()]
-            } else {
-                [std::f32::consts::PI, y, mat[3].asin()]
-            };
-        } else {
-            let cz = before[2].cos();
-            result = if cz > 0.0 {
-                [(-mat[7]).asin(), y, 0.0]
-            } else {
-                [mat[7].asin(), y, std::f32::consts::PI]
-            };
-        }
-    } else {
-        result = [mat[5].atan2(mat[8]), (-mat[2]).asin(), mat[1].atan2(mat[0])];
-    }
-
-    let pi = std::f32::consts::PI;
-    let candidates: [[f32; 3]; 8] = [
-        [result[0] + pi, pi - result[1], result[2] + pi],
-        [result[0] + pi, pi - result[1], result[2] - pi],
-        [result[0] + pi, -pi - result[1], result[2] + pi],
-        [result[0] + pi, -pi - result[1], result[2] - pi],
-        [result[0] - pi, pi - result[1], result[2] + pi],
-        [result[0] - pi, pi - result[1], result[2] - pi],
-        [result[0] - pi, -pi - result[1], result[2] + pi],
-        [result[0] - pi, -pi - result[1], result[2] - pi],
-    ];
-    let mut min_error = diff_angle(result[0], before[0]).abs()
-        + diff_angle(result[1], before[1]).abs()
-        + diff_angle(result[2], before[2]).abs();
-    for candidate in &candidates {
-        let error = diff_angle(candidate[0], before[0]).abs()
-            + diff_angle(candidate[1], before[1]).abs()
-            + diff_angle(candidate[2], before[2]).abs();
-        if error < min_error {
-            min_error = error;
-            result = *candidate;
-        }
-    }
-    result
-}
-
-fn diff_angle(a: f32, b: f32) -> f32 {
-    let diff = normalize_angle(a) - normalize_angle(b);
-    if diff > std::f32::consts::PI {
-        diff - std::f32::consts::TAU
-    } else if diff < -std::f32::consts::PI {
-        diff + std::f32::consts::TAU
-    } else {
-        diff
-    }
-}
-
-fn normalize_angle(angle: f32) -> f32 {
-    let mut result = angle;
-    while result >= std::f32::consts::TAU {
-        result -= std::f32::consts::TAU;
-    }
-    while result < 0.0 {
-        result += std::f32::consts::TAU;
-    }
-    result
-}
-
-fn euler_xyz_to_quat(euler: &[f32; 3]) -> Quat {
-    let [x, y, z] = *euler;
-    let c1 = (x / 2.0).cos();
-    let c2 = (y / 2.0).cos();
-    let c3 = (z / 2.0).cos();
-    let s1 = (x / 2.0).sin();
-    let s2 = (y / 2.0).sin();
-    let s3 = (z / 2.0).sin();
-    Quat::from_xyzw(
-        s1 * c2 * c3 + c1 * s2 * s3,
-        c1 * s2 * c3 - s1 * c2 * s3,
-        c1 * c2 * s3 + s1 * s2 * c3,
-        c1 * c2 * c3 - s1 * s2 * s3,
-    )
-}
-
-struct LimitedAxesLinkStepInput<'a> {
-    local_effector: &'a Vec3A,
-    local_target: &'a Vec3A,
-    link_index: usize,
-    base_rotations: &'a [Quat],
-    ik_rotations: &'a mut [Quat],
-    chain_states: &'a mut [ChainLinkState],
-    limits: crate::IkAngleLimit,
-    limit_angle: f32,
-}
-
-fn solve_limited_axes_link_step(input: LimitedAxesLinkStepInput<'_>) {
-    let state = &mut input.chain_states[input.link_index];
-    let base = input.base_rotations[input.link_index];
-    let current = (input.ik_rotations[input.link_index] * base).normalize();
-    let current_mat = quat_to_rotation_mat3(current);
-    let mut total_euler = decompose_euler_xyz(&current_mat, &state.previous_euler);
-    let mut working_effector = *input.local_effector;
-    let target = input.local_target.normalize();
-
-    for axis_index in [2usize, 1, 0] {
-        let (lower, upper) = limit_axis_bounds(input.limits, axis_index);
-        if lower == 0.0 && upper == 0.0 {
-            let next = total_euler[axis_index].clamp(lower, upper);
-            let applied = next - total_euler[axis_index];
-            total_euler[axis_index] = next;
-            if applied.abs() > 0.0 {
-                working_effector = Quat::from_axis_angle(axis_vec(axis_index).into(), applied)
-                    .mul_vec3a(working_effector);
-            }
-            continue;
-        }
-
-        let axis = axis_vec(axis_index);
-        let signed_angle = signed_projected_angle(working_effector, target, axis);
-        if signed_angle.abs() <= 1.0e-6 {
-            continue;
-        }
-        let step = if input.limit_angle > 0.0 {
-            signed_angle.clamp(-input.limit_angle, input.limit_angle)
-        } else {
-            signed_angle
-        };
-        let next = (total_euler[axis_index] + step).clamp(lower, upper);
-        let applied = next - total_euler[axis_index];
-        total_euler[axis_index] = next;
-        if applied.abs() > 0.0 {
-            working_effector =
-                Quat::from_axis_angle(axis.into(), applied).mul_vec3a(working_effector);
-        }
-    }
-
-    state.previous_euler = total_euler;
-    let chain_rotation = euler_xyz_to_quat(&total_euler).normalize();
-    input.ik_rotations[input.link_index] = (chain_rotation * base.inverse()).normalize();
-}
-
-fn limit_axis_bounds(limits: crate::IkAngleLimit, axis_index: usize) -> (f32, f32) {
-    match axis_index {
-        0 => (limits.min.x, limits.max.x),
-        1 => (limits.min.y, limits.max.y),
-        _ => (limits.min.z, limits.max.z),
-    }
-}
-
-fn axis_vec(axis_index: usize) -> Vec3A {
-    match axis_index {
-        0 => Vec3A::new(1.0, 0.0, 0.0),
-        1 => Vec3A::new(0.0, 1.0, 0.0),
-        _ => Vec3A::new(0.0, 0.0, 1.0),
-    }
-}
-
-fn signed_projected_angle(from: Vec3A, to: Vec3A, axis: Vec3A) -> f32 {
-    let projected_from = from - axis * from.dot(axis);
-    let projected_to = to - axis * to.dot(axis);
-    if projected_from.length_squared() <= f32::EPSILON
-        || projected_to.length_squared() <= f32::EPSILON
-    {
-        return 0.0;
-    }
-    let from_n = projected_from.normalize();
-    let to_n = projected_to.normalize();
-    let dot = from_n.dot(to_n).clamp(-1.0, 1.0);
-    let angle = dot.acos();
-    let sign = axis.dot(from_n.cross(to_n)).signum();
-    angle * if sign == 0.0 { 1.0 } else { sign }
-}
-
-struct PlaneLinkStepInput<'a> {
-    local_effector: &'a Vec3A,
-    local_target: &'a Vec3A,
-    link_index: usize,
-    base_rotations: &'a [Quat],
-    ik_rotations: &'a mut [Quat],
-    chain_states: &'a mut [ChainLinkState],
-    axis_index: usize,
-    limits: crate::IkAngleLimit,
-    iteration: usize,
-    limit_angle: f32,
-}
-
-fn solve_plane_link_step(input: PlaneLinkStepInput<'_>) {
-    let rotate_axis = match input.axis_index {
-        0 => Vec3A::new(1.0, 0.0, 0.0),
-        1 => Vec3A::new(0.0, 1.0, 0.0),
-        _ => Vec3A::new(0.0, 0.0, 1.0),
-    };
-    let local_eff_n = input.local_effector.normalize();
-    let local_tgt_n = input.local_target.normalize();
-
-    let dot = local_eff_n.dot(local_tgt_n).clamp(-1.0, 1.0);
-    let raw_angle = dot.acos();
-    let capped_angle = if input.limit_angle > 0.0 {
-        raw_angle.min(input.limit_angle)
-    } else {
-        raw_angle
-    };
-
-    let target_vec1 =
-        Quat::from_axis_angle(rotate_axis.into(), capped_angle).mul_vec3a(local_eff_n);
-    let target_vec2 =
-        Quat::from_axis_angle(rotate_axis.into(), -capped_angle).mul_vec3a(local_eff_n);
-    let signed_angle = if target_vec1.dot(local_tgt_n) > target_vec2.dot(local_tgt_n) {
-        capped_angle
-    } else {
-        -capped_angle
-    };
-
-    let state = &mut input.chain_states[input.link_index];
-    let mut next_angle = state.plane_mode_angle + signed_angle;
-    let (lower, upper) = match input.axis_index {
-        0 => (input.limits.min.x, input.limits.max.x),
-        1 => (input.limits.min.y, input.limits.max.y),
-        _ => (input.limits.min.z, input.limits.max.z),
-    };
-    let base = input.base_rotations[input.link_index];
-
-    if input.iteration == 0 && (next_angle < lower || next_angle > upper) {
-        if -next_angle > lower && -next_angle < upper {
-            next_angle = -next_angle;
-        } else {
-            let half = (lower + upper) * 0.5;
-            if (half - next_angle).abs() > (half + next_angle).abs() {
-                next_angle = -next_angle;
-            }
-        }
-    }
-
-    state.plane_mode_angle = next_angle.clamp(lower, upper);
-    let chain_rotation = Quat::from_axis_angle(rotate_axis.into(), state.plane_mode_angle);
-    input.ik_rotations[input.link_index] = (chain_rotation * base.inverse()).normalize();
 }
 
 #[cfg(test)]

--- a/crates/mmd-anim-schema/Cargo.toml
+++ b/crates/mmd-anim-schema/Cargo.toml
@@ -9,7 +9,6 @@ readme.workspace = true
 keywords.workspace = true
 categories.workspace = true
 description = "Shared IR and trace schema for mmd-anim"
-publish = false
 
 [dependencies]
 glam.workspace = true

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -55,6 +55,9 @@ cargo doc --workspace --no-deps
 
 - [three-mmd-loader](https://github.com/yohawing/three-mmd-loader): `mmd-anim` を
   アニメーション・形式処理 backend として利用する Three.js 向け MMD loader。
+- [maya_mmd_tools](https://github.com/yohawing/maya_mmd_tools):
+  Maya 向け MMD アニメーション編集ツールとして利用する Maya プラグイン。 VMDインポート時のフルベイク用と、リグ実装にあたっての正本として利用。
+- [unity-mmd-loader](https://github.com/yohawing/unity-mmd-loader): Unity6、URPに最適化Unity向けMMD Loader。インポーターと、コアアニメーションランタイムとして利用。
 
 Rust API、C ABI、WASM wrapper を通じて、他のホストや製品にも同じ機能を組み込めます。
 

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -81,8 +81,8 @@ Rust API、C ABI、WASM wrapper を通じて、他のホストや製品にも同
 | `mmd-anim-format` | PMX/VMD のランタイム取り込み、形式判定、読み込み（構造化）、PMX/PMD/VMD/VPD/X/VAC の書き出しを提供する。 |
 | `mmd-anim-ffi` | ネイティブホスト向けの C ABI。ランタイム操作と PMX パーツ書き出しを公開する。0.1.x 系ではリポジトリ内専用。 |
 | `mmd-anim-wasm` | ブラウザ向けの `wasm-bindgen` ラッパー。ランタイム操作、読み込み/書き出し、PMX パーツ書き出しを公開する。0.1.x 系ではワークスペース内専用。 |
-| `mmd-anim-cli` | メンテナ向けの診断・検証コマンド。0.1.x 系ではリポジトリ内専用。 |
-| `mmd-anim-schema` | メンテナ向けの品質確認用スキーマ補助クレート。0.1.x 系ではリポジトリ内専用。 |
+| `mmd-anim-cli` | MMD 形式ファイルの検査・変換・診断コマンド。`cargo install mmd-anim-cli` でインストール可能。 |
+| `mmd-anim-schema` | CLI や診断ツールが使用する共有 IR・トレーススキーマ。 |
 
 通常のライブラリ利用では `mmd-anim` を依存に追加してください。低レイヤだけを直接使いたい場合は
 `mmd-anim-format` や `mmd-anim-runtime` に直接依存できます。
@@ -191,16 +191,25 @@ const generatedPmxBytes = exportPmxFromParts(
 );
 ```
 
-## CLI で読み込み / 書き出しを確認する
+## CLI
 
-形式の読み込みや書き出しを手元で確認したい場合は、リポジトリ内専用の `mmd-anim-cli` が使えます。
-利用できるサブコマンドの一覧は次のコマンドで確認できます。
+`mmd-anim-cli` は MMD 形式ファイル（PMX, VMD, VPD, PMM, X/VAC）の検査・変換・診断を行うコマンドラインツールです。
+
+```powershell
+cargo install mmd-anim-cli
+```
+
+インストール後、`mmd-anim` コマンドが使えます。
+
+```powershell
+mmd-anim --help
+```
+
+開発中はワークスペースから直接実行することもできます。
 
 ```powershell
 cargo run -p mmd-anim-cli -- --help
 ```
-
-このコマンドラインツールはメンテナ向けの診断ツールで、公開リリースの前提条件にはしていません。
 
 ## 現在の制限と注意点
 


### PR DESCRIPTION
## Summary
- **CLI リファクタリング**: フラットなサブコマンド構造をモジュール分割し、clap derive ベースに刷新。操作グループ（parse/export/import/compare/bench/rig 等）に再編成
- **Rig プリミティブ**: IK・付与変形の評価プリミティブを runtime から分離・公開し、C ABI と PMX rig spec 抽出を追加
- **crates.io 公開設定**: `mmd-anim-cli` と `mmd-anim-schema` を `cargo install mmd-anim-cli` でインストール可能に
- **フォーマット改善**: magic byte による形式自動判定、export --from-json の UX 改善

## Test plan
- [ ] `cargo test --workspace` 全パス
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` 警告なし
- [ ] `cargo install mmd-anim-cli` で CLI がインストールできること（schema/cli 公開後）
- [ ] `mmd-anim --help` でサブコマンド一覧が表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)