### PR TITLE
[codex] Fix PMX ordered append IK evaluation

### DIFF
--- a/crates/mmd-anim-cli/tests/kotora_forearm_golden.rs
+++ b/crates/mmd-anim-cli/tests/kotora_forearm_golden.rs
@@ -1,0 +1,121 @@
+use std::{
+    path::{Path, PathBuf},
+    process::{Command, Output},
+};
+
+const KOTORA_MANIFEST_ENV: &str = "MMD_ANIM_KOTORA_FOREARM_GOLDEN_MANIFEST";
+const DEFAULT_KOTORA_MANIFEST: &str = "F:\\Develop\\MMDDev\\GoldenOracle\\runs\\motion-numeric\\kotora-gym-weekender-forearm\\manifest.kotora-only.json";
+
+#[test]
+#[ignore = "requires local Kotora GoldenOracle data generated from MMD/MMDDumper"]
+fn kotora_forearm_golden_compare_passes_with_ordered_pmx_runtime() {
+    let manifest = local_manifest();
+    require_local_manifest(&manifest);
+
+    let output = mmd_anim()
+        .arg("verify")
+        .arg(&manifest)
+        .args(["--mode", "numeric"])
+        .output()
+        .expect("run mmd-anim verify");
+
+    assert!(
+        output.status.success(),
+        "Kotora focused compare should pass once the forearm runtime is fixed\n{}",
+        combined_output(&output)
+    );
+    let combined = combined_output(&output);
+    assert_contains(
+        &combined,
+        "Numeric compare: ok",
+        "Kotora compare did not report success",
+    );
+    assert_contains(
+        &combined,
+        "motionMaxAbsError=0.001101",
+        "unexpected Kotora max error",
+    );
+    assert_contains(
+        &combined,
+        "motionWorst=kotora-gym-weekender-forearm:4800:左肘捩抽出",
+        "unexpected Kotora worst bone/frame",
+    );
+}
+
+#[test]
+#[ignore = "requires local Kotora GoldenOracle data generated from MMD/MMDDumper"]
+fn kotora_forearm_golden_diagnosis_stays_within_epsilon_after_fix() {
+    let manifest = local_manifest();
+    require_local_manifest(&manifest);
+
+    let output = mmd_anim()
+        .arg("verify")
+        .arg(&manifest)
+        .args([
+            "--mode",
+            "numeric",
+            "--diagnose",
+            "kotora-gym-weekender-forearm",
+            "4800",
+            "左肘捩抽出",
+            "--eval-frame",
+            "4801",
+        ])
+        .output()
+        .expect("run mmd-anim verify --diagnose");
+
+    assert!(
+        output.status.success(),
+        "Kotora diagnosis command failed\n{}",
+        combined_output(&output)
+    );
+    let combined = combined_output(&output);
+    assert_contains(
+        &combined,
+        "bone=左肘捩抽出 index=69 oracleIndex=69",
+        "diagnosis no longer points at the expected extraction bone",
+    );
+    assert_contains(
+        &combined,
+        "postMaxDelta=0.00110",
+        "diagnosis max delta changed",
+    );
+    assert_contains(
+        &combined,
+        "vmdKeys=0 exactVmdKeys=0",
+        "diagnosis should remain focused on an unkeyed extraction bone",
+    );
+}
+
+fn local_manifest() -> PathBuf {
+    std::env::var_os(KOTORA_MANIFEST_ENV)
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from(DEFAULT_KOTORA_MANIFEST))
+}
+
+fn require_local_manifest(path: &Path) {
+    assert!(
+        path.exists(),
+        "missing local Kotora GoldenOracle manifest: {}; set {KOTORA_MANIFEST_ENV} to override",
+        path.display()
+    );
+}
+
+fn mmd_anim() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_mmd-anim"))
+}
+
+fn combined_output(output: &Output) -> String {
+    format!(
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+fn assert_contains(haystack: &str, needle: &str, context: &str) {
+    assert!(
+        haystack.contains(needle),
+        "{context}: missing `{needle}`\n{haystack}"
+    );
+}

--- a/crates/mmd-anim-format/src/pmx/mod.rs
+++ b/crates/mmd-anim-format/src/pmx/mod.rs
@@ -21,6 +21,7 @@ const BONE_FLAG_APPEND_ROTATE: u16 = 0x0100;
 const BONE_FLAG_APPEND_TRANSLATE: u16 = 0x0200;
 const BONE_FLAG_FIXED_AXIS: u16 = 0x0400;
 const BONE_FLAG_LOCAL_AXIS: u16 = 0x0800;
+const BONE_FLAG_TRANSFORM_AFTER_PHYSICS: u16 = 0x1000;
 const BONE_FLAG_EXTERNAL_PARENT: u16 = 0x2000;
 const PMX_SKINNING_MODE_BDEF1: &str = "bdef1";
 const PMX_SKINNING_MODE_BDEF2: &str = "bdef2";
@@ -781,7 +782,11 @@ pub fn read_bones(
             rest_position: position,
             inverse_bind_matrix: Mat4::from_translation((-position).into()),
             transform_order,
+            transform_after_physics: flags & BONE_FLAG_TRANSFORM_AFTER_PHYSICS != 0,
             fixed_axis,
+            // PMX fixed-axis is preserved as rig metadata. MMD-compatible pose evaluation
+            // does not project ordinary VMD/local rotations onto this axis.
+            enforce_fixed_axis: false,
         });
     }
 
@@ -4153,7 +4158,11 @@ fn bone_flag_bits(flags: &PmxParsedBoneFlags) -> u16 {
         } else {
             0
         }
-        | (u16::from(flags.transform_after_physics) << 12)
+        | if flags.transform_after_physics {
+            BONE_FLAG_TRANSFORM_AFTER_PHYSICS
+        } else {
+            0
+        }
         | if flags.external_parent_transform {
             BONE_FLAG_EXTERNAL_PARENT
         } else {
@@ -5484,6 +5493,7 @@ mod tests {
         assert_eq!(BONE_FLAG_APPEND_TRANSLATE, 0x0200);
         assert_eq!(BONE_FLAG_FIXED_AXIS, 0x0400);
         assert_eq!(BONE_FLAG_LOCAL_AXIS, 0x0800);
+        assert_eq!(BONE_FLAG_TRANSFORM_AFTER_PHYSICS, 0x1000);
         assert_eq!(BONE_FLAG_EXTERNAL_PARENT, 0x2000);
     }
 
@@ -6590,6 +6600,7 @@ mod tests {
 
         let result = import_pmx_model(&buf).unwrap();
         assert_eq!(result.bones[0].fixed_axis, Some(Vec3A::Y));
+        assert!(!result.bones[0].enforce_fixed_axis);
     }
 
     #[test]

--- a/crates/mmd-anim-runtime/src/model.rs
+++ b/crates/mmd-anim-runtime/src/model.rs
@@ -63,7 +63,9 @@ pub struct BoneInit {
     pub rest_position: Vec3A,
     pub inverse_bind_matrix: Mat4,
     pub transform_order: i32,
+    pub transform_after_physics: bool,
     pub fixed_axis: Option<Vec3A>,
+    pub enforce_fixed_axis: bool,
 }
 
 impl BoneInit {
@@ -73,12 +75,15 @@ impl BoneInit {
             rest_position,
             inverse_bind_matrix: Mat4::IDENTITY,
             transform_order: 0,
+            transform_after_physics: false,
             fixed_axis: None,
+            enforce_fixed_axis: false,
         }
     }
 
     pub fn with_fixed_axis(mut self, axis: Vec3A) -> Self {
         self.fixed_axis = Some(axis);
+        self.enforce_fixed_axis = true;
         self
     }
 }
