### PR TITLE
chore(release): v0.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## 0.1.6 - 2026-06-25
+
+Patch release for CLI overhaul, rig primitives, crates.io CLI publishing, and
+PMX roundtrip fixes.
+
+### Added
+
+- Restructured CLI from flat subcommands to operation-based groups (parse,
+  export, import, compare, bench, rig, golden, oracle, patch) with clap derive.
+- Added magic byte format detection so the CLI can identify files without
+  relying on file extensions.
+- Added IK and append transform evaluation primitives extracted from the
+  runtime, enabling host-side rig solvers to call individual solve steps.
+- Added rig primitive C ABI (`mmd-anim-ffi`) and PMX rig spec extraction for
+  native host integration.
+- Added `rig inspect` CLI command for diagnosing rig specs from PMX files.
+- Enabled crates.io publishing for `mmd-anim-cli` and `mmd-anim-schema`.
+  `mmd-anim-cli` is now installable via `cargo install mmd-anim-cli`.
+
+### Fixed
+
+- Fixed PMX roundtrip DTO precision loss where vertex deform types
+  (BDEF1/BDEF2/SDEF/QDEF) were not preserved, causing all vertices to be
+  re-exported as BDEF4.
+- Fixed JSON roundtrip serialization of non-finite f32 values (NaN, Infinity,
+  -Infinity) in PMX DTOs. Added `json_f32` serde helper that encodes these as
+  JSON strings and restores them on deserialization.
+- Improved CLI output readability and help text.
+
 ## 0.1.5 - 2026-06-21
 
 Patch release for PMX material split host import and parser API parity.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -187,7 +187,7 @@ checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "mmd-anim"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "mmd-anim-format",
  "mmd-anim-runtime",
