### PR TITLE
Fix release asset publishing workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,7 @@ jobs:
           cargo package -p mmd-anim-runtime --list
           cargo package -p mmd-anim-format --list
           cargo package -p mmd-anim --list
+          cargo package -p mmd-anim-cli --list
 
       - name: Dry-run dependency-free crate
         run: cargo publish -p mmd-anim-runtime --dry-run
@@ -126,6 +127,7 @@ jobs:
       - name: Create or update GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
         shell: bash
         run: |
           set -euo pipefail
@@ -200,3 +202,4 @@ jobs:
           publish_crate mmd-anim-runtime
           publish_crate mmd-anim-format
           publish_crate mmd-anim
+          publish_crate mmd-anim-cli


### PR DESCRIPTION
## Summary

Fixes the release workflow issue found during the `v0.1.9` tag run.

- sets `GH_REPO` for the release asset upload step so `gh release` works without a checked-out git repository
- includes `mmd-anim-cli` in package auditing
- includes `mmd-anim-cli` in crates.io publish order for future releases

## Validation

- `rtk git diff --check -- .github/workflows/release.yml`
- verified `mmd-anim-cli = 0.1.9` is visible on crates.io after the manual publish