@@ -215,7 +220,10 @@ pub struct ModelArena {
     inverse_bind_matrices: Box<[Mat4]>,
     transform_orders: Box<[i32]>,
     fixed_axis_flags: Box<[u8]>,
+    fixed_axis_constraint_flags: Box<[u8]>,
     fixed_axes: Box<[Vec3A]>,
+    transform_after_physics_flags: Box<[u8]>,
+    ik_link_flags: Box<[u8]>,
     eval_order: Box<[BoneIndex]>,
     eval_order_positions: Box<[usize]>,
     ik_solvers: Box<[IkSolver]>,
@@ -265,7 +273,9 @@ impl ModelArena {
         let mut rest_positions = Vec::with_capacity(bone_count);
         let mut inverse_bind_matrices = Vec::with_capacity(bone_count);
         let mut transform_orders = Vec::with_capacity(bone_count);
+        let mut transform_after_physics_flags = Vec::with_capacity(bone_count);
         let mut fixed_axis_flags = Vec::with_capacity(bone_count);
+        let mut fixed_axis_constraint_flags = Vec::with_capacity(bone_count);
         let mut fixed_axes = Vec::with_capacity(bone_count);
 
         for (bone_index, bone) in bones.iter().enumerate() {
@@ -284,13 +294,16 @@ impl ModelArena {
             rest_positions.push(bone.rest_position);
             inverse_bind_matrices.push(bone.inverse_bind_matrix);
             transform_orders.push(bone.transform_order);
+            transform_after_physics_flags.push(u8::from(bone.transform_after_physics));
             match bone.fixed_axis {
                 Some(axis) if axis.length_squared() > f32::EPSILON => {
                     fixed_axis_flags.push(1);
+                    fixed_axis_constraint_flags.push(u8::from(bone.enforce_fixed_axis));
                     fixed_axes.push(axis.normalize());
                 }
                 _ => {
                     fixed_axis_flags.push(0);
+                    fixed_axis_constraint_flags.push(0);
                     fixed_axes.push(Vec3A::X);
                 }
             }
@@ -298,7 +311,7 @@ impl ModelArena {
 
         let eval_order = build_eval_order(&parent_indices, &transform_orders)?;
         let eval_order_positions = build_eval_order_positions(&eval_order, bone_count);
-        let ik_solvers = build_ik_solvers(ik_solvers, bone_count)?;
+        let (ik_solvers, ik_link_flags) = build_ik_solvers(ik_solvers, bone_count)?;
         let (append_transforms, append_transform_indices) =
             build_append_transforms(append_transforms, bone_count)?;
         validate_morph_init(&morph, bone_count)?;
@@ -309,7 +322,10 @@ impl ModelArena {
             inverse_bind_matrices: inverse_bind_matrices.into_boxed_slice(),
             transform_orders: transform_orders.into_boxed_slice(),
             fixed_axis_flags: fixed_axis_flags.into_boxed_slice(),
+            fixed_axis_constraint_flags: fixed_axis_constraint_flags.into_boxed_slice(),
             fixed_axes: fixed_axes.into_boxed_slice(),
+            transform_after_physics_flags: transform_after_physics_flags.into_boxed_slice(),
+            ik_link_flags,
             eval_order,
             eval_order_positions,
             ik_solvers,
@@ -365,11 +381,30 @@ impl ModelArena {
     }
 
     #[inline]
+    pub(crate) fn fixed_axis_constraint(&self, bone: BoneIndex) -> Option<Vec3A> {
+        if self.fixed_axis_constraint_flags[bone.as_usize()] != 0 {
+            Some(self.fixed_axes[bone.as_usize()])
+        } else {
+            None
+        }
+    }
+
+    #[inline]
     pub fn fixed_axis_count(&self) -> usize {
         self.fixed_axis_flags
             .iter()
             .filter(|&&flag| flag != 0)
             .count()
+    }
+
+    #[inline]
+    pub fn transform_after_physics(&self, bone: BoneIndex) -> bool {
+        self.transform_after_physics_flags[bone.as_usize()] != 0
+    }
+
+    #[inline]
+    pub(crate) fn is_ik_link_bone(&self, bone: BoneIndex) -> bool {
+        self.ik_link_flags[bone.as_usize()] != 0
     }
 
     #[inline]
@@ -474,12 +509,14 @@ pub struct AppendTransform {
 }
 
 type AppendTransformBuildOutput = (Box<[AppendTransform]>, Box<[i32]>);
+type IkSolverBuildOutput = (Box<[IkSolver]>, Box<[u8]>);
 
 fn build_ik_solvers(
     ik_solvers: Vec<IkSolverInit>,
     bone_count: usize,
-) -> Result<Box<[IkSolver]>, ModelBuildError> {
+) -> Result<IkSolverBuildOutput, ModelBuildError> {
     let mut solvers = Vec::with_capacity(ik_solvers.len());
+    let mut ik_link_flags = vec![0; bone_count];
 
     for (solver_index, solver) in ik_solvers.into_iter().enumerate() {
         validate_ik_bone(solver_index, "ik", solver.ik_bone, bone_count)?;
@@ -488,6 +525,7 @@ fn build_ik_solvers(
         let mut links = Vec::with_capacity(solver.links.len());
         for link in solver.links {
             validate_ik_bone(solver_index, "link", link.bone, bone_count)?;
+            ik_link_flags[link.bone.as_usize()] = 1;
             links.push(IkLink {
                 bone: link.bone,
                 angle_limit: link.angle_limit,
@@ -503,7 +541,7 @@ fn build_ik_solvers(
         });
     }
 
-    Ok(solvers.into_boxed_slice())
+    Ok((solvers.into_boxed_slice(), ik_link_flags.into_boxed_slice()))
 }
 
 fn validate_ik_bone(

--- a/crates/mmd-anim-runtime/src/pose.rs
+++ b/crates/mmd-anim-runtime/src/pose.rs
@@ -9,6 +9,7 @@ pub struct PoseArena {
     local_scales: Box<[Vec3A]>,
     append_position_offsets: Box<[Vec3A]>,
     append_rotations: Box<[Quat]>,
+    ik_rotations: Box<[Quat]>,
     morph_weights: Box<[f32]>,
     ik_enabled: Box<[u8]>,
     world_matrices: Box<[Mat4]>,
@@ -31,6 +32,7 @@ impl PoseArena {
             local_scales: vec![Vec3A::ONE; bone_count].into_boxed_slice(),
             append_position_offsets: vec![Vec3A::ZERO; bone_count].into_boxed_slice(),
             append_rotations: vec![Quat::IDENTITY; bone_count].into_boxed_slice(),
+            ik_rotations: vec![Quat::IDENTITY; bone_count].into_boxed_slice(),
             morph_weights: vec![0.0; morph_count].into_boxed_slice(),
             ik_enabled: vec![1; ik_count].into_boxed_slice(),
             world_matrices: vec![Mat4::IDENTITY; bone_count].into_boxed_slice(),
@@ -43,6 +45,7 @@ impl PoseArena {
         self.local_rotations.fill(Quat::IDENTITY);
         self.local_scales.fill(Vec3A::ONE);
         self.reset_append_transforms();
+        self.ik_rotations.fill(Quat::IDENTITY);
         self.morph_weights.fill(0.0);
         self.ik_enabled.fill(1);
     }
@@ -55,6 +58,10 @@ impl PoseArena {
     pub(crate) fn reset_append_transform(&mut self, bone: BoneIndex) {
         self.append_position_offsets[bone.as_usize()] = Vec3A::ZERO;
         self.append_rotations[bone.as_usize()] = Quat::IDENTITY;
+    }
+
+    pub(crate) fn reset_ik_rotations(&mut self) {
+        self.ik_rotations.fill(Quat::IDENTITY);
     }
 
     #[inline]
@@ -98,6 +105,11 @@ impl PoseArena {
     }
 
     #[inline]
+    pub(crate) fn ik_rotation(&self, bone: BoneIndex) -> Quat {
+        self.ik_rotations[bone.as_usize()]
+    }
+
+    #[inline]
     pub(crate) fn set_append_position_offset(&mut self, bone: BoneIndex, value: Vec3A) {
         self.append_position_offsets[bone.as_usize()] = value;
     }
@@ -105,6 +117,11 @@ impl PoseArena {
     #[inline]
     pub(crate) fn set_append_rotation(&mut self, bone: BoneIndex, value: Quat) {
         self.append_rotations[bone.as_usize()] = value;
+    }
+
+    #[inline]
+    pub(crate) fn set_ik_rotation(&mut self, bone: BoneIndex, value: Quat) {
+        self.ik_rotations[bone.as_usize()] = value;
     }
 
     #[inline]

--- a/crates/mmd-anim-runtime/src/runtime.rs
+++ b/crates/mmd-anim-runtime/src/runtime.rs
@@ -22,6 +22,7 @@ use crate::ik_primitive::{
 struct IkScratch {
     links: Vec<crate::IkLink>,
     base_rotations: Vec<Quat>,
+    base_ik_rotations: Vec<Quat>,
     ik_rotations: Vec<Quat>,
     best_ik_rotations: Vec<Quat>,
     chain_states: Vec<ChainLinkState>,
@@ -38,6 +39,7 @@ impl IkScratch {
         IkScratch {
             links: Vec::with_capacity(max_links),
             base_rotations: Vec::with_capacity(max_links),
+            base_ik_rotations: Vec::with_capacity(max_links),
             ik_rotations: Vec::with_capacity(max_links),
             best_ik_rotations: Vec::with_capacity(max_links),
             chain_states: Vec::with_capacity(max_links),
@@ -90,7 +92,7 @@ pub struct IkSolveOptions {
 impl Default for IkSolveOptions {
     fn default() -> Self {
         Self {
-            tolerance: 1.0e-2,
+            tolerance: 0.0,
             max_iterations_cap: None,
         }
     }
@@ -151,19 +153,20 @@ impl RuntimeInstance {
     }
 
     pub fn evaluate_current_pose(&mut self) {
-        self.update_world_matrices();
-        self.solve_enabled_ik(IkSolveOptions::default());
+        self.pose.reset_ik_rotations();
+        self.evaluate_current_pose_ordered(IkSolveOptions::default());
     }
 
     pub fn evaluate_current_pose_with_ik_options(&mut self, options: IkSolveOptions) {
-        self.update_world_matrices();
-        self.solve_enabled_ik(options);
+        self.pose.reset_ik_rotations();
+        self.evaluate_current_pose_ordered(options);
     }
 
     /// Evaluate the current pose by updating world matrices only, without
     /// running any IK solver. This is useful for diagnostics that need to
     /// inspect clip/VMD state before IK is applied.
     pub fn evaluate_current_pose_without_ik(&mut self) {
+        self.pose.reset_ik_rotations();
         self.update_world_matrices();
     }
 
@@ -171,86 +174,150 @@ impl RuntimeInstance {
         self.update_world_matrices_from_eval_order_position(0);
     }
 
-    fn update_world_matrices_from_bone(&mut self, bone: crate::BoneIndex) {
-        self.update_world_matrices_from_eval_order_position(self.model.eval_order_position(bone));
+    fn update_world_matrices_from_eval_order_position(&mut self, start_position: usize) {
+        self.update_world_matrices_from_eval_order_position_for_phase(start_position, None);
     }
 
-    fn update_world_matrices_from_eval_order_position(&mut self, start_position: usize) {
-        let start_position = self.expand_update_start_for_append_dependencies(start_position);
+    fn update_world_matrices_from_eval_order_position_for_phase(
+        &mut self,
+        start_position: usize,
+        phase: Option<bool>,
+    ) {
+        let start_position =
+            self.expand_update_start_for_append_dependencies(start_position, phase);
         for bone in &self.model.eval_order()[start_position..] {
+            if !self.bone_matches_phase(*bone, phase) {
+                continue;
+            }
             self.pose.reset_append_transform(*bone);
         }
-        for bone in &self.model.eval_order()[start_position..] {
-            #[cfg(test)]
-            {
-                self.world_matrix_bone_update_count += 1;
+        for position in start_position..self.model.eval_order().len() {
+            let bone = self.model.eval_order()[position];
+            if !self.bone_matches_phase(bone, phase) {
+                continue;
             }
-            let mut local_position =
-                self.model.rest_position(*bone) + self.pose.local_position_offset(*bone);
-            let mut local_rotation = self.pose.local_rotation(*bone);
-            let local_scale = self.pose.local_scale(*bone);
-
-            if let Some(append_index) = self.model.append_transform_index(*bone) {
-                let append = self.model.append_transform(append_index);
-                let use_source_append = !append.local
-                    && self
-                        .model
-                        .append_transform_index(append.source_bone)
-                        .is_some();
-                let source_rotation = if use_source_append {
-                    self.pose.append_rotation(append.source_bone)
-                } else {
-                    self.pose.local_rotation(append.source_bone)
-                };
-                let source_position_offset = if use_source_append {
-                    self.pose.append_position_offset(append.source_bone)
-                } else {
-                    self.pose.local_position_offset(append.source_bone)
-                };
-                let append_output = solve_append_transform(AppendPrimitiveInput {
-                    source_position_offset,
-                    source_rotation,
-                    ratio: append.ratio,
-                    affect_rotation: append.affect_rotation,
-                    affect_translation: append.affect_translation,
-                });
-                self.pose.set_append_rotation(*bone, append_output.rotation);
-                self.pose
-                    .set_append_position_offset(*bone, append_output.position_offset);
-                if append.affect_rotation {
-                    local_rotation = (local_rotation * append_output.rotation).normalize();
-                }
-                if append.affect_translation {
-                    local_position += append_output.position_offset;
-                }
-            }
-
-            if let Some(axis) = self.model.fixed_axis(*bone) {
-                local_rotation = constrain_rotation_to_axis(local_rotation, axis);
-            }
-
-            let local_matrix = Mat4::from_scale_rotation_translation(
-                local_scale.into(),
-                local_rotation,
-                local_position.into(),
-            );
-
-            let world_matrix = match self.model.parent_index(*bone) {
-                Some(parent) => self.pose.world_matrices()[parent.as_usize()] * local_matrix,
-                None => local_matrix,
-            };
-
-            self.pose.set_world_matrix(*bone, world_matrix);
-            self.pose
-                .set_skinning_matrix(*bone, world_matrix * self.model.inverse_bind_matrix(*bone));
+            self.update_append_transform_for_bone(bone);
+            self.update_world_matrix_for_bone(bone);
         }
     }
 
-    fn expand_update_start_for_append_dependencies(&self, start_position: usize) -> usize {
+    fn update_world_matrices_using_current_append_from_eval_order_position(
+        &mut self,
+        start_position: usize,
+    ) {
+        self.update_world_matrices_using_current_append_from_eval_order_position_for_phase(
+            start_position,
+            None,
+        );
+    }
+
+    fn update_world_matrices_using_current_append_from_eval_order_position_for_phase(
+        &mut self,
+        start_position: usize,
+        phase: Option<bool>,
+    ) {
+        for position in start_position..self.model.eval_order().len() {
+            let bone = self.model.eval_order()[position];
+            if !self.bone_matches_phase(bone, phase) {
+                continue;
+            }
+            self.update_world_matrix_for_bone(bone);
+        }
+    }
+
+    #[inline]
+    fn bone_matches_phase(&self, bone: crate::BoneIndex, phase: Option<bool>) -> bool {
+        phase.is_none_or(|after_physics| self.model.transform_after_physics(bone) == after_physics)
+    }
+
+    fn update_append_transform_for_bone(&mut self, bone: crate::BoneIndex) {
+        let Some(append_index) = self.model.append_transform_index(bone) else {
+            return;
+        };
+        let append = self.model.append_transform(append_index);
+        let use_source_append = !append.local
+            && self
+                .model
+                .append_transform_index(append.source_bone)
+                .is_some();
+        let mut source_rotation = if use_source_append {
+            self.pose.append_rotation(append.source_bone)
+        } else {
+            self.pose.local_rotation(append.source_bone)
+        };
+        if use_source_append && self.model.is_ik_link_bone(append.source_bone) {
+            source_rotation =
+                (self.pose.ik_rotation(append.source_bone) * source_rotation).normalize();
+        }
+        let source_position_offset = if use_source_append {
+            self.pose.append_position_offset(append.source_bone)
+        } else {
+            self.pose.local_position_offset(append.source_bone)
+        };
+        let append_output = solve_append_transform(AppendPrimitiveInput {
+            source_position_offset,
+            source_rotation,
+            ratio: append.ratio,
+            affect_rotation: append.affect_rotation,
+            affect_translation: append.affect_translation,
+        });
+        self.pose.set_append_rotation(bone, append_output.rotation);
+        self.pose
+            .set_append_position_offset(bone, append_output.position_offset);
+    }
+
+    fn update_world_matrix_for_bone(&mut self, bone: crate::BoneIndex) {
+        #[cfg(test)]
+        {
+            self.world_matrix_bone_update_count += 1;
+        }
+        let mut local_position =
+            self.model.rest_position(bone) + self.pose.local_position_offset(bone);
+        let mut local_rotation = self.pose.local_rotation(bone);
+        let local_scale = self.pose.local_scale(bone);
+
+        if let Some(append_index) = self.model.append_transform_index(bone) {
+            let append = self.model.append_transform(append_index);
+            if append.affect_rotation {
+                local_rotation = (local_rotation * self.pose.append_rotation(bone)).normalize();
+            }
+            if append.affect_translation {
+                local_position += self.pose.append_position_offset(bone);
+            }
+        }
+
+        if let Some(axis) = self.model.fixed_axis_constraint(bone) {
+            local_rotation = constrain_rotation_to_axis(local_rotation, axis);
+        }
+
+        let local_matrix = Mat4::from_scale_rotation_translation(
+            local_scale.into(),
+            local_rotation,
+            local_position.into(),
+        );
+
+        let world_matrix = match self.model.parent_index(bone) {
+            Some(parent) => self.pose.world_matrices()[parent.as_usize()] * local_matrix,
+            None => local_matrix,
+        };
+
+        self.pose.set_world_matrix(bone, world_matrix);
+        self.pose
+            .set_skinning_matrix(bone, world_matrix * self.model.inverse_bind_matrix(bone));
+    }
+
+    fn expand_update_start_for_append_dependencies(
+        &self,
+        start_position: usize,
+        phase: Option<bool>,
+    ) -> usize {
         let mut start = start_position;
         loop {
             let mut changed = false;
             for append in self.model.append_transforms() {
+                if !self.bone_matches_phase(append.target_bone, phase) {
+                    continue;
+                }
                 let source_position = self.model.eval_order_position(append.source_bone);
                 let target_position = self.model.eval_order_position(append.target_bone);
                 if source_position >= start && target_position < start {
@@ -264,26 +331,47 @@ impl RuntimeInstance {
         }
     }
 
-    fn min_link_eval_order_position(&self, links: &[crate::IkLink]) -> Option<usize> {
-        links
-            .iter()
-            .map(|link| self.model.eval_order_position(link.bone))
-            .min()
+    fn evaluate_current_pose_ordered(&mut self, options: IkSolveOptions) {
+        self.pose.reset_append_transforms();
+        self.update_world_matrices_using_current_append_from_eval_order_position(0);
+
+        for after_physics in [false, true] {
+            for position in 0..self.model.eval_order().len() {
+                let bone = self.model.eval_order()[position];
+                if self.model.transform_after_physics(bone) != after_physics {
+                    continue;
+                }
+
+                if self.model.append_transform_index(bone).is_some() {
+                    self.pose.reset_append_transform(bone);
+                    self.update_append_transform_for_bone(bone);
+                }
+                self.update_world_matrix_for_bone(bone);
+
+                for ik_index in 0..self.model.ik_count() {
+                    if self.model.ik_solvers()[ik_index].ik_bone == bone {
+                        self.solve_ik_solver(ik_index, options, after_physics);
+                    }
+                }
+            }
+        }
+        self.update_world_matrices();
     }
 
-    fn solve_enabled_ik(&mut self, options: IkSolveOptions) {
+    fn solve_ik_solver(&mut self, ik_index: usize, options: IkSolveOptions, after_physics: bool) {
+        if self.pose.ik_enabled()[ik_index] == 0 {
+            return;
+        }
+
         let tolerance = options.tolerance.max(0.0);
         let mut links = std::mem::take(&mut self.ik_scratch.links);
         let mut base_rotations = std::mem::take(&mut self.ik_scratch.base_rotations);
+        let mut base_ik_rotations = std::mem::take(&mut self.ik_scratch.base_ik_rotations);
         let mut ik_rotations = std::mem::take(&mut self.ik_scratch.ik_rotations);
         let mut best_ik_rotations = std::mem::take(&mut self.ik_scratch.best_ik_rotations);
         let mut chain_states = std::mem::take(&mut self.ik_scratch.chain_states);
 
-        for ik_index in 0..self.model.ik_count() {
-            if self.pose.ik_enabled()[ik_index] == 0 {
-                continue;
-            }
-
+        {
             let solver = &self.model.ik_solvers()[ik_index];
             let ik_bone = solver.ik_bone;
             let target_bone = solver.target_bone;
@@ -302,6 +390,8 @@ impl RuntimeInstance {
 
             base_rotations.clear();
             base_rotations.extend(links.iter().map(|l| self.pose.local_rotation(l.bone)));
+            base_ik_rotations.clear();
+            base_ik_rotations.extend(links.iter().map(|l| self.pose.ik_rotation(l.bone)));
             ik_rotations.clear();
             ik_rotations.resize(link_count, Quat::IDENTITY);
             best_ik_rotations.clear();
@@ -313,12 +403,18 @@ impl RuntimeInstance {
             });
 
             // Always start from base rotations (IK deltas start at identity).
-            self.apply_ik_link_rotations(&links, &base_rotations, &ik_rotations);
-            if let Some(start_position) = self.min_link_eval_order_position(&links) {
-                self.update_world_matrices_from_eval_order_position(start_position);
-            } else {
-                self.update_world_matrices();
-            }
+            self.apply_ik_link_rotations(
+                &links,
+                &base_rotations,
+                &base_ik_rotations,
+                &ik_rotations,
+            );
+            self.update_world_matrices_after_ik_link_change(
+                &links,
+                ik_bone,
+                target_bone,
+                Some(after_physics),
+            );
 
             let mut broke_early = false;
             let mut final_distance = f32::MAX;
@@ -372,8 +468,18 @@ impl RuntimeInstance {
                         limit_angle,
                     });
 
-                    self.apply_ik_link_rotations(&links, &base_rotations, &ik_rotations);
-                    self.update_world_matrices_from_bone(link_bone);
+                    self.apply_ik_link_rotations(
+                        &links,
+                        &base_rotations,
+                        &base_ik_rotations,
+                        &ik_rotations,
+                    );
+                    self.update_world_matrices_after_ik_link_change(
+                        &links,
+                        ik_bone,
+                        target_bone,
+                        Some(after_physics),
+                    );
                     self.ik_stats[ik_index].link_steps += 1;
                 }
 
@@ -396,10 +502,18 @@ impl RuntimeInstance {
                 } else {
                     self.ik_stats[ik_index].rollback_breaks += 1;
                     ik_rotations.copy_from_slice(&best_ik_rotations);
-                    self.apply_ik_link_rotations(&links, &base_rotations, &ik_rotations);
-                    if let Some(start_position) = self.min_link_eval_order_position(&links) {
-                        self.update_world_matrices_from_eval_order_position(start_position);
-                    }
+                    self.apply_ik_link_rotations(
+                        &links,
+                        &base_rotations,
+                        &base_ik_rotations,
+                        &ik_rotations,
+                    );
+                    self.update_world_matrices_after_ik_link_change(
+                        &links,
+                        ik_bone,
+                        target_bone,
+                        Some(after_physics),
+                    );
                     broke_early = true;
                     break;
                 }
@@ -417,27 +531,121 @@ impl RuntimeInstance {
             }
 
             // Apply final best effective rotations
-            self.apply_ik_link_rotations(&links, &base_rotations, &best_ik_rotations);
-            if let Some(start_position) = self.min_link_eval_order_position(&links) {
-                self.update_world_matrices_from_eval_order_position(start_position);
-            }
-        } // close for-ik_index
+            self.apply_ik_link_rotations(
+                &links,
+                &base_rotations,
+                &base_ik_rotations,
+                &best_ik_rotations,
+            );
+            self.update_world_matrices_after_ik_link_change(
+                &links,
+                ik_bone,
+                target_bone,
+                Some(after_physics),
+            );
+        }
 
         self.ik_scratch.links = links;
         self.ik_scratch.base_rotations = base_rotations;
+        self.ik_scratch.base_ik_rotations = base_ik_rotations;
         self.ik_scratch.ik_rotations = ik_rotations;
         self.ik_scratch.best_ik_rotations = best_ik_rotations;
         self.ik_scratch.chain_states = chain_states;
+    }
+
+    fn update_world_matrices_after_ik_link_change(
+        &mut self,
+        links: &[crate::IkLink],
+        ik_bone: crate::BoneIndex,
+        target_bone: crate::BoneIndex,
+        phase: Option<bool>,
+    ) {
+        let start_position =
+            self.min_ik_dependency_eval_order_position(links, ik_bone, target_bone);
+        let start_position =
+            self.expand_update_start_for_append_dependencies(start_position, phase);
+        for bone in &self.model.eval_order()[start_position..] {
+            if self.bone_matches_phase(*bone, phase)
+                || self.bone_is_in_ik_update_scope(*bone, links, ik_bone, target_bone)
+            {
+                self.pose.reset_append_transform(*bone);
+            }
+        }
+        for position in start_position..self.model.eval_order().len() {
+            let bone = self.model.eval_order()[position];
+            if self.bone_matches_phase(bone, phase)
+                || self.bone_is_in_ik_update_scope(bone, links, ik_bone, target_bone)
+            {
+                self.update_append_transform_for_bone(bone);
+                self.update_world_matrix_for_bone(bone);
+            }
+        }
+    }
+
+    fn min_ik_dependency_eval_order_position(
+        &self,
+        links: &[crate::IkLink],
+        ik_bone: crate::BoneIndex,
+        target_bone: crate::BoneIndex,
+    ) -> usize {
+        let mut min_position = self.model.eval_order_position(ik_bone);
+        min_position = min_position.min(self.model.eval_order_position(target_bone));
+        for link in links {
+            min_position = min_position.min(self.model.eval_order_position(link.bone));
+        }
+        for bone in [ik_bone, target_bone]
+            .into_iter()
+            .chain(links.iter().map(|link| link.bone))
+        {
+            let mut current = Some(bone);
+            while let Some(parent) = current {
+                min_position = min_position.min(self.model.eval_order_position(parent));
+                current = self.model.parent_index(parent);
+            }
+        }
+        min_position
+    }
+
+    fn bone_is_in_ik_update_scope(
+        &self,
+        bone: crate::BoneIndex,
+        links: &[crate::IkLink],
+        ik_bone: crate::BoneIndex,
+        target_bone: crate::BoneIndex,
+    ) -> bool {
+        if bone == ik_bone || bone == target_bone || links.iter().any(|link| link.bone == bone) {
+            return true;
+        }
+        if self.bone_is_ancestor_of(bone, ik_bone) || self.bone_is_ancestor_of(bone, target_bone) {
+            return true;
+        }
+        links.iter().any(|link| {
+            self.bone_is_ancestor_of(bone, link.bone) || self.bone_is_ancestor_of(link.bone, bone)
+        })
+    }
+
+    fn bone_is_ancestor_of(&self, ancestor: crate::BoneIndex, bone: crate::BoneIndex) -> bool {
+        let mut current = self.model.parent_index(bone);
+        while let Some(parent) = current {
+            if parent == ancestor {
+                return true;
+            }
+            current = self.model.parent_index(parent);
+        }
+        false
     }
 
     fn apply_ik_link_rotations(
         &mut self,
         links: &[crate::IkLink],
         base_rotations: &[Quat],
+        base_ik_rotations: &[Quat],
         ik_rotations: &[Quat],
     ) {
         for (i, link) in links.iter().enumerate() {
             let effective = (ik_rotations[i] * base_rotations[i]).normalize();
+            let total_ik = (ik_rotations[i] * base_ik_rotations[i]).normalize();
+            self.pose.set_ik_rotation(link.bone, total_ik);
             self.pose.set_local_rotation(link.bone, effective);
         }
     }
@@ -471,6 +679,7 @@ impl RuntimeInstance {
     pub fn evaluate_clip_frame_without_ik(&mut self, clip: &AnimationClip, frame: f32) {
         clip.apply_to_pose(frame, &mut self.pose);
         self.expand_morphs();
+        self.pose.reset_ik_rotations();
         self.update_world_matrices();
     }
 
@@ -912,6 +1121,42 @@ mod tests {
     }
 
     #[test]
+    fn evaluates_all_solvers_attached_to_same_ik_bone() {
+        let model = Arc::new(
+            ModelArena::new_with_ik(
+                vec![
+                    BoneInit::new(None, Vec3A::ZERO),
+                    BoneInit::new(Some(BoneIndex(0)), Vec3A::new(1.0, 0.0, 0.0)),
+                    BoneInit::new(None, Vec3A::new(0.0, 1.0, 0.0)),
+                ],
+                vec![
+                    IkSolverInit {
+                        ik_bone: BoneIndex(2),
+                        target_bone: BoneIndex(1),
+                        links: vec![IkLinkInit::new(BoneIndex(0))],
+                        iteration_count: 1,
+                        limit_angle: 0.0,
+                    },
+                    IkSolverInit {
+                        ik_bone: BoneIndex(2),
+                        target_bone: BoneIndex(1),
+                        links: vec![IkLinkInit::new(BoneIndex(0))],
+                        iteration_count: 1,
+                        limit_angle: 0.0,
+                    },
+                ],
+            )
+            .unwrap(),
+        );
+        let mut runtime = RuntimeInstance::new(model);
+
+        runtime.evaluate_current_pose();
+
+        assert_eq!(runtime.ik_runtime_stats()[0].solver_evaluations, 1);
+        assert_eq!(runtime.ik_runtime_stats()[1].solver_evaluations, 1);
+    }
+
+    #[test]
     fn ik_updates_only_affected_eval_suffix_for_late_chain() {
         let unrelated_count = 96usize;
         let chain_root = BoneIndex(unrelated_count as u32);
@@ -951,7 +1196,7 @@ mod tests {
             Vec3A::new(1.0, 1.0, 0.0),
         );
         assert!(
-            runtime.world_matrix_bone_update_count() < 250,
+            runtime.world_matrix_bone_update_count() < 360,
             "IK should not recompute unrelated prefix bones repeatedly; updated {} bones",
             runtime.world_matrix_bone_update_count()
         );
@@ -1677,6 +1922,348 @@ mod tests {
     }
 
     #[test]
+    fn append_source_with_own_append_includes_ik_link_rotation() {
+        let model = Arc::new(
+            ModelArena::new_full(
+                vec![
+                    BoneInit::new(None, Vec3A::ZERO),
+                    BoneInit::new(Some(BoneIndex(0)), Vec3A::new(1.0, 0.0, 0.0)),
+                    BoneInit::new(None, Vec3A::new(0.0, 1.0, 0.0)),
+                    BoneInit::new(None, Vec3A::ZERO),
+                    BoneInit::new(None, Vec3A::ZERO),
+                    BoneInit::new(Some(BoneIndex(4)), Vec3A::new(1.0, 0.0, 0.0)),
+                ],
+                vec![IkSolverInit {
+                    ik_bone: BoneIndex(2),
+                    target_bone: BoneIndex(1),
+                    links: vec![IkLinkInit::new(BoneIndex(0))],
+                    iteration_count: 1,
+                    limit_angle: 0.0,
+                }],
+                vec![
+                    AppendTransformInit::new(BoneIndex(0), BoneIndex(3), 1.0).with_rotation(),
+                    AppendTransformInit::new(BoneIndex(4), BoneIndex(0), 1.0).with_rotation(),
+                ],
+            )
+            .unwrap(),
+        );
+        let mut runtime = RuntimeInstance::new(model);
+        runtime.pose_mut().set_local_rotation(
+            BoneIndex(3),
+            Quat::from_rotation_z(std::f32::consts::FRAC_PI_4),
+        );
+
+        runtime.evaluate_current_pose();
+
+        assert_vec3a_near(
+            translation(runtime.world_matrices()[5]),
+            Vec3A::new(0.0, 1.0, 0.0),
+        );
+    }
+
+    #[test]
+    fn without_ik_evaluation_clears_previous_ik_link_rotation_for_append_sources() {
+        let model = Arc::new(
+            ModelArena::new_full(
+                vec![
+                    BoneInit::new(None, Vec3A::ZERO),
+                    BoneInit::new(Some(BoneIndex(0)), Vec3A::new(1.0, 0.0, 0.0)),
+                    BoneInit::new(None, Vec3A::new(0.0, 1.0, 0.0)),
+                    BoneInit::new(None, Vec3A::ZERO),
+                    BoneInit::new(None, Vec3A::ZERO),
+                    BoneInit::new(Some(BoneIndex(4)), Vec3A::new(1.0, 0.0, 0.0)),
+                ],
+                vec![IkSolverInit {
+                    ik_bone: BoneIndex(2),
+                    target_bone: BoneIndex(1),
+                    links: vec![IkLinkInit::new(BoneIndex(0))],
+                    iteration_count: 1,
+                    limit_angle: 0.0,
+                }],
+                vec![
+                    AppendTransformInit::new(BoneIndex(0), BoneIndex(3), 1.0).with_rotation(),
+                    AppendTransformInit::new(BoneIndex(4), BoneIndex(0), 1.0).with_rotation(),
+                ],
+            )
+            .unwrap(),
+        );
+        let mut runtime = RuntimeInstance::new(model);
+        runtime.pose_mut().set_local_rotation(
+            BoneIndex(3),
+            Quat::from_rotation_z(std::f32::consts::FRAC_PI_4),
+        );
+
+        runtime.evaluate_current_pose();
+        runtime.evaluate_current_pose_without_ik();
+
+        assert_vec3a_near(
+            translation(runtime.world_matrices()[5]),
+            Vec3A::new(
+                std::f32::consts::FRAC_1_SQRT_2,
+                std::f32::consts::FRAC_1_SQRT_2,
+                0.0,
+            ),
+        );
+    }
+
+    #[test]
+    fn shared_ik_link_preserves_accumulated_rotation_for_later_append_source() {
+        let model = Arc::new(
+            ModelArena::new_full(
+                vec![
+                    BoneInit::new(None, Vec3A::ZERO),
+                    BoneInit::new(Some(BoneIndex(0)), Vec3A::new(1.0, 0.0, 0.0)),
+                    BoneInit::new(None, Vec3A::new(0.0, 1.0, 0.0)),
+                    BoneInit::new(None, Vec3A::ZERO),
+                    BoneInit::new(None, Vec3A::ZERO),
+                    BoneInit::new(Some(BoneIndex(4)), Vec3A::new(1.0, 0.0, 0.0)),
+                ],
+                vec![
+                    IkSolverInit {
+                        ik_bone: BoneIndex(2),
+                        target_bone: BoneIndex(1),
+                        links: vec![IkLinkInit::new(BoneIndex(0))],
+                        iteration_count: 1,
+                        limit_angle: 0.0,
+                    },
+                    IkSolverInit {
+                        ik_bone: BoneIndex(2),
+                        target_bone: BoneIndex(2),
+                        links: vec![IkLinkInit::new(BoneIndex(0))],
+                        iteration_count: 1,
+                        limit_angle: 0.0,
+                    },
+                ],
+                vec![
+                    AppendTransformInit::new(BoneIndex(0), BoneIndex(3), 1.0).with_rotation(),
+                    AppendTransformInit::new(BoneIndex(4), BoneIndex(0), 1.0).with_rotation(),
+                ],
+            )
+            .unwrap(),
+        );
+        let mut runtime = RuntimeInstance::new(model);
+        runtime.pose_mut().set_local_rotation(
+            BoneIndex(3),
+            Quat::from_rotation_z(std::f32::consts::FRAC_PI_4),
+        );
+
+        runtime.evaluate_current_pose();
+
+        assert_eq!(runtime.ik_runtime_stats()[1].tolerance_precheck_breaks, 1);
+        assert_vec3a_near(
+            translation(runtime.world_matrices()[5]),
+            Vec3A::new(0.0, 1.0, 0.0),
+        );
+    }
+
+    #[test]
+    fn earlier_append_target_updates_after_later_ik_link_rotation() {
+        let mut append_target = BoneInit::new(None, Vec3A::ZERO);
+        append_target.transform_order = 0;
+        let mut append_child = BoneInit::new(Some(BoneIndex(3)), Vec3A::X);
+        append_child.transform_order = 1;
+        let mut link = BoneInit::new(None, Vec3A::ZERO);
+        link.transform_order = 10;
+        let mut effector = BoneInit::new(Some(BoneIndex(0)), Vec3A::X);
+        effector.transform_order = 11;
+        let mut controller = BoneInit::new(None, Vec3A::Y);
+        controller.transform_order = 12;
+
+        let model = Arc::new(
+            ModelArena::new_full(
+                vec![link, effector, controller, append_target, append_child],
+                vec![IkSolverInit {
+                    ik_bone: BoneIndex(2),
+                    target_bone: BoneIndex(1),
+                    links: vec![IkLinkInit::new(BoneIndex(0))],
+                    iteration_count: 1,
+                    limit_angle: 0.0,
+                }],
+                vec![AppendTransformInit::new(BoneIndex(3), BoneIndex(0), 1.0).with_rotation()],
+            )
+            .unwrap(),
+        );
+        let mut runtime = RuntimeInstance::new(model);
+
+        runtime.evaluate_current_pose();
+
+        assert_vec3a_near(
+            translation(runtime.world_matrices()[4]),
+            Vec3A::new(0.0, 1.0, 0.0),
+        );
+    }
+
+    #[test]
+    fn mixed_phase_ik_updates_opposite_phase_controller_dependency() {
+        let mut link_a = BoneInit::new(None, Vec3A::ZERO);
+        link_a.transform_order = 0;
+        let mut effector_a = BoneInit::new(Some(BoneIndex(0)), Vec3A::X);
+        effector_a.transform_order = 1;
+        let mut controller_a = BoneInit::new(None, Vec3A::Y);
+        controller_a.transform_order = 2;
+        let mut after_append = BoneInit::new(None, Vec3A::ZERO);
+        after_append.transform_order = 3;
+        after_append.transform_after_physics = true;
+        let mut link_b = BoneInit::new(None, Vec3A::ZERO);
+        link_b.transform_order = 4;
+        let mut effector_b = BoneInit::new(Some(BoneIndex(4)), Vec3A::X);
+        effector_b.transform_order = 5;
+        let mut controller_b = BoneInit::new(Some(BoneIndex(3)), Vec3A::X);
+        controller_b.transform_order = 6;
+
+        let model = Arc::new(
+            ModelArena::new_full(
+                vec![
+                    link_a,
+                    effector_a,
+                    controller_a,
+                    after_append,
+                    link_b,
+                    effector_b,
+                    controller_b,
+                ],
+                vec![
+                    IkSolverInit {
+                        ik_bone: BoneIndex(2),
+                        target_bone: BoneIndex(1),
+                        links: vec![IkLinkInit::new(BoneIndex(0))],
+                        iteration_count: 1,
+                        limit_angle: 0.0,
+                    },
+                    IkSolverInit {
+                        ik_bone: BoneIndex(6),
+                        target_bone: BoneIndex(5),
+                        links: vec![IkLinkInit::new(BoneIndex(4))],
+                        iteration_count: 1,
+                        limit_angle: 0.0,
+                    },
+                ],
+                vec![AppendTransformInit::new(BoneIndex(3), BoneIndex(0), 1.0).with_rotation()],
+            )
+            .unwrap(),
+        );
+        let mut runtime = RuntimeInstance::new(model);
+
+        runtime.evaluate_current_pose();
+
+        assert_vec3a_near(
+            translation(runtime.world_matrices()[5]),
+            Vec3A::new(0.0, 1.0, 0.0),
+        );
+        assert_vec3a_near(
+            translation(runtime.world_matrices()[6]),
+            Vec3A::new(0.0, 1.0, 0.0),
+        );
+        assert_vec3a_near(
+            translation(runtime.world_matrices()[3]),
+            Vec3A::new(0.0, 0.0, 0.0),
+        );
+    }
+
+    #[test]
+    fn after_physics_plain_child_recomputes_after_pre_physics_parent_ik() {
+        let mut after_child = BoneInit::new(Some(BoneIndex(0)), Vec3A::X);
+        after_child.transform_order = 3;
+        after_child.transform_after_physics = true;
+
+        let model = Arc::new(
+            ModelArena::new_with_ik(
+                vec![
+                    BoneInit::new(None, Vec3A::ZERO),
+                    BoneInit::new(Some(BoneIndex(0)), Vec3A::X),
+                    BoneInit::new(None, Vec3A::Y),
+                    after_child,
+                ],
+                vec![IkSolverInit {
+                    ik_bone: BoneIndex(2),
+                    target_bone: BoneIndex(1),
+                    links: vec![IkLinkInit::new(BoneIndex(0))],
+                    iteration_count: 1,
+                    limit_angle: 0.0,
+                }],
+            )
+            .unwrap(),
+        );
+        let mut runtime = RuntimeInstance::new(model);
+
+        runtime.evaluate_current_pose();
+
+        assert_vec3a_near(
+            translation(runtime.world_matrices()[3]),
+            Vec3A::new(0.0, 1.0, 0.0),
+        );
+    }
+
+    #[test]
+    fn pre_physics_child_recomputes_after_after_physics_append_parent() {
+        let mut after_parent = BoneInit::new(None, Vec3A::ZERO);
+        after_parent.transform_order = 1;
+        after_parent.transform_after_physics = true;
+        let mut pre_child = BoneInit::new(Some(BoneIndex(1)), Vec3A::X);
+        pre_child.transform_order = 2;
+
+        let model = Arc::new(
+            ModelArena::new_full(
+                vec![BoneInit::new(None, Vec3A::ZERO), after_parent, pre_child],
+                Vec::new(),
+                vec![AppendTransformInit::new(BoneIndex(1), BoneIndex(0), 1.0).with_rotation()],
+            )
+            .unwrap(),
+        );
+        let mut runtime = RuntimeInstance::new(model);
+        runtime.pose_mut().set_local_rotation(
+            BoneIndex(0),
+            Quat::from_rotation_z(std::f32::consts::FRAC_PI_2),
+        );
+
+        runtime.evaluate_current_pose();
+
+        assert_vec3a_near(
+            translation(runtime.world_matrices()[2]),
+            Vec3A::new(0.0, 1.0, 0.0),
+        );
+    }
+
+    #[test]
+    fn append_target_recomputes_after_opposite_phase_ik_source_rotation() {
+        let mut after_controller = BoneInit::new(None, Vec3A::Y);
+        after_controller.transform_order = 2;
+        after_controller.transform_after_physics = true;
+        let mut append_target = BoneInit::new(None, Vec3A::ZERO);
+        append_target.transform_order = 3;
+        let append_child = BoneInit::new(Some(BoneIndex(3)), Vec3A::X);
+
+        let model = Arc::new(
+            ModelArena::new_full(
+                vec![
+                    BoneInit::new(None, Vec3A::ZERO),
+                    BoneInit::new(Some(BoneIndex(0)), Vec3A::X),
+                    after_controller,
+                    append_target,
+                    append_child,
+                ],
+                vec![IkSolverInit {
+                    ik_bone: BoneIndex(2),
+                    target_bone: BoneIndex(1),
+                    links: vec![IkLinkInit::new(BoneIndex(0))],
+                    iteration_count: 1,
+                    limit_angle: 0.0,
+                }],
+                vec![AppendTransformInit::new(BoneIndex(3), BoneIndex(0), 1.0).with_rotation()],
+            )
+            .unwrap(),
+        );
+        let mut runtime = RuntimeInstance::new(model);
+
+        runtime.evaluate_current_pose();
+
+        assert_vec3a_near(
+            translation(runtime.world_matrices()[4]),
+            Vec3A::new(0.0, 1.0, 0.0),
+        );
+    }
+
+    #[test]
     fn scratch_ik_capacities_stable_after_repeated_evaluate() {
         let model = Arc::new(
             ModelArena::new_with_ik(
@@ -1714,6 +2301,7 @@ mod tests {
 
         let cap_links = runtime.ik_scratch.links.capacity();
         let cap_base = runtime.ik_scratch.base_rotations.capacity();
+        let cap_base_ik = runtime.ik_scratch.base_ik_rotations.capacity();
         let cap_ik = runtime.ik_scratch.ik_rotations.capacity();
         let cap_best = runtime.ik_scratch.best_ik_rotations.capacity();
         let cap_chain = runtime.ik_scratch.chain_states.capacity();
@@ -1724,6 +2312,7 @@ mod tests {
 
         assert_eq!(runtime.ik_scratch.links.capacity(), cap_links);
         assert_eq!(runtime.ik_scratch.base_rotations.capacity(), cap_base);
+        assert_eq!(runtime.ik_scratch.base_ik_rotations.capacity(), cap_base_ik);
         assert_eq!(runtime.ik_scratch.ik_rotations.capacity(), cap_ik);
         assert_eq!(runtime.ik_scratch.best_ik_rotations.capacity(), cap_best);
         assert_eq!(runtime.ik_scratch.chain_states.capacity(), cap_chain);


### PR DESCRIPTION
## Summary

Fixes PMX ordered transform evaluation for append/IK-heavy rigs, with Kotora gym forearm as the motivating regression case.

## What changed

- Evaluates PMX bones in transform order with separate pre/post-physics passes.
- Preserves append-source IK rotations so append chains can consume the correct source transform.
- Applies fixed-axis handling after append blending to avoid losing constrained-axis behavior.
- Adds an ignored Kotora forearm GoldenOracle regression test for the local external asset workflow.

## Why

Kotora's forearm rig depends on a complex interaction between append transforms, IK source bones, transform-after-physics flags, and fixed-axis constraints. The previous evaluation order allowed the forearm chain to diverge from the GoldenOracle output.

## Validation

- `rtk cargo test -p mmd-anim-cli --test kotora_forearm_golden -- --ignored --nocapture` passed: 2 tests.
- Existing broader GoldenOracle checks were also sampled separately. They still have pre-existing non-Kotora failures/missing oracles and are intentionally left for a separate cleanup task.