@@ -195,7 +195,7 @@ dependencies = [
 
 [[package]]
 name = "mmd-anim-cli"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "clap",
  "glam",
@@ -207,7 +207,7 @@ dependencies = [
 
 [[package]]
 name = "mmd-anim-ffi"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "glam",
  "mmd-anim-format",
@@ -217,7 +217,7 @@ dependencies = [
 
 [[package]]
 name = "mmd-anim-format"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "encoding_rs",
  "glam",
@@ -229,7 +229,7 @@ dependencies = [
 
 [[package]]
 name = "mmd-anim-runtime"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "glam",
  "thiserror",
@@ -237,7 +237,7 @@ dependencies = [
 
 [[package]]
 name = "mmd-anim-schema"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "glam",
  "serde",
@@ -247,7 +247,7 @@ dependencies = [
 
 [[package]]
 name = "mmd-anim-wasm"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "glam",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.1.5"
+version = "0.1.6"
 edition = "2024"
 rust-version = "1.87"
 license = "MIT"
@@ -28,7 +28,7 @@ serde_json = "1.0.145"
 wasm-bindgen = "0.2.105"
 js-sys = "0.3"
 encoding_rs = "0.8"
-mmd-anim-runtime = { path = "crates/mmd-anim-runtime", version = "0.1.5" }
-mmd-anim-schema = { path = "crates/mmd-anim-schema", version = "0.1.5" }
-mmd-anim-format = { path = "crates/mmd-anim-format", version = "0.1.5" }
+mmd-anim-runtime = { path = "crates/mmd-anim-runtime", version = "0.1.6" }
+mmd-anim-schema = { path = "crates/mmd-anim-schema", version = "0.1.6" }
+mmd-anim-format = { path = "crates/mmd-anim-format", version = "0.1.6" }
  

--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ cargo doc --workspace --no-deps
 
 - [three-mmd-loader](https://github.com/yohawing/three-mmd-loader): A Three.js
   MMD loader that uses `mmd-anim` as its animation and format backend.
+- [maya_mmd_tools](https://github.com/yohawing/maya_mmd_tools): Maya plugin for
+  MMD model and motion handling, using `mmd-anim` as its native runtime.
 
 More integrations can share the same runtime core through the Rust API, C ABI,
 or WASM wrapper.

--- a/crates/mmd-anim-cli/src/commands/bench.rs
+++ b/crates/mmd-anim-cli/src/commands/bench.rs
@@ -119,15 +119,30 @@ pub(crate) fn bench_pair(cfg: BenchPairConfig) -> Result<ExitCode, Box<dyn std::
     println!("bench-pair:");
     println!(
         "  model:   bones={} ik={} ikTolerance={:.8} ikMaxIterationsCap={} append={} fixedAxis={}",
-        bone_count, ik_display, cfg.ik_options.tolerance, ik_cap_display, append_count, fixed_axis_count,
+        bone_count,
+        ik_display,
+        cfg.ik_options.tolerance,
+        ik_cap_display,
+        append_count,
+        fixed_axis_count,
     );
     println!(
         "  motion:  vmdBoneKeys={} vmdMorphKeys={} clipBoneTracks={} clipMorphTracks={} propertyTrack={} clipFrameRange={}",
-        vmd.bone_keyframes.len(), vmd.morph_keyframes.len(), clip.bone_track_count(), clip.morph_track_count(), clip.has_property_track(), frame_range,
+        vmd.bone_keyframes.len(),
+        vmd.morph_keyframes.len(),
+        clip.bone_track_count(),
+        clip.morph_track_count(),
+        clip.has_property_track(),
+        frame_range,
     );
     println!(
         "  timing:  readMs={:.3} pmxImportMs={:.3} vmdImportMs={:.3} clipBuildMs={:.3} evalMs={:.3} totalMs={:.3}",
-        read_elapsed.as_secs_f64() * 1000.0, pmx_elapsed.as_secs_f64() * 1000.0, vmd_elapsed.as_secs_f64() * 1000.0, clip_elapsed.as_secs_f64() * 1000.0, eval_ms, total_elapsed.as_secs_f64() * 1000.0,
+        read_elapsed.as_secs_f64() * 1000.0,
+        pmx_elapsed.as_secs_f64() * 1000.0,
+        vmd_elapsed.as_secs_f64() * 1000.0,
+        clip_elapsed.as_secs_f64() * 1000.0,
+        eval_ms,
+        total_elapsed.as_secs_f64() * 1000.0,
     );
     println!(
         "  result:  frames={} startFrame={:.3} step={:.3} msPerFrame={:.6} fps={:.1} checksum={:08x} morphChecksum={:08x}",

--- a/crates/mmd-anim-ffi/src/lib.rs
+++ b/crates/mmd-anim-ffi/src/lib.rs
@@ -5,12 +5,12 @@ use std::{ptr, slice, str, sync::Arc};
 
 use mmd_anim_runtime::ModelArena;
 use mmd_anim_runtime::{
-    solve_append_transform, AnimationClip, AppendPrimitiveInput, AppendTransformInit,
-    BoneAnimationBinding, BoneIndex, BoneInit, BoneMorphOffset, GroupMorphOffset, IkAngleLimit,
-    IkChainDefinition, IkChainLinkDefinition, IkChainPoseInput, IkChainSolver, IkLinkInit,
-    IkSolveOptions, IkSolverInit, MorphAnimationBinding, MorphIndex, MorphInit, MorphKeyframe,
-    MorphOffsetSpan, MorphTrack, MovableBoneKeyframe, MovableBoneTrack, PropertyAnimationBinding,
-    PropertyKeyframe, RuntimeInstance,
+    AnimationClip, AppendPrimitiveInput, AppendTransformInit, BoneAnimationBinding, BoneIndex,
+    BoneInit, BoneMorphOffset, GroupMorphOffset, IkAngleLimit, IkChainDefinition,
+    IkChainLinkDefinition, IkChainPoseInput, IkChainSolver, IkLinkInit, IkSolveOptions,
+    IkSolverInit, MorphAnimationBinding, MorphIndex, MorphInit, MorphKeyframe, MorphOffsetSpan,
+    MorphTrack, MovableBoneKeyframe, MovableBoneTrack, PropertyAnimationBinding, PropertyKeyframe,
+    RuntimeInstance, solve_append_transform,
 };
 
 pub const ABI_VERSION: u32 = 1;
@@ -5296,10 +5296,7 @@ mod tests {
             .unwrap_or_else(|err| panic!("{context}: manifest_json parse failed: {err}"))
     }
 
-    fn rig_spec_manifest_json(
-        spec: *mut MmdRuntimePmxRigSpec,
-        context: &str,
-    ) -> serde_json::Value {
+    fn rig_spec_manifest_json(spec: *mut MmdRuntimePmxRigSpec, context: &str) -> serde_json::Value {
         let manifest_bytes =
             ffi_buffer_to_vec(unsafe { mmd_runtime_pmx_rig_spec_manifest_json(spec) });
         assert!(
@@ -5362,7 +5359,10 @@ mod tests {
             "ikChainCount mismatch"
         );
         assert_eq!(grants.len(), grant_count as usize, "grantCount mismatch");
-        assert!(bone_count > 0, "fixture rig spec: boneCount must be positive");
+        assert!(
+            bone_count > 0,
+            "fixture rig spec: boneCount must be positive"
+        );
         assert!(
             ik_chain_count > 0,
             "fixture rig spec: ikChainCount must be positive"
@@ -5370,7 +5370,10 @@ mod tests {
 
         for (bone_index, bone) in bones.iter().enumerate() {
             let context = format!("fixture rig spec: bone {bone_index}");
-            assert!(bone.get("name").is_some_and(|v| v.is_string()), "{context}: name");
+            assert!(
+                bone.get("name").is_some_and(|v| v.is_string()),
+                "{context}: name"
+            );
             assert!(
                 bone.get("nameBytes").is_some_and(|v| v.is_string()),
                 "{context}: nameBytes"
@@ -5388,8 +5391,14 @@ mod tests {
                 bone.get("deformLayer").is_some_and(|v| v.is_number()),
                 "{context}: deformLayer"
             );
-            assert!(bone.get("fixedAxis").is_some(), "{context}: fixedAxis missing");
-            assert!(bone.get("localAxis").is_some(), "{context}: localAxis missing");
+            assert!(
+                bone.get("fixedAxis").is_some(),
+                "{context}: fixedAxis missing"
+            );
+            assert!(
+                bone.get("localAxis").is_some(),
+                "{context}: localAxis missing"
+            );
             assert!(
                 bone.get("transformAfterPhysics")
                     .is_some_and(|v| v.is_boolean()),

--- a/crates/mmd-anim-format/src/lib.rs
+++ b/crates/mmd-anim-format/src/lib.rs
@@ -32,11 +32,11 @@ pub use pmx::{
     PmxParsedModel, PmxPartsBoneDescriptor, PmxPartsDescriptor, PmxPartsDisplayFrameDescriptor,
     PmxPartsDisplayFrameItem, PmxPartsGroupMorphOffset, PmxPartsIndexSizes, PmxPartsInput,
     PmxPartsJointDescriptor, PmxPartsMaterialDescriptor, PmxPartsMaterialFlags,
-    PmxPartsMorphDescriptor, PmxPartsRigidBodyDescriptor, PmxPartsVertexMorphOffset,
-    PmxRigSpec, PmxRigSpecBone, PmxRigSpecGrant, PmxRigSpecIkChain, PmxRigSpecIkLink,
-    PmxRigSpecLocalAxis, PmxRuntimeImport, build_pmx_model_from_parts, export_pmx_model,
-    import_pmx_model, import_pmx_runtime, parse_pmx_material_split, parse_pmx_model,
-    parse_pmx_rig_spec, split_pmx_model_by_material, validate_pmx_export_model,
+    PmxPartsMorphDescriptor, PmxPartsRigidBodyDescriptor, PmxPartsVertexMorphOffset, PmxRigSpec,
+    PmxRigSpecBone, PmxRigSpecGrant, PmxRigSpecIkChain, PmxRigSpecIkLink, PmxRigSpecLocalAxis,
+    PmxRuntimeImport, build_pmx_model_from_parts, export_pmx_model, import_pmx_model,
+    import_pmx_runtime, parse_pmx_material_split, parse_pmx_model, parse_pmx_rig_spec,
+    split_pmx_model_by_material, validate_pmx_export_model,
 };
 pub use vmd::{
     VmdCameraState, VmdClipBuildOptions, VmdIkEntry, VmdImportResult, VmdParsedAnimation,

--- a/crates/mmd-anim-format/src/pmx/json_f32.rs
+++ b/crates/mmd-anim-format/src/pmx/json_f32.rs
@@ -1,9 +1,9 @@
 use std::fmt;
 
 use serde::{
+    Deserialize, Deserializer, Serialize, Serializer,
     de::{self, SeqAccess, Visitor},
     ser::SerializeSeq,
-    Deserialize, Deserializer, Serialize, Serializer,
 };
 
 const NAN_TOKEN: &str = "NaN";


### PR DESCRIPTION
## Summary
v0.1.6 リリース準備。CHANGELOG・バージョンバンプ・README 更新・fmt 適用。

### v0.1.6 の主な変更
- **CLI 刷新**: フラットサブコマンド → 操作グループ (parse/export/import/compare/bench/rig 等) + clap derive
- **Rig プリミティブ**: IK/付与変形の評価プリミティブ分離、C ABI、PMX rig spec 抽出
- **crates.io 公開**: `mmd-anim-cli` と `mmd-anim-schema` が `cargo install` 可能に
- **PMX roundtrip 修正**: deform type 消失 (SDEF/QDEF → BDEF4) を修正
- **JSON roundtrip 修正**: NaN/Infinity の直列化エラーを修正
- **マジックバイト形式検出**: 拡張子に依存しないファイル形式判定

## Test plan
- [x] `cargo test --workspace` 全 492 テスト pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo doc --workspace --no-deps` 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)