### PR TITLE
Add reduced pose support and skin diff tooling across CLI, FFI, and Bullet backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -162,6 +162,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
+
+[[package]]
 name = "either"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -411,6 +436,7 @@ name = "mmd-anim-runtime"
 version = "0.2.0"
 dependencies = [
  "glam",
+ "rayon",
  "thiserror",
 ]
 
@@ -460,6 +486,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ categories = ["multimedia"]
 anyhow = "1.0.100"
 glam = { version = "0.32.1", features = ["debug-glam-assert", "fast-math"] }
 thiserror = "2.0.17"
+rayon = "1.10"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"
 wasm-bindgen = "0.2.105"

--- a/crates/mmd-anim-cli/src/commands/fbx.rs
+++ b/crates/mmd-anim-cli/src/commands/fbx.rs
@@ -294,6 +294,8 @@ pub(crate) fn convert_pmx_to_fbx(
             report["poseReduction"]["workStats"] = json!({
                 "globalValidationPasses": work.global_validation_passes,
                 "candidateRebuilds": work.candidate_rebuilds,
+                "candidateBoneTrackRebuilds": work.candidate_bone_track_rebuilds,
+                "candidateMorphTrackRebuilds": work.candidate_morph_track_rebuilds,
                 "localPrefitBoneSegmentFits": work.local_prefit_bone_segment_fits,
                 "localPrefitMorphSegmentFits": work.local_prefit_morph_segment_fits,
                 "localPrefitBoneKeyAdditions": work.local_prefit_bone_key_additions,
@@ -305,6 +307,7 @@ pub(crate) fn convert_pmx_to_fbx(
                 "boneSamples": work.bone_samples,
                 "morphSamples": work.morph_samples,
                 "worldRebuilds": work.world_rebuilds,
+                "worldBoneRecomputes": work.world_bone_recomputes,
                 "worldRotationDecompositions": work.world_rotation_decompositions,
                 "normalKeyAdditions": work.normal_key_additions,
                 "ancestorKeyAdditions": work.ancestor_key_additions,

--- a/crates/mmd-anim-cli/src/commands/fbx.rs
+++ b/crates/mmd-anim-cli/src/commands/fbx.rs
@@ -16,6 +16,7 @@ pub(crate) struct ConvertFbxJsonReport<'a> {
     pub vmd: Option<&'a Path>,
     pub bones_only: bool,
     pub physics_bake: bool,
+    pub pose_reduced: bool,
     pub readable_bone_names: bool,
     pub bone_name_map: Option<&'a Path>,
     pub physics_params: Option<&'a Path>,
@@ -27,20 +28,30 @@ pub(crate) struct ConvertFbxJsonReport<'a> {
 }
 
 pub(crate) fn convert_fbx_json(report: ConvertFbxJsonReport<'_>) -> serde_json::Value {
-    let mode = match (report.physics_bake, report.vmd.is_some(), report.bones_only) {
-        (true, true, true) => "pmx-vmd-physics-bake-bones-only",
-        (true, true, false) => "pmx-vmd-physics-bake",
-        (false, true, true) => "pmx-vmd-bake-bones-only",
-        (false, false, true) => "pmx-bones-only",
-        (false, true, false) => "pmx-vmd-bake",
-        (false, false, false) => "pmx-to-fbx",
-        (true, false, _) => unreachable!("physics bake requires VMD"),
+    let mode = if report.pose_reduced {
+        match (report.physics_bake, report.bones_only) {
+            (true, true) => "pmx-vmd-physics-bake-reduced-bones-only",
+            (true, false) => "pmx-vmd-physics-bake-reduced",
+            (false, true) => "pmx-vmd-bake-reduced-bones-only",
+            (false, false) => "pmx-vmd-bake-reduced",
+        }
+    } else {
+        match (report.physics_bake, report.vmd.is_some(), report.bones_only) {
+            (true, true, true) => "pmx-vmd-physics-bake-bones-only",
+            (true, true, false) => "pmx-vmd-physics-bake",
+            (false, true, true) => "pmx-vmd-bake-bones-only",
+            (false, false, true) => "pmx-bones-only",
+            (false, true, false) => "pmx-vmd-bake",
+            (false, false, false) => "pmx-to-fbx",
+            (true, false, _) => unreachable!("physics bake requires VMD"),
+        }
     };
     let mut value = json!({
         "status": "ok",
         "command": "convert-fbx",
         "mode": mode,
         "bonesOnly": report.bones_only,
+        "poseReduced": report.pose_reduced,
         "readableBoneNames": report.readable_bone_names,
         "boneNameMap": report.bone_name_map.map(|path| path.display().to_string()),
         "physicsParams": report.physics_params.map(|path| path.display().to_string()),
@@ -76,6 +87,10 @@ pub(crate) struct ConvertFbxOptions {
     pub copy_diffuse_textures: bool,
     pub bones_only: bool,
     pub physics_bake: bool,
+    pub reduce_pose: bool,
+    pub pose_position_tolerance: f32,
+    pub pose_rotation_tolerance: f32,
+    pub pose_morph_tolerance: f32,
     pub readable_bone_names: bool,
     pub write_physics_params: bool,
     pub use_json: bool,
@@ -89,6 +104,9 @@ pub(crate) fn convert_pmx_to_fbx(
 ) -> Result<ExitCode, Box<dyn std::error::Error>> {
     if convert_options.physics_bake && vmd.is_none() {
         return Err("convert-fbx --physics-bake requires --vmd".into());
+    }
+    if convert_options.reduce_pose && vmd.is_none() {
+        return Err("convert-fbx --reduce-pose requires --vmd".into());
     }
     #[cfg(not(feature = "physics-bullet-native"))]
     if convert_options.physics_bake {
@@ -131,6 +149,7 @@ pub(crate) fn convert_pmx_to_fbx(
     };
 
     let mut baked_max_frame = None;
+    let mut reduction_report = None;
     let fbx = if let Some(vmd_path) = vmd {
         let motion_data = read_file(vmd_path)?;
         let motion = mmd_anim_format::parse_vmd_animation(&motion_data).map_err(|error| {
@@ -186,8 +205,30 @@ pub(crate) fn convert_pmx_to_fbx(
         }
         baked_max_frame = Some(last_frame);
         let runtime_model = Arc::new(runtime_import.model);
-        if convert_options.physics_bake {
+        if convert_options.physics_bake && convert_options.reduce_pose {
+            let export = export_reduced_fbx_with_physics_bake(
+                &model,
+                runtime_model,
+                &clip,
+                last_frame,
+                &options,
+                pose_reduction_tolerances(&convert_options),
+            )?;
+            reduction_report = Some(export.report);
+            export.bytes
+        } else if convert_options.physics_bake {
             export_fbx_with_physics_bake(&model, runtime_model, &clip, last_frame, &options)?
+        } else if convert_options.reduce_pose {
+            let export = mmd_anim_format::fbx::export_pmx_fbx_binary_with_reduced_runtime_bake(
+                &model,
+                runtime_model,
+                &clip,
+                last_frame,
+                pose_reduction_tolerances(&convert_options),
+                &options,
+            )?;
+            reduction_report = Some(export.report);
+            export.bytes
         } else {
             mmd_anim_format::fbx::export_fbx_with_runtime_bake(
                 &model,
@@ -219,6 +260,7 @@ pub(crate) fn convert_pmx_to_fbx(
             vmd,
             bones_only: convert_options.bones_only,
             physics_bake: convert_options.physics_bake,
+            pose_reduced: convert_options.reduce_pose,
             readable_bone_names: convert_options.readable_bone_names,
             bone_name_map: bone_name_map.as_deref(),
             physics_params: physics_params.as_deref(),
@@ -228,6 +270,20 @@ pub(crate) fn convert_pmx_to_fbx(
             exported_blend_shapes,
             copied_diffuse_textures,
         });
+        let mut report = report;
+        if let Some(reduction) = reduction_report {
+            report["poseReduction"] = json!({
+                "sourceBoneKeys": reduction.source_bone_key_count,
+                "reducedBoneKeys": reduction.reduced_bone_key_count,
+                "sourceMorphKeys": reduction.source_morph_key_count,
+                "reducedMorphKeys": reduction.reduced_morph_key_count,
+                "maxLocalPositionError": reduction.max_local_position_error,
+                "maxLocalRotationErrorRadians": reduction.max_local_rotation_error_radians,
+                "maxWorldPositionError": reduction.max_world_position_error,
+                "maxWorldRotationErrorRadians": reduction.max_world_rotation_error_radians,
+                "maxMorphWeightError": reduction.max_morph_weight_error,
+            });
+        }
         println!("{}", serde_json::to_string_pretty(&report)?);
     } else {
         let physics_bake_text = if convert_options.physics_bake {
@@ -312,6 +368,20 @@ impl mmd_anim_format::fbx::FbxPoseSource for PhysicsBakePoseSource<'_> {
         }
         Ok(self.runtime.world_matrices())
     }
+
+    fn morph_weights(&self) -> Option<&[f32]> {
+        Some(self.runtime.morph_weights())
+    }
+}
+
+fn pose_reduction_tolerances(options: &ConvertFbxOptions) -> mmd_anim_runtime::ReductionTolerances {
+    mmd_anim_runtime::ReductionTolerances {
+        local_position: options.pose_position_tolerance,
+        local_rotation_radians: options.pose_rotation_tolerance,
+        world_position: options.pose_position_tolerance,
+        world_rotation_radians: options.pose_rotation_tolerance,
+        morph_weight: options.pose_morph_tolerance,
+    }
 }
 
 #[cfg(feature = "physics-bullet-native")]
@@ -338,6 +408,33 @@ fn export_fbx_with_physics_bake(
     Ok(bytes)
 }
 
+#[cfg(feature = "physics-bullet-native")]
+fn export_reduced_fbx_with_physics_bake(
+    model: &mmd_anim_format::PmxParsedModel,
+    runtime_model: Arc<mmd_anim_runtime::ModelArena>,
+    clip: &mmd_anim_runtime::AnimationClip,
+    last_frame: u32,
+    options: &mmd_anim_format::fbx::FbxExportOptions,
+    tolerances: mmd_anim_runtime::ReductionTolerances,
+) -> Result<mmd_anim_format::fbx::FbxReducedPoseExport, Box<dyn std::error::Error>> {
+    let mut pose_source = PhysicsBakePoseSource {
+        runtime: mmd_anim_runtime::RuntimeInstance::new(Arc::clone(&runtime_model)),
+        bullet: mmd_anim_physics_bullet::build_bullet_world_from_pmx(model)?,
+        clip,
+    };
+    Ok(
+        mmd_anim_format::fbx::export_pmx_fbx_binary_with_reduced_pose_source(
+            model,
+            runtime_model,
+            last_frame,
+            0,
+            tolerances,
+            options,
+            &mut pose_source,
+        )?,
+    )
+}
+
 #[cfg(not(feature = "physics-bullet-native"))]
 fn export_fbx_with_physics_bake(
     _model: &mmd_anim_format::PmxParsedModel,
@@ -346,6 +443,18 @@ fn export_fbx_with_physics_bake(
     _last_frame: u32,
     _options: &mmd_anim_format::fbx::FbxExportOptions,
 ) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+    Err("convert-fbx --physics-bake requires the physics-bullet-native feature".into())
+}
+
+#[cfg(not(feature = "physics-bullet-native"))]
+fn export_reduced_fbx_with_physics_bake(
+    _model: &mmd_anim_format::PmxParsedModel,
+    _runtime_model: Arc<mmd_anim_runtime::ModelArena>,
+    _clip: &mmd_anim_runtime::AnimationClip,
+    _last_frame: u32,
+    _options: &mmd_anim_format::fbx::FbxExportOptions,
+    _tolerances: mmd_anim_runtime::ReductionTolerances,
+) -> Result<mmd_anim_format::fbx::FbxReducedPoseExport, Box<dyn std::error::Error>> {
     Err("convert-fbx --physics-bake requires the physics-bullet-native feature".into())
 }
 
@@ -803,6 +912,7 @@ mod tests {
             vmd: Some(Path::new("motion.vmd")),
             bones_only: true,
             physics_bake: false,
+            pose_reduced: false,
             readable_bone_names: false,
             bone_name_map: None,
             physics_params: None,
@@ -845,6 +955,7 @@ mod tests {
             vmd: Some(Path::new("motion.vmd")),
             bones_only: false,
             physics_bake: true,
+            pose_reduced: false,
             readable_bone_names: false,
             bone_name_map: None,
             physics_params: None,
@@ -871,6 +982,10 @@ mod tests {
                 copy_diffuse_textures: false,
                 bones_only: false,
                 physics_bake: true,
+                reduce_pose: false,
+                pose_position_tolerance: 0.1,
+                pose_rotation_tolerance: 0.05,
+                pose_morph_tolerance: 0.001,
                 readable_bone_names: false,
                 write_physics_params: false,
                 use_json: false,
@@ -902,6 +1017,7 @@ mod tests {
             vmd: None,
             bones_only: false,
             physics_bake: false,
+            pose_reduced: false,
             readable_bone_names: true,
             bone_name_map: Some(Path::new("model.bone-map.json")),
             physics_params: None,
@@ -935,6 +1051,7 @@ mod tests {
             vmd: None,
             bones_only: false,
             physics_bake: false,
+            pose_reduced: false,
             readable_bone_names: false,
             bone_name_map: None,
             physics_params: Some(Path::new("model.physics-params.json")),

--- a/crates/mmd-anim-cli/src/commands/fbx.rs
+++ b/crates/mmd-anim-cli/src/commands/fbx.rs
@@ -294,6 +294,12 @@ pub(crate) fn convert_pmx_to_fbx(
             report["poseReduction"]["workStats"] = json!({
                 "globalValidationPasses": work.global_validation_passes,
                 "candidateRebuilds": work.candidate_rebuilds,
+                "localPrefitBoneSegmentFits": work.local_prefit_bone_segment_fits,
+                "localPrefitMorphSegmentFits": work.local_prefit_morph_segment_fits,
+                "localPrefitBoneKeyAdditions": work.local_prefit_bone_key_additions,
+                "localPrefitMorphKeyAdditions": work.local_prefit_morph_key_additions,
+                "localPrefitBoneSamples": work.local_prefit_bone_samples,
+                "localPrefitMorphSamples": work.local_prefit_morph_samples,
                 "dccBoneSegmentFits": work.dcc_bone_segment_fits,
                 "dccMorphSegmentFits": work.dcc_morph_segment_fits,
                 "boneSamples": work.bone_samples,
@@ -307,6 +313,7 @@ pub(crate) fn convert_pmx_to_fbx(
         }
         if let Some(timings) = reduction_timings {
             report["poseReduction"]["timingsMs"] = json!({
+                "localPrefit": timings.local_prefit.as_secs_f64() * 1000.0,
                 "candidateBuild": timings.candidate_build.as_secs_f64() * 1000.0,
                 "errorMeasure": timings.error_measure.as_secs_f64() * 1000.0,
                 "dccFit": timings.dcc_fit.as_secs_f64() * 1000.0,

--- a/crates/mmd-anim-cli/src/commands/fbx.rs
+++ b/crates/mmd-anim-cli/src/commands/fbx.rs
@@ -150,6 +150,8 @@ pub(crate) fn convert_pmx_to_fbx(
 
     let mut baked_max_frame = None;
     let mut reduction_report = None;
+    let mut reduction_work_stats = None;
+    let mut reduction_timings = None;
     let fbx = if let Some(vmd_path) = vmd {
         let motion_data = read_file(vmd_path)?;
         let motion = mmd_anim_format::parse_vmd_animation(&motion_data).map_err(|error| {
@@ -215,6 +217,8 @@ pub(crate) fn convert_pmx_to_fbx(
                 pose_reduction_tolerances(&convert_options),
             )?;
             reduction_report = Some(export.report);
+            reduction_work_stats = Some(export.work_stats);
+            reduction_timings = Some(export.timings);
             export.bytes
         } else if convert_options.physics_bake {
             export_fbx_with_physics_bake(&model, runtime_model, &clip, last_frame, &options)?
@@ -228,6 +232,8 @@ pub(crate) fn convert_pmx_to_fbx(
                 &options,
             )?;
             reduction_report = Some(export.report);
+            reduction_work_stats = Some(export.work_stats);
+            reduction_timings = Some(export.timings);
             export.bytes
         } else {
             mmd_anim_format::fbx::export_fbx_with_runtime_bake(
@@ -282,6 +288,28 @@ pub(crate) fn convert_pmx_to_fbx(
                 "maxWorldPositionError": reduction.max_world_position_error,
                 "maxWorldRotationErrorRadians": reduction.max_world_rotation_error_radians,
                 "maxMorphWeightError": reduction.max_morph_weight_error,
+            });
+        }
+        if let Some(work) = reduction_work_stats {
+            report["poseReduction"]["workStats"] = json!({
+                "globalValidationPasses": work.global_validation_passes,
+                "candidateRebuilds": work.candidate_rebuilds,
+                "dccBoneSegmentFits": work.dcc_bone_segment_fits,
+                "dccMorphSegmentFits": work.dcc_morph_segment_fits,
+                "boneSamples": work.bone_samples,
+                "morphSamples": work.morph_samples,
+                "worldRebuilds": work.world_rebuilds,
+                "worldRotationDecompositions": work.world_rotation_decompositions,
+                "normalKeyAdditions": work.normal_key_additions,
+                "ancestorKeyAdditions": work.ancestor_key_additions,
+                "addedKeysPerPass": work.added_keys_per_pass,
+            });
+        }
+        if let Some(timings) = reduction_timings {
+            report["poseReduction"]["timingsMs"] = json!({
+                "candidateBuild": timings.candidate_build.as_secs_f64() * 1000.0,
+                "errorMeasure": timings.error_measure.as_secs_f64() * 1000.0,
+                "dccFit": timings.dcc_fit.as_secs_f64() * 1000.0,
             });
         }
         println!("{}", serde_json::to_string_pretty(&report)?);

--- a/crates/mmd-anim-cli/src/commands/fbx_skin_diff.rs
+++ b/crates/mmd-anim-cli/src/commands/fbx_skin_diff.rs
@@ -69,7 +69,14 @@ pub(crate) fn diff_fbx_skin(
         );
         println!("{}", serde_json::to_string(&value)?);
     } else {
-        print_diff_report_text(path_a, path_b, clusters_a.len(), clusters_b.len(), &options, &report);
+        print_diff_report_text(
+            path_a,
+            path_b,
+            clusters_a.len(),
+            clusters_b.len(),
+            &options,
+            &report,
+        );
     }
 
     if difference_count == 0 {
@@ -183,11 +190,7 @@ fn diff_report_json(
     options: &DiffFbxSkinOptions,
     report: &FbxSkinDiffReport,
 ) -> serde_json::Value {
-    let bones = report
-        .bones
-        .iter()
-        .map(bone_diff_json)
-        .collect::<Vec<_>>();
+    let bones = report.bones.iter().map(bone_diff_json).collect::<Vec<_>>();
     json!({
         "status": if report.difference_count() == 0 { "ok" } else { "diff" },
         "command": "fbx-skin-diff",

--- a/crates/mmd-anim-cli/src/commands/mod.rs
+++ b/crates/mmd-anim-cli/src/commands/mod.rs
@@ -10,4 +10,5 @@ pub(crate) mod parse;
 pub(crate) mod patch;
 pub(crate) mod rig;
 pub(crate) mod skin_check;
+pub(crate) mod vmd_reduce;
 pub(crate) mod vmd_sample;

--- a/crates/mmd-anim-cli/src/commands/skin_check.rs
+++ b/crates/mmd-anim-cli/src/commands/skin_check.rs
@@ -85,7 +85,11 @@ fn bone_name(parsed: &PmxParsedModel, index: u32) -> &str {
         .unwrap_or("<out-of-range>")
 }
 
-fn analyze_skin(parsed: &PmxParsedModel, tolerance: f32, distance_threshold: f32) -> SkinCheckReport {
+fn analyze_skin(
+    parsed: &PmxParsedModel,
+    tolerance: f32,
+    distance_threshold: f32,
+) -> SkinCheckReport {
     let geometry = &parsed.geometry;
     let vertex_count = geometry.positions.len() / 3;
     let modes = &geometry.sdef.skinning_modes;
@@ -195,7 +199,10 @@ impl SkinCheckReport {
             distance_threshold,
         );
 
-        if self.weight_sum.is_empty() && self.duplicate_bone.is_empty() && self.negative_index.is_empty() {
+        if self.weight_sum.is_empty()
+            && self.duplicate_bone.is_empty()
+            && self.negative_index.is_empty()
+        {
             println!("no skin anomalies found");
             return;
         }
@@ -224,7 +231,10 @@ impl SkinCheckReport {
         }
 
         if !self.duplicate_bone.is_empty() {
-            println!("\n[duplicate-bone] ({} vertices)", self.duplicate_bone.len());
+            println!(
+                "\n[duplicate-bone] ({} vertices)",
+                self.duplicate_bone.len()
+            );
             for anomaly in &self.duplicate_bone {
                 let slots_str = anomaly
                     .slots
@@ -365,7 +375,10 @@ mod tests {
         let result = skin_check(Path::new("nonexistent.pmx"), false, -1.0, 1.0);
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
-        assert!(err.contains("tolerance"), "error should mention tolerance: {err}");
+        assert!(
+            err.contains("tolerance"),
+            "error should mention tolerance: {err}"
+        );
     }
 
     #[test]

--- a/crates/mmd-anim-cli/src/commands/vmd_reduce.rs
+++ b/crates/mmd-anim-cli/src/commands/vmd_reduce.rs
@@ -1,0 +1,403 @@
+use std::{collections::HashMap, fs, path::Path, process::ExitCode, sync::Arc};
+
+use glam::{Quat, Vec3A};
+use mmd_anim_format::vmd::{VmdParsedBoneFrame, VmdParsedCounts, VmdParsedMorphFrame};
+use mmd_anim_runtime::{
+    BoneIndex, BoneInit, DensePoseSequenceView, ModelArena, MorphIndex, ReductionTarget,
+    ReductionTolerances, RuntimeInstance, SkeletonSnapshot, reduce_dense_pose_sequence,
+};
+use serde_json::json;
+
+use crate::{parse_failure_error, read_file, write_file};
+
+const MODEL_IDENTITY: u64 = 0x564d_4452;
+
+#[derive(Clone, Copy, Debug, clap::ValueEnum)]
+pub(crate) enum VmdReductionCurveMode {
+    Linear,
+    VmdBezier,
+}
+
+pub(crate) struct ReduceVmdOptions {
+    pub position_tolerance: f32,
+    pub rotation_tolerance: f32,
+    pub morph_tolerance: f32,
+    pub curve_mode: VmdReductionCurveMode,
+    pub max_sampled_frames: usize,
+    pub use_json: bool,
+}
+
+pub(crate) fn reduce_vmd(
+    input: &Path,
+    output: &Path,
+    options: ReduceVmdOptions,
+) -> Result<ExitCode, Box<dyn std::error::Error>> {
+    ensure_distinct_paths(input, output)?;
+    if options.max_sampled_frames == 0 {
+        return Err("reduce-vmd --max-sampled-frames must be greater than zero".into());
+    }
+    let data = read_file(input)?;
+    let mut animation = mmd_anim_format::parse_vmd_animation(&data).map_err(|error| {
+        parse_failure_error(
+            "reduce-vmd",
+            input,
+            mmd_anim_format::MmdFormatKind::Vmd,
+            error,
+        )
+    })?;
+    let mut runtime_import = mmd_anim_format::import_vmd_motion(&data).map_err(|error| {
+        parse_failure_error(
+            "reduce-vmd",
+            input,
+            mmd_anim_format::MmdFormatKind::Vmd,
+            error,
+        )
+    })?;
+    // Property/IK state is preserved verbatim in the output. It must not be
+    // applied to this model-independent, zero-IK sampling runtime.
+    runtime_import.property_keyframes.clear();
+
+    let (bone_names, bone_indices) = unique_bone_names(&animation);
+    let (morph_names, morph_indices) = unique_morph_names(&animation);
+    if bone_indices.is_empty() && morph_indices.is_empty() {
+        return Err("reduce-vmd requires at least one bone or morph keyframe".into());
+    }
+    let runtime_bone_count = bone_names.len().max(1);
+    let clip = mmd_anim_format::build_clip_from_import(
+        runtime_import,
+        &|name| bone_indices.get(name).copied().map(BoneIndex),
+        &|name| morph_indices.get(name).copied().map(MorphIndex),
+    );
+    let model = Arc::new(ModelArena::new(vec![
+        BoneInit::new(None, Vec3A::ZERO);
+        runtime_bone_count
+    ])?);
+    let mut runtime = RuntimeInstance::new_with_morph_count(model.clone(), morph_names.len());
+    let pose_max_frame = animation
+        .bone_frames
+        .iter()
+        .map(|frame| frame.frame)
+        .chain(animation.morph_frames.iter().map(|frame| frame.frame))
+        .max()
+        .unwrap_or(0);
+    let frame_count = usize::try_from(pose_max_frame)?
+        .checked_add(1)
+        .ok_or("reduce-vmd frame count overflow")?;
+    if frame_count > options.max_sampled_frames {
+        return Err(format!(
+            "reduce-vmd requires {frame_count} sampled frames, exceeding --max-sampled-frames {}",
+            options.max_sampled_frames
+        )
+        .into());
+    }
+    let world_capacity = frame_count
+        .checked_mul(runtime_bone_count)
+        .ok_or("reduce-vmd world sample capacity overflow")?;
+    let morph_capacity = frame_count
+        .checked_mul(morph_names.len())
+        .ok_or("reduce-vmd morph sample capacity overflow")?;
+    let mut world = Vec::with_capacity(world_capacity);
+    let mut morphs = Vec::with_capacity(morph_capacity);
+    for frame in 0..=pose_max_frame {
+        runtime.evaluate_clip_frame_without_ik(&clip, frame as f32);
+        world.extend_from_slice(runtime.pose().world_matrices());
+        morphs.extend_from_slice(runtime.pose().morph_weights());
+    }
+
+    let tolerances = ReductionTolerances {
+        local_position: options.position_tolerance,
+        local_rotation_radians: options.rotation_tolerance,
+        world_position: options.position_tolerance,
+        world_rotation_radians: options.rotation_tolerance,
+        morph_weight: options.morph_tolerance,
+    };
+    let snapshot = SkeletonSnapshot::new(
+        vec![-1; runtime_bone_count],
+        vec![Vec3A::ZERO; runtime_bone_count],
+        vec![Quat::IDENTITY; runtime_bone_count],
+        morph_names.len(),
+        MODEL_IDENTITY,
+    )?;
+    let target = match options.curve_mode {
+        VmdReductionCurveMode::Linear => ReductionTarget::LinearSlerp,
+        VmdReductionCurveMode::VmdBezier => {
+            eprintln!(
+                "warning: reduce-vmd --curve-mode vmd-bezier performs an expensive quantized control-point search"
+            );
+            ReductionTarget::VmdBezier
+        }
+    };
+    let reduced = reduce_dense_pose_sequence(
+        DensePoseSequenceView::new(
+            &world,
+            &morphs,
+            frame_count,
+            runtime_bone_count,
+            morph_names.len(),
+            0.0,
+            1.0,
+        )?,
+        snapshot,
+        tolerances,
+        target,
+    )?;
+    let report = reduced.report();
+    let source_bone_keys = animation.bone_frames.len();
+    let source_morph_keys = animation.morph_frames.len();
+    animation.bone_frames = prefer_smaller_bone_tracks(
+        &animation.bone_frames,
+        reduced_bone_frames(&reduced, &bone_names),
+    );
+    animation.morph_frames = prefer_smaller_morph_tracks(
+        &animation.morph_frames,
+        reduced_morph_frames(&reduced, &morph_names),
+    );
+    animation.metadata.counts = VmdParsedCounts {
+        bones: animation.bone_frames.len(),
+        morphs: animation.morph_frames.len(),
+        cameras: animation.camera_frames.len(),
+        lights: animation.light_frames.len(),
+        self_shadows: animation.self_shadow_frames.len(),
+        properties: animation.property_frames.len(),
+    };
+    let reduced_bone_keys = animation.bone_frames.len();
+    let reduced_morph_keys = animation.morph_frames.len();
+    let bytes = mmd_anim_format::export_vmd_animation(&animation);
+    mmd_anim_format::parse_vmd_animation(&bytes).map_err(|error| {
+        parse_failure_error(
+            "reduce-vmd output validation",
+            output,
+            mmd_anim_format::MmdFormatKind::Vmd,
+            error,
+        )
+    })?;
+    write_file(output, &bytes)?;
+
+    let value = json!({
+        "status": "ok",
+        "command": "reduce-vmd",
+        "curveMode": match options.curve_mode {
+            VmdReductionCurveMode::Linear => "linear",
+            VmdReductionCurveMode::VmdBezier => "vmd-bezier",
+        },
+        "input": input.display().to_string(),
+        "output": output.display().to_string(),
+        "bytesIn": data.len(),
+        "bytesOut": bytes.len(),
+        "maxFrame": animation.metadata.max_frame,
+        "sourceBoneKeys": source_bone_keys,
+        "reducedBoneKeys": reduced_bone_keys,
+        "sourceMorphKeys": source_morph_keys,
+        "reducedMorphKeys": reduced_morph_keys,
+        "maxLocalPositionError": report.max_local_position_error,
+        "maxLocalRotationErrorRadians": report.max_local_rotation_error_radians,
+        "maxMorphWeightError": report.max_morph_weight_error,
+        "preservedCameraKeys": animation.camera_frames.len(),
+        "preservedLightKeys": animation.light_frames.len(),
+        "preservedSelfShadowKeys": animation.self_shadow_frames.len(),
+        "preservedPropertyKeys": animation.property_frames.len(),
+    });
+    if options.use_json {
+        println!("{}", serde_json::to_string_pretty(&value)?);
+    } else {
+        println!(
+            "VMD reduced: boneKeys={source_bone_keys}->{reduced_bone_keys} morphKeys={source_morph_keys}->{reduced_morph_keys} bytes={}->{} maxFrame={}",
+            data.len(),
+            bytes.len(),
+            animation.metadata.max_frame
+        );
+    }
+    Ok(ExitCode::SUCCESS)
+}
+
+fn ensure_distinct_paths(input: &Path, output: &Path) -> Result<(), Box<dyn std::error::Error>> {
+    let input = fs::canonicalize(input)?;
+    let output = if output.exists() {
+        fs::canonicalize(output)?
+    } else {
+        let parent = output.parent().filter(|path| !path.as_os_str().is_empty());
+        let parent = fs::canonicalize(parent.unwrap_or(Path::new(".")))?;
+        let file_name = output
+            .file_name()
+            .ok_or("reduce-vmd output must have a file name")?;
+        parent.join(file_name)
+    };
+    #[cfg(windows)]
+    let same = input
+        .to_string_lossy()
+        .eq_ignore_ascii_case(&output.to_string_lossy());
+    #[cfg(not(windows))]
+    let same = input == output;
+    if same {
+        Err("reduce-vmd input and output must be different files".into())
+    } else {
+        Ok(())
+    }
+}
+
+fn reduced_bone_frames(
+    reduced: &mmd_anim_runtime::ReducedPoseSequence,
+    names: &[mmd_anim_format::VmdExportName],
+) -> Vec<VmdParsedBoneFrame> {
+    let mut frames = Vec::new();
+    for (bone, track) in reduced.bone_tracks().iter().enumerate().take(names.len()) {
+        for key in track.keys() {
+            frames.push(VmdParsedBoneFrame {
+                bone_name: names[bone].text.clone(),
+                bone_name_bytes: names[bone].bytes.clone(),
+                frame: key.sample_index as u32,
+                translation: key.translation.to_array(),
+                rotation: key.rotation.to_array(),
+                interpolation: vmd_interpolation_block(key.vmd_interpolation).to_vec(),
+            });
+        }
+    }
+    frames.sort_by(|a, b| (a.frame, &a.bone_name_bytes).cmp(&(b.frame, &b.bone_name_bytes)));
+    frames
+}
+
+fn reduced_morph_frames(
+    reduced: &mmd_anim_runtime::ReducedPoseSequence,
+    names: &[mmd_anim_format::VmdExportName],
+) -> Vec<VmdParsedMorphFrame> {
+    let mut frames = Vec::new();
+    for (morph, track) in reduced.morph_tracks().iter().enumerate() {
+        for key in track.keys() {
+            frames.push(VmdParsedMorphFrame {
+                morph_name: names[morph].text.clone(),
+                morph_name_bytes: names[morph].bytes.clone(),
+                frame: key.sample_index as u32,
+                weight: key.weight,
+            });
+        }
+    }
+    frames.sort_by(|a, b| (a.frame, &a.morph_name_bytes).cmp(&(b.frame, &b.morph_name_bytes)));
+    frames
+}
+
+fn prefer_smaller_bone_tracks(
+    source: &[VmdParsedBoneFrame],
+    candidate: Vec<VmdParsedBoneFrame>,
+) -> Vec<VmdParsedBoneFrame> {
+    let mut source_tracks: HashMap<Vec<u8>, Vec<VmdParsedBoneFrame>> = HashMap::new();
+    let mut candidate_tracks: HashMap<Vec<u8>, Vec<VmdParsedBoneFrame>> = HashMap::new();
+    for frame in source {
+        source_tracks
+            .entry(mmd_anim_format::normalize_vmd_name(&frame.bone_name_bytes))
+            .or_default()
+            .push(frame.clone());
+    }
+    for frame in candidate {
+        candidate_tracks
+            .entry(mmd_anim_format::normalize_vmd_name(&frame.bone_name_bytes))
+            .or_default()
+            .push(frame);
+    }
+    let mut frames = Vec::new();
+    for (name, source_track) in source_tracks {
+        let candidate_track = candidate_tracks.remove(&name).unwrap_or_default();
+        if candidate_track.len() < source_track.len() {
+            frames.extend(candidate_track);
+        } else {
+            frames.extend(source_track);
+        }
+    }
+    frames.sort_by(|a, b| (a.frame, &a.bone_name_bytes).cmp(&(b.frame, &b.bone_name_bytes)));
+    frames
+}
+
+fn prefer_smaller_morph_tracks(
+    source: &[VmdParsedMorphFrame],
+    candidate: Vec<VmdParsedMorphFrame>,
+) -> Vec<VmdParsedMorphFrame> {
+    let mut source_tracks: HashMap<Vec<u8>, Vec<VmdParsedMorphFrame>> = HashMap::new();
+    let mut candidate_tracks: HashMap<Vec<u8>, Vec<VmdParsedMorphFrame>> = HashMap::new();
+    for frame in source {
+        source_tracks
+            .entry(mmd_anim_format::normalize_vmd_name(&frame.morph_name_bytes))
+            .or_default()
+            .push(frame.clone());
+    }
+    for frame in candidate {
+        candidate_tracks
+            .entry(mmd_anim_format::normalize_vmd_name(&frame.morph_name_bytes))
+            .or_default()
+            .push(frame);
+    }
+    let mut frames = Vec::new();
+    for (name, source_track) in source_tracks {
+        let candidate_track = candidate_tracks.remove(&name).unwrap_or_default();
+        if candidate_track.len() < source_track.len() {
+            frames.extend(candidate_track);
+        } else {
+            frames.extend(source_track);
+        }
+    }
+    frames.sort_by(|a, b| (a.frame, &a.morph_name_bytes).cmp(&(b.frame, &b.morph_name_bytes)));
+    frames
+}
+
+fn vmd_interpolation_block(curves: mmd_anim_runtime::VmdBoneInterpolation) -> [u8; 64] {
+    let curves = [
+        curves.translation[0],
+        curves.translation[1],
+        curves.translation[2],
+        curves.rotation,
+    ];
+    let mut first = [0u8; 16];
+    for (channel, curve) in curves.into_iter().enumerate() {
+        first[channel] = curve.x1.min(127);
+        first[4 + channel] = curve.y1.min(127);
+        first[8 + channel] = curve.x2.min(127);
+        first[12 + channel] = curve.y2.min(127);
+    }
+    let mut block = [0u8; 64];
+    for chunk in block.chunks_exact_mut(16) {
+        chunk.copy_from_slice(&first);
+    }
+    block
+}
+
+fn unique_bone_names(
+    animation: &mmd_anim_format::VmdParsedAnimation,
+) -> (Vec<mmd_anim_format::VmdExportName>, HashMap<Vec<u8>, u32>) {
+    let mut names = Vec::new();
+    let mut indices = HashMap::new();
+    for frame in &animation.bone_frames {
+        let normalized = mmd_anim_format::normalize_vmd_name(&frame.bone_name_bytes);
+        if let std::collections::hash_map::Entry::Vacant(entry) = indices.entry(normalized) {
+            let index = names.len() as u32;
+            entry.insert(index);
+            names.push(mmd_anim_format::VmdExportName::new(
+                frame.bone_name.clone(),
+                frame.bone_name_bytes.clone(),
+            ));
+        }
+    }
+    if names.is_empty() {
+        names.push(mmd_anim_format::VmdExportName::new("", Vec::new()));
+    }
+    (names, indices)
+}
+
+fn unique_morph_names(
+    animation: &mmd_anim_format::VmdParsedAnimation,
+) -> (Vec<mmd_anim_format::VmdExportName>, HashMap<Vec<u8>, u32>) {
+    let mut names = Vec::new();
+    let mut indices = HashMap::new();
+    for frame in &animation.morph_frames {
+        let normalized = mmd_anim_format::normalize_vmd_name(&frame.morph_name_bytes);
+        if let std::collections::hash_map::Entry::Vacant(entry) = indices.entry(normalized) {
+            let index = names.len() as u32;
+            entry.insert(index);
+            names.push(mmd_anim_format::VmdExportName::new(
+                frame.morph_name.clone(),
+                frame.morph_name_bytes.clone(),
+            ));
+        }
+    }
+    (names, indices)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/mmd-anim-cli/src/commands/vmd_reduce/tests.rs
+++ b/crates/mmd-anim-cli/src/commands/vmd_reduce/tests.rs
@@ -1,0 +1,50 @@
+use super::*;
+
+fn bone_frame(frame: u32) -> VmdParsedBoneFrame {
+    VmdParsedBoneFrame {
+        bone_name: "bone".to_owned(),
+        bone_name_bytes: b"bone".to_vec(),
+        frame,
+        translation: [frame as f32, 0.0, 0.0],
+        rotation: [0.0, 0.0, 0.0, 1.0],
+        interpolation: vmd_interpolation_block(mmd_anim_runtime::VmdBoneInterpolation::LINEAR)
+            .to_vec(),
+    }
+}
+
+#[test]
+fn track_gate_uses_candidate_only_when_it_is_strictly_smaller() {
+    let source = vec![bone_frame(0), bone_frame(1), bone_frame(2)];
+    let smaller = prefer_smaller_bone_tracks(&source, vec![bone_frame(0), bone_frame(2)]);
+    assert_eq!(smaller.len(), 2);
+    let mut equal_candidate = source.clone();
+    equal_candidate[1].translation = [99.0, 0.0, 0.0];
+    let equal = prefer_smaller_bone_tracks(&source, equal_candidate);
+    assert_eq!(equal.len(), source.len());
+    assert_eq!(equal[1].translation, source[1].translation);
+}
+
+#[test]
+fn linear_interpolation_is_repeated_in_all_vmd_blocks() {
+    let block = vmd_interpolation_block(mmd_anim_runtime::VmdBoneInterpolation::LINEAR);
+    for chunk in block.chunks_exact(16) {
+        assert_eq!(chunk, &block[..16]);
+    }
+    assert_eq!(&block[..4], &[20, 20, 20, 20]);
+    assert_eq!(&block[8..12], &[107, 107, 107, 107]);
+}
+
+#[test]
+fn rejects_the_same_file_through_an_alias_path() {
+    let unique = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let dir = std::env::temp_dir().join(format!("mmd-anim-reduce-vmd-{unique}"));
+    std::fs::create_dir_all(&dir).unwrap();
+    let input = dir.join("motion.vmd");
+    std::fs::write(&input, b"fixture").unwrap();
+    let alias = dir.join(".").join("motion.vmd");
+    assert!(ensure_distinct_paths(&input, &alias).is_err());
+    std::fs::remove_dir_all(&dir).unwrap();
+}

--- a/crates/mmd-anim-cli/src/main.rs
+++ b/crates/mmd-anim-cli/src/main.rs
@@ -272,6 +272,37 @@ enum Commands {
         json: bool,
     },
 
+    /// Reduce dense VMD bone and morph tracks into sparse linear VMD curves.
+    #[command(
+        name = "reduce-vmd",
+        long_about = "Reduce dense VMD bone and morph keyframes into sparse linear/slerp curves while preserving camera, light, self-shadow, and property tracks.\nThe reducer samples integer VMD frames and validates local position, rotation, and morph errors before writing the sparse VMD.",
+        after_help = "Examples:\n  mmd-anim reduce-vmd dense.vmd sparse.vmd\n  mmd-anim reduce-vmd dense.vmd sparse.vmd --position-tolerance 0.001 --rotation-tolerance 0.001 --morph-tolerance 0.001 --json"
+    )]
+    ReduceVmd {
+        /// Path to the dense input VMD file
+        input: PathBuf,
+        /// Path to the reduced output VMD file
+        output: PathBuf,
+        /// Maximum local translation error in MMD units
+        #[arg(long, default_value_t = 1.0e-4)]
+        position_tolerance: f32,
+        /// Maximum local rotation error in radians
+        #[arg(long, default_value_t = 1.0e-4)]
+        rotation_tolerance: f32,
+        /// Maximum morph weight error
+        #[arg(long, default_value_t = 1.0e-4)]
+        morph_tolerance: f32,
+        /// Curve fitting mode; vmd-bezier is substantially slower
+        #[arg(long, value_enum, default_value = "linear")]
+        curve_mode: commands::vmd_reduce::VmdReductionCurveMode,
+        /// Refuse motions requiring more sampled frames unless explicitly raised
+        #[arg(long, default_value_t = 100_000)]
+        max_sampled_frames: usize,
+        /// Output reduction report as JSON
+        #[arg(long)]
+        json: bool,
+    },
+
     /// Build a PMM scene from a model and motion.
     #[command(
         name = "build-pmm",
@@ -539,6 +570,27 @@ fn main() -> ExitCode {
             from_json,
             json,
         }) => dispatch_export(&input, &output, from_json, json),
+        Some(Commands::ReduceVmd {
+            input,
+            output,
+            position_tolerance,
+            rotation_tolerance,
+            morph_tolerance,
+            curve_mode,
+            max_sampled_frames,
+            json,
+        }) => commands::vmd_reduce::reduce_vmd(
+            &input,
+            &output,
+            commands::vmd_reduce::ReduceVmdOptions {
+                position_tolerance,
+                rotation_tolerance,
+                morph_tolerance,
+                curve_mode,
+                max_sampled_frames,
+                use_json: json,
+            },
+        ),
         Some(Commands::BuildPmm {
             model,
             motion,

--- a/crates/mmd-anim-cli/src/main.rs
+++ b/crates/mmd-anim-cli/src/main.rs
@@ -310,6 +310,18 @@ enum Commands {
         /// Bake native Bullet physics into the exported bone animation (requires --vmd)
         #[arg(long, requires = "vmd")]
         physics_bake: bool,
+        /// Reduce the final baked pose into sparse DCC cubic curves before FBX export
+        #[arg(long, requires = "vmd")]
+        reduce_pose: bool,
+        /// Local/world position error limit used by --reduce-pose
+        #[arg(long, requires = "reduce_pose", default_value_t = 0.1)]
+        pose_position_tolerance: f32,
+        /// Local/world rotation error limit in radians used by --reduce-pose
+        #[arg(long, requires = "reduce_pose", default_value_t = 0.05)]
+        pose_rotation_tolerance: f32,
+        /// Morph-weight error limit used by --reduce-pose
+        #[arg(long, requires = "reduce_pose", default_value_t = 0.001)]
+        pose_morph_tolerance: f32,
         /// Copy PMX diffuse textures next to the FBX and rewrite FBX texture paths
         #[arg(long)]
         copy_diffuse_textures: bool,
@@ -539,6 +551,10 @@ fn main() -> ExitCode {
             vmd,
             max_frame,
             physics_bake,
+            reduce_pose,
+            pose_position_tolerance,
+            pose_rotation_tolerance,
+            pose_morph_tolerance,
             copy_diffuse_textures,
             bones_only,
             readable_bone_names,
@@ -551,6 +567,10 @@ fn main() -> ExitCode {
             commands::fbx::ConvertFbxOptions {
                 max_frame,
                 physics_bake,
+                reduce_pose,
+                pose_position_tolerance,
+                pose_rotation_tolerance,
+                pose_morph_tolerance,
                 copy_diffuse_textures,
                 bones_only,
                 readable_bone_names,

--- a/crates/mmd-anim-ffi/Cargo.toml
+++ b/crates/mmd-anim-ffi/Cargo.toml
@@ -18,7 +18,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 glam.workspace = true
 mmd-anim-runtime.workspace = true
-mmd-anim-format = { path = "../mmd-anim-format", version = "0.2.0" }
+mmd-anim-format = { path = "../mmd-anim-format", version = "0.2.0", features = ["fbx"] }
 mmd-anim-physics-bullet = { path = "../mmd-anim-physics-bullet", version = "0.2.0", optional = true, features = ["native", "runtime", "pmx-format"] }
 serde_json.workspace = true
 

--- a/crates/mmd-anim-ffi/include/mmd_runtime.h
+++ b/crates/mmd-anim-ffi/include/mmd_runtime.h
@@ -131,6 +131,19 @@ typedef enum mmd_runtime_reduction_target {
     MMD_RUNTIME_REDUCTION_TARGET_DCC_CUBIC = 2
 } mmd_runtime_reduction_target_t;
 
+typedef enum mmd_runtime_unity_curve_semantic {
+    MMD_RUNTIME_UNITY_CURVE_BONE_LOCAL_TRANSLATION = 0,
+    MMD_RUNTIME_UNITY_CURVE_BONE_LOCAL_EULER = 1,
+    MMD_RUNTIME_UNITY_CURVE_MORPH_WEIGHT = 2
+} mmd_runtime_unity_curve_semantic_t;
+
+typedef enum mmd_runtime_unity_curve_axis {
+    MMD_RUNTIME_UNITY_CURVE_AXIS_X = 0,
+    MMD_RUNTIME_UNITY_CURVE_AXIS_Y = 1,
+    MMD_RUNTIME_UNITY_CURVE_AXIS_Z = 2,
+    MMD_RUNTIME_UNITY_CURVE_AXIS_NONE = 3
+} mmd_runtime_unity_curve_axis_t;
+
 typedef struct mmd_runtime_ffi_reduction_tolerances {
     float local_position;
     float local_rotation_radians;
@@ -150,6 +163,20 @@ typedef struct mmd_runtime_ffi_pose_reduction_report {
     float max_world_rotation_error_radians;
     float max_morph_weight_error;
 } mmd_runtime_ffi_pose_reduction_report_t;
+
+typedef struct mmd_runtime_ffi_unity_curve_descriptor {
+    uint32_t semantic;    /* mmd_runtime_unity_curve_semantic_t */
+    uint32_t target_index; /* bone index or morph index */
+    uint32_t axis;        /* mmd_runtime_unity_curve_axis_t */
+    size_t   key_count;
+} mmd_runtime_ffi_unity_curve_descriptor_t;
+
+typedef struct mmd_runtime_ffi_unity_curve_key {
+    float time_seconds;
+    float value;
+    float in_tangent;
+    float out_tangent;
+} mmd_runtime_ffi_unity_curve_key_t;
 
 typedef enum mmd_runtime_physics_mode {
     MMD_RUNTIME_PHYSICS_MODE_OFF = 0,
@@ -1151,6 +1178,40 @@ size_t mmd_runtime_reduced_pose_morph_count(const mmd_runtime_reduced_pose_t* po
 mmd_runtime_status_t mmd_runtime_reduced_pose_report(
     const mmd_runtime_reduced_pose_t*               pose,
     mmd_runtime_ffi_pose_reduction_report_t*        out_report);
+
+/* Enumerates target-native Unity scalar curves from a DCC_CUBIC reduced pose.
+   Curves are translation XYZ then local Euler XYZ for each bone, followed by
+   one weight curve for each morph. frames_per_second must be finite and > 0;
+   flip_z selects Unity handedness conversion. LINEAR_SLERP and VMD_BEZIER
+   reduced poses return MMD_RUNTIME_STATUS_UNSUPPORTED rather than being
+   silently converted to Hermite curves. The reduced handle owns its skeleton
+   snapshot, so these calls remain valid after the source model is freed. */
+mmd_runtime_status_t mmd_runtime_reduced_pose_unity_curve_count(
+    const mmd_runtime_reduced_pose_t* pose,
+    float                             frames_per_second,
+    bool                              flip_z,
+    size_t*                           out_curve_count);
+
+mmd_runtime_status_t mmd_runtime_reduced_pose_unity_curve_descriptor(
+    const mmd_runtime_reduced_pose_t*             pose,
+    float                                         frames_per_second,
+    bool                                          flip_z,
+    size_t                                        curve_index,
+    mmd_runtime_ffi_unity_curve_descriptor_t*     out_descriptor);
+
+/* Two-call caller-owned retrieval. Pass out_keys = NULL and capacity = 0 to
+   receive MMD_RUNTIME_STATUS_BUFFER_TOO_SMALL plus out_required_count, then
+   allocate that many keys and call again. Any short buffer returns the same
+   status and required count. Euler filtering, degree conversion, and
+   per-second tangent conversion are already applied by Rust. */
+mmd_runtime_status_t mmd_runtime_reduced_pose_unity_curve_keys(
+    const mmd_runtime_reduced_pose_t* pose,
+    float                             frames_per_second,
+    bool                              flip_z,
+    size_t                            curve_index,
+    mmd_runtime_ffi_unity_curve_key_t* out_keys,
+    size_t                            out_key_capacity,
+    size_t*                           out_required_count);
 
 /* Samples [bone][16] column-major world matrices and [morph] weights. */
 mmd_runtime_status_t mmd_runtime_reduced_pose_sample(

--- a/crates/mmd-anim-ffi/include/mmd_runtime.h
+++ b/crates/mmd-anim-ffi/include/mmd_runtime.h
@@ -1213,15 +1213,6 @@ mmd_runtime_status_t mmd_runtime_reduced_pose_unity_curve_keys(
     size_t                            out_key_capacity,
     size_t*                           out_required_count);
 
-/* Samples [bone][16] column-major world matrices and [morph] weights. */
-mmd_runtime_status_t mmd_runtime_reduced_pose_sample(
-    const mmd_runtime_reduced_pose_t* pose,
-    float                             frame,
-    float*                            out_world_matrices_f32,
-    size_t                            out_world_matrices_f32_len,
-    float*                            out_morph_weights_f32,
-    size_t                            out_morph_weights_f32_len);
-
 /* Stateful sequential physics bake.
    After world creation or a successful mmd_runtime_physics_world_reset, the
    first bake sample is seed-only: evaluate_clip_frame_before_physics at that

--- a/crates/mmd-anim-ffi/include/mmd_runtime.h
+++ b/crates/mmd-anim-ffi/include/mmd_runtime.h
@@ -92,6 +92,7 @@ typedef struct mmd_runtime_vmd_camera_track_t mmd_runtime_vmd_camera_track_t;
 typedef struct mmd_runtime_vmd_light_track_t mmd_runtime_vmd_light_track_t;
 typedef struct mmd_runtime_vmd_self_shadow_track_t mmd_runtime_vmd_self_shadow_track_t;
 typedef struct mmd_runtime_physics_world_t mmd_runtime_physics_world_t;
+typedef struct mmd_runtime_reduced_pose_t mmd_runtime_reduced_pose_t;
 
 /* ------------------------------------------------------------------ */
 /*  Flag constants                                                    */
@@ -123,6 +124,32 @@ typedef enum mmd_runtime_status {
     MMD_RUNTIME_STATUS_BUFFER_TOO_SMALL = 3,
     MMD_RUNTIME_STATUS_ERROR = 4
 } mmd_runtime_status_t;
+
+typedef enum mmd_runtime_reduction_target {
+    MMD_RUNTIME_REDUCTION_TARGET_LINEAR_SLERP = 0,
+    MMD_RUNTIME_REDUCTION_TARGET_VMD_BEZIER = 1,
+    MMD_RUNTIME_REDUCTION_TARGET_DCC_CUBIC = 2
+} mmd_runtime_reduction_target_t;
+
+typedef struct mmd_runtime_ffi_reduction_tolerances {
+    float local_position;
+    float local_rotation_radians;
+    float world_position;
+    float world_rotation_radians;
+    float morph_weight;
+} mmd_runtime_ffi_reduction_tolerances_t;
+
+typedef struct mmd_runtime_ffi_pose_reduction_report {
+    size_t source_bone_key_count;
+    size_t reduced_bone_key_count;
+    size_t source_morph_key_count;
+    size_t reduced_morph_key_count;
+    float max_local_position_error;
+    float max_local_rotation_error_radians;
+    float max_world_position_error;
+    float max_world_rotation_error_radians;
+    float max_morph_weight_error;
+} mmd_runtime_ffi_pose_reduction_report_t;
 
 typedef enum mmd_runtime_physics_mode {
     MMD_RUNTIME_PHYSICS_MODE_OFF = 0,
@@ -1100,6 +1127,39 @@ bool mmd_runtime_instance_evaluate_clip_frame_batch(
     size_t                        out_world_matrices_f32_len,
     float*                        out_morph_weights_f32,
     size_t                        out_morph_weights_f32_len);
+
+/* Reduces dense batch output into an owned opaque sparse-pose handle.
+   Dense layouts match evaluate_clip_frame_batch. On failure, *out_reduced_pose
+   is set to NULL. */
+mmd_runtime_status_t mmd_runtime_reduced_pose_create_from_dense(
+    const mmd_runtime_model_t*                     model,
+    uint64_t                                       model_identity,
+    const float*                                   world_matrices_f32,
+    size_t                                         world_matrices_f32_len,
+    const float*                                   morph_weights_f32,
+    size_t                                         morph_weights_f32_len,
+    size_t                                         frame_count,
+    float                                          start_frame,
+    float                                          frame_step,
+    uint32_t                                       target,
+    mmd_runtime_ffi_reduction_tolerances_t         tolerances,
+    mmd_runtime_reduced_pose_t**                   out_reduced_pose);
+
+void mmd_runtime_reduced_pose_free(mmd_runtime_reduced_pose_t* pose);
+size_t mmd_runtime_reduced_pose_bone_count(const mmd_runtime_reduced_pose_t* pose);
+size_t mmd_runtime_reduced_pose_morph_count(const mmd_runtime_reduced_pose_t* pose);
+mmd_runtime_status_t mmd_runtime_reduced_pose_report(
+    const mmd_runtime_reduced_pose_t*               pose,
+    mmd_runtime_ffi_pose_reduction_report_t*        out_report);
+
+/* Samples [bone][16] column-major world matrices and [morph] weights. */
+mmd_runtime_status_t mmd_runtime_reduced_pose_sample(
+    const mmd_runtime_reduced_pose_t* pose,
+    float                             frame,
+    float*                            out_world_matrices_f32,
+    size_t                            out_world_matrices_f32_len,
+    float*                            out_morph_weights_f32,
+    size_t                            out_morph_weights_f32_len);
 
 /* Stateful sequential physics bake.
    After world creation or a successful mmd_runtime_physics_world_reset, the

--- a/crates/mmd-anim-ffi/scripts/smoke.ps1
+++ b/crates/mmd-anim-ffi/scripts/smoke.ps1
@@ -13,7 +13,7 @@ $FfiDir     = Resolve-Path "$PSScriptRoot\.."
 Write-Host "=== mmd-anim-ffi smoke ===" -ForegroundColor Cyan
 
 # --- 1. Build cdylib -------------------------------------------------
-Write-Host "`n[1/3] Building mmd-anim-ffi (release)..." -ForegroundColor Yellow
+Write-Host "`n[1/4] Building mmd-anim-ffi (release)..." -ForegroundColor Yellow
 & cargo build -p mmd-anim-ffi --release
 if ($LASTEXITCODE -ne 0) {
     Write-Host "FAIL: cargo build exited $LASTEXITCODE" -ForegroundColor Red
@@ -22,7 +22,7 @@ if ($LASTEXITCODE -ne 0) {
 Write-Host "  OK" -ForegroundColor Green
 
 # --- 2. Verify cdylib exists -----------------------------------------
-Write-Host "`n[2/3] Locating cdylib..." -ForegroundColor Yellow
+Write-Host "`n[2/4] Locating cdylib..." -ForegroundColor Yellow
 $cdylib = Get-ChildItem -Recurse "$ProjectRoot\target\release" |
     Where-Object { $_.Name -in @("mmd_runtime_ffi.dll", "libmmd_runtime_ffi.so", "libmmd_runtime_ffi.dylib") } |
     Select-Object -First 1
@@ -32,8 +32,17 @@ if (-not $cdylib) {
 }
 Write-Host "  Found: $($cdylib.FullName) ($($cdylib.Length) bytes)" -ForegroundColor Green
 
-# --- 3. Dumpbin symbol check (optional) ------------------------------
-Write-Host "`n[3/3] Cross-referencing exports against header..." -ForegroundColor Yellow
+# --- 3. Deterministic Rust/header drift check ------------------------
+Write-Host "`n[3/4] Checking Rust/header ABI drift..." -ForegroundColor Yellow
+& python "$ProjectRoot\tools\check_ffi_header_symbols.py"
+if ($LASTEXITCODE -ne 0) {
+    Write-Host "FAIL: header drift check exited $LASTEXITCODE" -ForegroundColor Red
+    exit 1
+}
+Write-Host "  OK" -ForegroundColor Green
+
+# --- 4. Dumpbin symbol check (optional) ------------------------------
+Write-Host "`n[4/4] Cross-referencing exports against header..." -ForegroundColor Yellow
 $header = Get-Content "$FfiDir\include\mmd_runtime.h" -Raw
 
 # Expected function export names (no-mangle C symbols from lib.rs)
@@ -74,6 +83,9 @@ $expectedExports = @(
     "mmd_runtime_clip_create_from_vmd_bytes_for_model"
     "mmd_runtime_clip_frame_range"
     "mmd_runtime_clip_free"
+    "mmd_runtime_reduced_pose_unity_curve_count"
+    "mmd_runtime_reduced_pose_unity_curve_descriptor"
+    "mmd_runtime_reduced_pose_unity_curve_keys"
 )
 
 # Check each expected export name appears in the header

--- a/crates/mmd-anim-ffi/scripts/smoke.ps1
+++ b/crates/mmd-anim-ffi/scripts/smoke.ps1
@@ -44,6 +44,10 @@ Write-Host "  OK" -ForegroundColor Green
 # --- 4. Dumpbin symbol check (optional) ------------------------------
 Write-Host "`n[4/4] Cross-referencing exports against header..." -ForegroundColor Yellow
 $header = Get-Content "$FfiDir\include\mmd_runtime.h" -Raw
+if ($header -match "\bmmd_runtime_reduced_pose_sample\b") {
+    Write-Host "  FAIL: dense reduced-pose sampling remains in the public header." -ForegroundColor Red
+    exit 1
+}
 
 # Expected function export names (no-mangle C symbols from lib.rs)
 $expectedExports = @(
@@ -83,6 +87,11 @@ $expectedExports = @(
     "mmd_runtime_clip_create_from_vmd_bytes_for_model"
     "mmd_runtime_clip_frame_range"
     "mmd_runtime_clip_free"
+    "mmd_runtime_reduced_pose_create_from_dense"
+    "mmd_runtime_reduced_pose_free"
+    "mmd_runtime_reduced_pose_bone_count"
+    "mmd_runtime_reduced_pose_morph_count"
+    "mmd_runtime_reduced_pose_report"
     "mmd_runtime_reduced_pose_unity_curve_count"
     "mmd_runtime_reduced_pose_unity_curve_descriptor"
     "mmd_runtime_reduced_pose_unity_curve_keys"
@@ -110,6 +119,10 @@ if (-not $dumpbin) {
 } else {
     Write-Host "  dumpbin found; checking binary exports..." -ForegroundColor Yellow
     $exports = @(& dumpbin /EXPORTS $cdylib.FullName 2>&1 | Where-Object { $_ -match '^\s+\d+\s+\w+\s+\w+\s+(\w+)' } | ForEach-Object { $matches[1] })
+    if ("mmd_runtime_reduced_pose_sample" -in $exports) {
+        Write-Host "  FAIL: dense reduced-pose sampling remains in the binary exports." -ForegroundColor Red
+        exit 1
+    }
     $missingFromBinary = $expectedExports | Where-Object { $_ -notin $exports }
     if ($missingFromBinary.Count -gt 0) {
         Write-Host "  FAIL: $($missingFromBinary.Count) export(s) missing from binary:" -ForegroundColor Red

--- a/crates/mmd-anim-ffi/src/lib.rs
+++ b/crates/mmd-anim-ffi/src/lib.rs
@@ -9,14 +9,16 @@ use std::{ptr, slice, str, sync::Arc};
 
 use mmd_anim_runtime::ModelArena;
 use mmd_anim_runtime::{
-    AnimationClip, AppendPrimitiveInput, BoneAnimationBinding, BoneIndex, FlatAppendTransformInput,
-    FlatBoneInput, FlatBoneMorphInput, FlatGroupMorphInput, FlatIkLinkInput, FlatIkSolverInput,
-    HostPoseView, IkAngleLimit, IkChainDefinition, IkChainLinkDefinition, IkChainPoseInput,
-    IkChainSolver, IkSolveOptions, MorphAnimationBinding, MorphIndex, MorphInit, MorphKeyframe,
-    MorphTrack, MovableBoneKeyframe, MovableBoneTrack, PhysicsMode, PhysicsStepStats,
-    PhysicsTickConfig, PropertyAnimationBinding, PropertyKeyframe, RuntimeInstance,
-    build_append_transforms_from_flat_iter, build_bones_from_flat, build_ik_solvers_from_flat_iter,
-    build_morph_init_from_flat_iter, solve_append_transform,
+    AnimationClip, AppendPrimitiveInput, BoneAnimationBinding, BoneIndex, DensePoseSequenceView,
+    FlatAppendTransformInput, FlatBoneInput, FlatBoneMorphInput, FlatGroupMorphInput,
+    FlatIkLinkInput, FlatIkSolverInput, HostPoseView, IkAngleLimit, IkChainDefinition,
+    IkChainLinkDefinition, IkChainPoseInput, IkChainSolver, IkSolveOptions, MorphAnimationBinding,
+    MorphIndex, MorphInit, MorphKeyframe, MorphTrack, MovableBoneKeyframe, MovableBoneTrack,
+    PhysicsMode, PhysicsStepStats, PhysicsTickConfig, PoseReductionReport,
+    PropertyAnimationBinding, PropertyKeyframe, ReducedPoseSequence, ReductionTarget,
+    ReductionTolerances, RuntimeInstance, SkeletonSnapshot, build_append_transforms_from_flat_iter,
+    build_bones_from_flat, build_ik_solvers_from_flat_iter, build_morph_init_from_flat_iter,
+    solve_append_transform,
 };
 
 pub const ABI_VERSION: u32 = 2;
@@ -68,6 +70,10 @@ fn flatten_matrices_into_slice(dst: &mut [f32], matrices: &[glam::Mat4]) {
 
 pub struct MmdRuntimeClip {
     clip: AnimationClip,
+}
+
+pub struct MmdRuntimeReducedPose {
+    sequence: ReducedPoseSequence,
 }
 
 pub struct MmdRuntimeVmdCameraTrack {
@@ -245,6 +251,30 @@ pub struct MmdRuntimeFfiGroupMorphOffset {
 pub struct MmdRuntimeFfiByteBuffer {
     pub data: *mut u8,
     pub len: usize,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct MmdRuntimeFfiReductionTolerances {
+    pub local_position: f32,
+    pub local_rotation_radians: f32,
+    pub world_position: f32,
+    pub world_rotation_radians: f32,
+    pub morph_weight: f32,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct MmdRuntimeFfiPoseReductionReport {
+    pub source_bone_key_count: usize,
+    pub reduced_bone_key_count: usize,
+    pub source_morph_key_count: usize,
+    pub reduced_morph_key_count: usize,
+    pub max_local_position_error: f32,
+    pub max_local_rotation_error_radians: f32,
+    pub max_world_position_error: f32,
+    pub max_world_rotation_error_radians: f32,
+    pub max_morph_weight_error: f32,
 }
 
 #[repr(C)]
@@ -5194,6 +5224,266 @@ pub unsafe extern "C" fn mmd_runtime_instance_evaluate_clip_frame_batch(
             }
             true
         })
+    })
+}
+
+fn reduction_target_from_u32(value: u32) -> Option<ReductionTarget> {
+    match value {
+        0 => Some(ReductionTarget::LinearSlerp),
+        1 => Some(ReductionTarget::VmdBezier),
+        2 => Some(ReductionTarget::DccCubic),
+        _ => None,
+    }
+}
+
+fn ffi_reduction_report(report: PoseReductionReport) -> MmdRuntimeFfiPoseReductionReport {
+    MmdRuntimeFfiPoseReductionReport {
+        source_bone_key_count: report.source_bone_key_count,
+        reduced_bone_key_count: report.reduced_bone_key_count,
+        source_morph_key_count: report.source_morph_key_count,
+        reduced_morph_key_count: report.reduced_morph_key_count,
+        max_local_position_error: report.max_local_position_error,
+        max_local_rotation_error_radians: report.max_local_rotation_error_radians,
+        max_world_position_error: report.max_world_position_error,
+        max_world_rotation_error_radians: report.max_world_rotation_error_radians,
+        max_morph_weight_error: report.max_morph_weight_error,
+    }
+}
+
+/// Reduces caller-owned dense batch output into an opaque sparse pose handle.
+///
+/// `world_matrices_f32` uses `[frame][bone][16]` column-major layout and
+/// `morph_weights_f32` uses `[frame][morph]`. The model supplies the immutable
+/// skeleton snapshot. On failure `*out_reduced_pose` is set to null.
+///
+/// # Safety
+///
+/// All non-empty input regions must be readable for their declared lengths.
+/// `out_reduced_pose` must point to writable handle storage. The returned
+/// handle must be released with `mmd_runtime_reduced_pose_free`.
+#[unsafe(no_mangle)]
+#[allow(clippy::too_many_arguments)]
+pub unsafe extern "C" fn mmd_runtime_reduced_pose_create_from_dense(
+    model: *const MmdRuntimeModel,
+    model_identity: u64,
+    world_matrices_f32: *const f32,
+    world_matrices_f32_len: usize,
+    morph_weights_f32: *const f32,
+    morph_weights_f32_len: usize,
+    frame_count: usize,
+    start_frame: f32,
+    frame_step: f32,
+    target: u32,
+    tolerances: MmdRuntimeFfiReductionTolerances,
+    out_reduced_pose: *mut *mut MmdRuntimeReducedPose,
+) -> MmdRuntimeStatus {
+    ffi_guard(MmdRuntimeStatus::Error, || {
+        let Some(out_reduced_pose) = (unsafe { out_reduced_pose.as_mut() }) else {
+            return status_failure(MmdRuntimeStatus::InvalidInput, FFI_ERR_INVALID_INPUT);
+        };
+        *out_reduced_pose = ptr::null_mut();
+        let Some(model) = (unsafe { model.as_ref() }) else {
+            return status_failure(MmdRuntimeStatus::InvalidInput, FFI_ERR_INVALID_INPUT);
+        };
+        let Some(target) = reduction_target_from_u32(target) else {
+            return status_failure(MmdRuntimeStatus::InvalidInput, FFI_ERR_INVALID_INPUT);
+        };
+        let bone_count = model.model.bone_count();
+        if frame_count == 0 || !morph_weights_f32_len.is_multiple_of(frame_count) {
+            return status_failure(MmdRuntimeStatus::InvalidInput, FFI_ERR_INVALID_INPUT);
+        }
+        let morph_count = morph_weights_f32_len / frame_count;
+        let Some(required_world_len) = frame_count
+            .checked_mul(bone_count)
+            .and_then(|len| len.checked_mul(16))
+        else {
+            return status_failure(MmdRuntimeStatus::InvalidInput, FFI_ERR_INVALID_INPUT);
+        };
+        let Some(required_morph_len) = frame_count.checked_mul(morph_count) else {
+            return status_failure(MmdRuntimeStatus::InvalidInput, FFI_ERR_INVALID_INPUT);
+        };
+        if world_matrices_f32_len != required_world_len
+            || morph_weights_f32_len != required_morph_len
+            || (required_world_len > 0 && world_matrices_f32.is_null())
+            || (required_morph_len > 0 && morph_weights_f32.is_null())
+        {
+            return status_failure(MmdRuntimeStatus::InvalidInput, FFI_ERR_INVALID_INPUT);
+        }
+        let world_values = if required_world_len == 0 {
+            &[]
+        } else {
+            unsafe { slice::from_raw_parts(world_matrices_f32, required_world_len) }
+        };
+        let morph_weights = if required_morph_len == 0 {
+            &[]
+        } else {
+            unsafe { slice::from_raw_parts(morph_weights_f32, required_morph_len) }
+        };
+        let world_matrices = world_values
+            .chunks_exact(16)
+            .map(glam::Mat4::from_cols_slice)
+            .collect::<Vec<_>>();
+        let snapshot = match SkeletonSnapshot::from_model_with_morph_count(
+            &model.model,
+            model_identity,
+            morph_count,
+        ) {
+            Ok(snapshot) => snapshot,
+            Err(error) => {
+                return status_failure(MmdRuntimeStatus::InvalidInput, &error.to_string());
+            }
+        };
+        let dense = match DensePoseSequenceView::new(
+            &world_matrices,
+            morph_weights,
+            frame_count,
+            bone_count,
+            morph_count,
+            start_frame,
+            frame_step,
+        ) {
+            Ok(dense) => dense,
+            Err(error) => {
+                return status_failure(MmdRuntimeStatus::InvalidInput, &error.to_string());
+            }
+        };
+        let tolerances = ReductionTolerances {
+            local_position: tolerances.local_position,
+            local_rotation_radians: tolerances.local_rotation_radians,
+            world_position: tolerances.world_position,
+            world_rotation_radians: tolerances.world_rotation_radians,
+            morph_weight: tolerances.morph_weight,
+        };
+        let sequence =
+            match mmd_anim_runtime::reduce_dense_pose_sequence(dense, snapshot, tolerances, target)
+            {
+                Ok(sequence) => sequence,
+                Err(error) => {
+                    return status_failure(MmdRuntimeStatus::InvalidInput, &error.to_string());
+                }
+            };
+        *out_reduced_pose = Box::into_raw(Box::new(MmdRuntimeReducedPose { sequence }));
+        MmdRuntimeStatus::Ok
+    })
+}
+
+/// Releases a reduced-pose handle. Null is accepted.
+///
+/// # Safety
+///
+/// `pose` must be null or a live handle returned by the create function, and
+/// each non-null handle may be freed exactly once.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn mmd_runtime_reduced_pose_free(pose: *mut MmdRuntimeReducedPose) {
+    ffi_guard_void(|| {
+        if !pose.is_null() {
+            drop(unsafe { Box::from_raw(pose) });
+        }
+    });
+}
+
+/// Returns the reduced pose bone count, or zero for null.
+///
+/// # Safety
+///
+/// `pose` must be null or a live reduced-pose handle.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn mmd_runtime_reduced_pose_bone_count(
+    pose: *const MmdRuntimeReducedPose,
+) -> usize {
+    ffi_guard(0, || {
+        unsafe { pose.as_ref() }
+            .map(|pose| pose.sequence.snapshot().bone_count())
+            .unwrap_or(0)
+    })
+}
+
+/// Returns the reduced pose morph count, or zero for null.
+///
+/// # Safety
+///
+/// `pose` must be null or a live reduced-pose handle.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn mmd_runtime_reduced_pose_morph_count(
+    pose: *const MmdRuntimeReducedPose,
+) -> usize {
+    ffi_guard(0, || {
+        unsafe { pose.as_ref() }
+            .map(|pose| pose.sequence.snapshot().morph_count())
+            .unwrap_or(0)
+    })
+}
+
+/// Copies the immutable reduction report.
+///
+/// # Safety
+///
+/// `pose` must be a live reduced-pose handle and `out_report` writable.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn mmd_runtime_reduced_pose_report(
+    pose: *const MmdRuntimeReducedPose,
+    out_report: *mut MmdRuntimeFfiPoseReductionReport,
+) -> MmdRuntimeStatus {
+    ffi_guard(MmdRuntimeStatus::Error, || {
+        let Some(pose) = (unsafe { pose.as_ref() }) else {
+            return status_failure(MmdRuntimeStatus::InvalidInput, FFI_ERR_INVALID_INPUT);
+        };
+        let Some(out_report) = (unsafe { out_report.as_mut() }) else {
+            return status_failure(MmdRuntimeStatus::InvalidInput, FFI_ERR_INVALID_INPUT);
+        };
+        *out_report = ffi_reduction_report(pose.sequence.report());
+        MmdRuntimeStatus::Ok
+    })
+}
+
+/// Samples a reduced pose into caller-owned world-matrix and morph buffers.
+///
+/// # Safety
+///
+/// `pose` must be a live reduced-pose handle. Non-empty output regions must
+/// be writable for their declared lengths and must not alias.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn mmd_runtime_reduced_pose_sample(
+    pose: *const MmdRuntimeReducedPose,
+    frame: f32,
+    out_world_matrices_f32: *mut f32,
+    out_world_matrices_f32_len: usize,
+    out_morph_weights_f32: *mut f32,
+    out_morph_weights_f32_len: usize,
+) -> MmdRuntimeStatus {
+    ffi_guard(MmdRuntimeStatus::Error, || {
+        let Some(pose) = (unsafe { pose.as_ref() }) else {
+            return status_failure(MmdRuntimeStatus::InvalidInput, FFI_ERR_INVALID_INPUT);
+        };
+        let required_world_len = pose.sequence.snapshot().bone_count() * 16;
+        let required_morph_len = pose.sequence.snapshot().morph_count();
+        if out_world_matrices_f32_len < required_world_len
+            || out_morph_weights_f32_len < required_morph_len
+        {
+            return status_failure(MmdRuntimeStatus::BufferTooSmall, "output buffer too small");
+        }
+        if (required_world_len > 0 && out_world_matrices_f32.is_null())
+            || (required_morph_len > 0 && out_morph_weights_f32.is_null())
+        {
+            return status_failure(MmdRuntimeStatus::InvalidInput, FFI_ERR_INVALID_INPUT);
+        }
+        let sample = match pose.sequence.sample(frame) {
+            Ok(sample) => sample,
+            Err(error) => {
+                return status_failure(MmdRuntimeStatus::InvalidInput, &error.to_string());
+            }
+        };
+        if required_world_len > 0 {
+            let out_world =
+                unsafe { slice::from_raw_parts_mut(out_world_matrices_f32, required_world_len) };
+            flatten_matrices_into_slice(out_world, &sample.world_matrices);
+        }
+        if required_morph_len > 0 {
+            let out_morph =
+                unsafe { slice::from_raw_parts_mut(out_morph_weights_f32, required_morph_len) };
+            out_morph.copy_from_slice(&sample.morph_weights);
+        }
+        MmdRuntimeStatus::Ok
     })
 }
 

--- a/crates/mmd-anim-ffi/src/lib.rs
+++ b/crates/mmd-anim-ffi/src/lib.rs
@@ -5710,57 +5710,6 @@ pub unsafe extern "C" fn mmd_runtime_reduced_pose_unity_curve_keys(
     })
 }
 
-/// Samples a reduced pose into caller-owned world-matrix and morph buffers.
-///
-/// # Safety
-///
-/// `pose` must be a live reduced-pose handle. Non-empty output regions must
-/// be writable for their declared lengths and must not alias.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn mmd_runtime_reduced_pose_sample(
-    pose: *const MmdRuntimeReducedPose,
-    frame: f32,
-    out_world_matrices_f32: *mut f32,
-    out_world_matrices_f32_len: usize,
-    out_morph_weights_f32: *mut f32,
-    out_morph_weights_f32_len: usize,
-) -> MmdRuntimeStatus {
-    ffi_guard(MmdRuntimeStatus::Error, || {
-        let Some(pose) = (unsafe { pose.as_ref() }) else {
-            return status_failure(MmdRuntimeStatus::InvalidInput, FFI_ERR_INVALID_INPUT);
-        };
-        let required_world_len = pose.sequence.snapshot().bone_count() * 16;
-        let required_morph_len = pose.sequence.snapshot().morph_count();
-        if out_world_matrices_f32_len < required_world_len
-            || out_morph_weights_f32_len < required_morph_len
-        {
-            return status_failure(MmdRuntimeStatus::BufferTooSmall, "output buffer too small");
-        }
-        if (required_world_len > 0 && out_world_matrices_f32.is_null())
-            || (required_morph_len > 0 && out_morph_weights_f32.is_null())
-        {
-            return status_failure(MmdRuntimeStatus::InvalidInput, FFI_ERR_INVALID_INPUT);
-        }
-        let sample = match pose.sequence.sample(frame) {
-            Ok(sample) => sample,
-            Err(error) => {
-                return status_failure(MmdRuntimeStatus::InvalidInput, &error.to_string());
-            }
-        };
-        if required_world_len > 0 {
-            let out_world =
-                unsafe { slice::from_raw_parts_mut(out_world_matrices_f32, required_world_len) };
-            flatten_matrices_into_slice(out_world, &sample.world_matrices);
-        }
-        if required_morph_len > 0 {
-            let out_morph =
-                unsafe { slice::from_raw_parts_mut(out_morph_weights_f32, required_morph_len) };
-            out_morph.copy_from_slice(&sample.morph_weights);
-        }
-        MmdRuntimeStatus::Ok
-    })
-}
-
 fn resolve_batch_worker_count(requested_worker_count: u32, frame_count: usize) -> usize {
     let requested = requested_worker_count as usize;
     let default_workers = std::thread::available_parallelism()

--- a/crates/mmd-anim-ffi/src/lib.rs
+++ b/crates/mmd-anim-ffi/src/lib.rs
@@ -7,6 +7,10 @@ use std::os::raw::c_char;
 use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::{ptr, slice, str, sync::Arc};
 
+use mmd_anim_format::fbx::{
+    UnityAnimationClipDto, UnityMorphBinding, UnityReducedPoseBindings,
+    reduced_pose_to_unity_animation_clip_with_fps,
+};
 use mmd_anim_runtime::ModelArena;
 use mmd_anim_runtime::{
     AnimationClip, AppendPrimitiveInput, BoneAnimationBinding, BoneIndex, DensePoseSequenceView,
@@ -74,6 +78,13 @@ pub struct MmdRuntimeClip {
 
 pub struct MmdRuntimeReducedPose {
     sequence: ReducedPoseSequence,
+    unity_curve_cache: RefCell<Option<MmdRuntimeUnityCurveCache>>,
+}
+
+struct MmdRuntimeUnityCurveCache {
+    frames_per_second_bits: u32,
+    flip_z: bool,
+    clip: UnityAnimationClipDto,
 }
 
 pub struct MmdRuntimeVmdCameraTrack {
@@ -275,6 +286,33 @@ pub struct MmdRuntimeFfiPoseReductionReport {
     pub max_world_position_error: f32,
     pub max_world_rotation_error_radians: f32,
     pub max_morph_weight_error: f32,
+}
+
+pub const MMD_RUNTIME_UNITY_CURVE_BONE_LOCAL_TRANSLATION: u32 = 0;
+pub const MMD_RUNTIME_UNITY_CURVE_BONE_LOCAL_EULER: u32 = 1;
+pub const MMD_RUNTIME_UNITY_CURVE_MORPH_WEIGHT: u32 = 2;
+
+pub const MMD_RUNTIME_UNITY_CURVE_AXIS_X: u32 = 0;
+pub const MMD_RUNTIME_UNITY_CURVE_AXIS_Y: u32 = 1;
+pub const MMD_RUNTIME_UNITY_CURVE_AXIS_Z: u32 = 2;
+pub const MMD_RUNTIME_UNITY_CURVE_AXIS_NONE: u32 = 3;
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct MmdRuntimeFfiUnityCurveDescriptor {
+    pub semantic: u32,
+    pub target_index: u32,
+    pub axis: u32,
+    pub key_count: usize,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct MmdRuntimeFfiUnityCurveKey {
+    pub time_seconds: f32,
+    pub value: f32,
+    pub in_tangent: f32,
+    pub out_tangent: f32,
 }
 
 #[repr(C)]
@@ -5362,7 +5400,10 @@ pub unsafe extern "C" fn mmd_runtime_reduced_pose_create_from_dense(
                     return status_failure(MmdRuntimeStatus::InvalidInput, &error.to_string());
                 }
             };
-        *out_reduced_pose = Box::into_raw(Box::new(MmdRuntimeReducedPose { sequence }));
+        *out_reduced_pose = Box::into_raw(Box::new(MmdRuntimeReducedPose {
+            sequence,
+            unity_curve_cache: RefCell::new(None),
+        }));
         MmdRuntimeStatus::Ok
     })
 }
@@ -5432,6 +5473,239 @@ pub unsafe extern "C" fn mmd_runtime_reduced_pose_report(
             return status_failure(MmdRuntimeStatus::InvalidInput, FFI_ERR_INVALID_INPUT);
         };
         *out_report = ffi_reduction_report(pose.sequence.report());
+        MmdRuntimeStatus::Ok
+    })
+}
+
+fn validate_unity_curve_request(
+    pose: &MmdRuntimeReducedPose,
+    frames_per_second: f32,
+) -> Result<(), MmdRuntimeStatus> {
+    if !frames_per_second.is_finite() || frames_per_second <= 0.0 {
+        return Err(status_failure(
+            MmdRuntimeStatus::InvalidInput,
+            "frames per second must be finite and greater than zero",
+        ));
+    }
+    if pose.sequence.target() != ReductionTarget::DccCubic {
+        return Err(status_failure(
+            MmdRuntimeStatus::Unsupported,
+            "Unity curve enumeration requires a DccCubic reduced pose",
+        ));
+    }
+    Ok(())
+}
+
+fn unity_curve_count(sequence: &ReducedPoseSequence) -> Option<usize> {
+    sequence
+        .bone_tracks()
+        .len()
+        .checked_mul(6)
+        .and_then(|bone_curves| bone_curves.checked_add(sequence.morph_tracks().len()))
+}
+
+fn unity_curve_descriptor(
+    sequence: &ReducedPoseSequence,
+    curve_index: usize,
+) -> Option<MmdRuntimeFfiUnityCurveDescriptor> {
+    let bone_curve_count = sequence.bone_tracks().len().checked_mul(6)?;
+    if curve_index < bone_curve_count {
+        let target = curve_index / 6;
+        let channel = curve_index % 6;
+        let target_index = u32::try_from(target).ok()?;
+        let key_count = sequence.bone_tracks()[target].keys().len();
+        let (semantic, axis) = if channel < 3 {
+            (MMD_RUNTIME_UNITY_CURVE_BONE_LOCAL_TRANSLATION, channel)
+        } else {
+            (MMD_RUNTIME_UNITY_CURVE_BONE_LOCAL_EULER, channel - 3)
+        };
+        return Some(MmdRuntimeFfiUnityCurveDescriptor {
+            semantic,
+            target_index,
+            axis: axis as u32,
+            key_count,
+        });
+    }
+    let target = curve_index.checked_sub(bone_curve_count)?;
+    let track = sequence.morph_tracks().get(target)?;
+    Some(MmdRuntimeFfiUnityCurveDescriptor {
+        semantic: MMD_RUNTIME_UNITY_CURVE_MORPH_WEIGHT,
+        target_index: u32::try_from(target).ok()?,
+        axis: MMD_RUNTIME_UNITY_CURVE_AXIS_NONE,
+        key_count: track.keys().len(),
+    })
+}
+
+fn unity_clip_for_reduced_pose(
+    sequence: &ReducedPoseSequence,
+    frames_per_second: f32,
+    flip_z: bool,
+) -> Result<UnityAnimationClipDto, MmdRuntimeStatus> {
+    let bindings = UnityReducedPoseBindings {
+        model_identity: sequence.snapshot().model_identity(),
+        bone_paths: vec![String::new(); sequence.snapshot().bone_count()],
+        morph_bindings: (0..sequence.snapshot().morph_count())
+            .map(|_| {
+                Some(UnityMorphBinding {
+                    path: String::new(),
+                    property: String::new(),
+                })
+            })
+            .collect(),
+    };
+    reduced_pose_to_unity_animation_clip_with_fps(sequence, &bindings, frames_per_second, flip_z)
+        .map_err(|error| status_failure(MmdRuntimeStatus::InvalidInput, &error.to_string()))
+}
+
+fn ensure_unity_curve_cache(
+    pose: &MmdRuntimeReducedPose,
+    frames_per_second: f32,
+    flip_z: bool,
+) -> Result<(), MmdRuntimeStatus> {
+    validate_unity_curve_request(pose, frames_per_second)?;
+    let cache_matches = pose
+        .unity_curve_cache
+        .borrow()
+        .as_ref()
+        .is_some_and(|cache| {
+            cache.frames_per_second_bits == frames_per_second.to_bits() && cache.flip_z == flip_z
+        });
+    if cache_matches {
+        return Ok(());
+    }
+    let clip = unity_clip_for_reduced_pose(&pose.sequence, frames_per_second, flip_z)?;
+    *pose.unity_curve_cache.borrow_mut() = Some(MmdRuntimeUnityCurveCache {
+        frames_per_second_bits: frames_per_second.to_bits(),
+        flip_z,
+        clip,
+    });
+    Ok(())
+}
+
+/// Returns the number of target-native Unity scalar curves.
+///
+/// # Safety
+///
+/// `pose` must be a live reduced-pose handle and `out_curve_count` writable.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn mmd_runtime_reduced_pose_unity_curve_count(
+    pose: *const MmdRuntimeReducedPose,
+    frames_per_second: f32,
+    flip_z: bool,
+    out_curve_count: *mut usize,
+) -> MmdRuntimeStatus {
+    ffi_guard(MmdRuntimeStatus::Error, || {
+        let Some(out_curve_count) = (unsafe { out_curve_count.as_mut() }) else {
+            return status_failure(MmdRuntimeStatus::InvalidInput, FFI_ERR_INVALID_INPUT);
+        };
+        *out_curve_count = 0;
+        let Some(pose) = (unsafe { pose.as_ref() }) else {
+            return status_failure(MmdRuntimeStatus::InvalidInput, FFI_ERR_INVALID_INPUT);
+        };
+        if let Err(status) = ensure_unity_curve_cache(pose, frames_per_second, flip_z) {
+            return status;
+        }
+        let Some(count) = unity_curve_count(&pose.sequence) else {
+            return status_failure(MmdRuntimeStatus::Error, "Unity curve count overflow");
+        };
+        *out_curve_count = count;
+        MmdRuntimeStatus::Ok
+    })
+}
+
+/// Copies one Unity scalar-curve descriptor.
+///
+/// Curves are ordered as translation XYZ then Euler XYZ for every bone,
+/// followed by one weight curve for every morph.
+///
+/// # Safety
+///
+/// `pose` must be a live reduced-pose handle and `out_descriptor` writable.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn mmd_runtime_reduced_pose_unity_curve_descriptor(
+    pose: *const MmdRuntimeReducedPose,
+    frames_per_second: f32,
+    flip_z: bool,
+    curve_index: usize,
+    out_descriptor: *mut MmdRuntimeFfiUnityCurveDescriptor,
+) -> MmdRuntimeStatus {
+    ffi_guard(MmdRuntimeStatus::Error, || {
+        let Some(out_descriptor) = (unsafe { out_descriptor.as_mut() }) else {
+            return status_failure(MmdRuntimeStatus::InvalidInput, FFI_ERR_INVALID_INPUT);
+        };
+        *out_descriptor = MmdRuntimeFfiUnityCurveDescriptor::default();
+        let Some(pose) = (unsafe { pose.as_ref() }) else {
+            return status_failure(MmdRuntimeStatus::InvalidInput, FFI_ERR_INVALID_INPUT);
+        };
+        if let Err(status) = ensure_unity_curve_cache(pose, frames_per_second, flip_z) {
+            return status;
+        }
+        let Some(descriptor) = unity_curve_descriptor(&pose.sequence, curve_index) else {
+            return status_failure(MmdRuntimeStatus::InvalidInput, "curve index out of range");
+        };
+        *out_descriptor = descriptor;
+        MmdRuntimeStatus::Ok
+    })
+}
+
+/// Copies one Unity scalar curve into a caller-owned key buffer.
+///
+/// `out_required_count` is always written after request validation. A null or
+/// short key buffer returns `BUFFER_TOO_SMALL` with the required count, which
+/// provides the first stage of the two-call retrieval pattern.
+///
+/// # Safety
+///
+/// `pose` must be a live reduced-pose handle. `out_required_count` must be
+/// writable. A non-empty key output region must be writable and must not alias
+/// `out_required_count`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn mmd_runtime_reduced_pose_unity_curve_keys(
+    pose: *const MmdRuntimeReducedPose,
+    frames_per_second: f32,
+    flip_z: bool,
+    curve_index: usize,
+    out_keys: *mut MmdRuntimeFfiUnityCurveKey,
+    out_key_capacity: usize,
+    out_required_count: *mut usize,
+) -> MmdRuntimeStatus {
+    ffi_guard(MmdRuntimeStatus::Error, || {
+        let Some(out_required_count) = (unsafe { out_required_count.as_mut() }) else {
+            return status_failure(MmdRuntimeStatus::InvalidInput, FFI_ERR_INVALID_INPUT);
+        };
+        *out_required_count = 0;
+        let Some(pose) = (unsafe { pose.as_ref() }) else {
+            return status_failure(MmdRuntimeStatus::InvalidInput, FFI_ERR_INVALID_INPUT);
+        };
+        if let Err(status) = ensure_unity_curve_cache(pose, frames_per_second, flip_z) {
+            return status;
+        }
+        let Some(descriptor) = unity_curve_descriptor(&pose.sequence, curve_index) else {
+            return status_failure(MmdRuntimeStatus::InvalidInput, "curve index out of range");
+        };
+        *out_required_count = descriptor.key_count;
+        if out_key_capacity < descriptor.key_count || out_keys.is_null() {
+            return status_failure(MmdRuntimeStatus::BufferTooSmall, "output buffer too small");
+        }
+        let cache = pose.unity_curve_cache.borrow();
+        let Some(curve) = cache
+            .as_ref()
+            .and_then(|cache| cache.clip.curves.get(curve_index))
+        else {
+            return status_failure(MmdRuntimeStatus::Error, "Unity curve mapping mismatch");
+        };
+        if curve.keys.len() != descriptor.key_count {
+            return status_failure(MmdRuntimeStatus::Error, "Unity curve key count mismatch");
+        }
+        let out_keys = unsafe { slice::from_raw_parts_mut(out_keys, descriptor.key_count) };
+        for (out, key) in out_keys.iter_mut().zip(&curve.keys) {
+            *out = MmdRuntimeFfiUnityCurveKey {
+                time_seconds: key.time_seconds,
+                value: key.value,
+                in_tangent: key.in_tangent,
+                out_tangent: key.out_tangent,
+            };
+        }
         MmdRuntimeStatus::Ok
     })
 }

--- a/crates/mmd-anim-ffi/src/tests.rs
+++ b/crates/mmd-anim-ffi/src/tests.rs
@@ -425,7 +425,7 @@ fn reduced_pose_unity_curve_cache_invalidates_for_fps_and_flip_z() {
 }
 
 #[test]
-fn reduced_pose_handle_samples_after_model_free_and_rejects_short_buffer() {
+fn reduced_pose_handle_reports_and_enumerates_sparse_curves_after_model_free() {
     let parents = [-1_i32];
     let rest = [0.0_f32, 0.0, 0.0];
     let model = unsafe { mmd_runtime_model_create(parents.as_ptr(), rest.as_ptr(), 1) };
@@ -456,7 +456,7 @@ fn reduced_pose_handle_samples_after_model_free_and_rejects_short_buffer() {
             3,
             0.0,
             30.0,
-            0,
+            2,
             tolerances,
             &mut reduced,
         )
@@ -497,38 +497,18 @@ fn reduced_pose_handle_samples_after_model_free_and_rejects_short_buffer() {
     assert_eq!(report.source_morph_key_count, 3);
     assert_eq!(report.reduced_morph_key_count, 2);
 
-    let mut short_world = [0.0_f32; 15];
+    let mut curve_count = 0;
     assert_eq!(
         unsafe {
-            mmd_runtime_reduced_pose_sample(
-                reduced,
-                30.0,
-                short_world.as_mut_ptr(),
-                short_world.len(),
-                ptr::null_mut(),
-                0,
-            )
-        },
-        MmdRuntimeStatus::BufferTooSmall
-    );
-
-    let mut world = [0.0_f32; 16];
-    let mut morph = [0.0_f32; 1];
-    assert_eq!(
-        unsafe {
-            mmd_runtime_reduced_pose_sample(
-                reduced,
-                30.0,
-                world.as_mut_ptr(),
-                world.len(),
-                morph.as_mut_ptr(),
-                morph.len(),
-            )
+            mmd_runtime_reduced_pose_unity_curve_count(reduced, 30.0, false, &mut curve_count)
         },
         MmdRuntimeStatus::Ok
     );
-    assert_near(world[12], 1.0, 1.0e-5);
-    assert_near(morph[0], 0.5, 1.0e-5);
+    assert_eq!(curve_count, 7);
+    let morph_keys = copy_unity_curve_keys(reduced, 30.0, false, curve_count - 1);
+    assert_eq!(morph_keys.len(), 2);
+    assert_near(morph_keys[0].value, 0.0, 1.0e-5);
+    assert_near(morph_keys[1].value, 100.0, 1.0e-5);
     unsafe { mmd_runtime_reduced_pose_free(reduced) };
     unsafe { mmd_runtime_reduced_pose_free(ptr::null_mut()) };
 }

--- a/crates/mmd-anim-ffi/src/tests.rs
+++ b/crates/mmd-anim-ffi/src/tests.rs
@@ -79,6 +79,351 @@ fn assert_slice_near(actual: &[f32], expected: &[f32], tolerance: f32) {
     }
 }
 
+fn reduced_pose_curve_fixture(target: u32) -> *mut MmdRuntimeReducedPose {
+    let parents = [-1_i32];
+    let rest = [0.0_f32, 0.0, 0.0];
+    let model = unsafe { mmd_runtime_model_create(parents.as_ptr(), rest.as_ptr(), 1) };
+    assert!(!model.is_null());
+
+    let mut dense_world = Vec::new();
+    for frame in 0..5 {
+        let amount = frame as f32 / 4.0;
+        let matrix = glam::Mat4::from_rotation_translation(
+            glam::Quat::from_rotation_y(0.7 * amount * amount),
+            glam::Vec3::new(amount, 0.25 * amount, 0.5 * amount),
+        );
+        dense_world.extend_from_slice(&matrix.to_cols_array());
+    }
+    let dense_morph = [0.0_f32, 0.1, 0.35, 0.7, 1.0];
+    let tolerances = MmdRuntimeFfiReductionTolerances {
+        local_position: 1.0e-5,
+        local_rotation_radians: 1.0e-5,
+        world_position: 1.0e-5,
+        world_rotation_radians: 1.0e-5,
+        morph_weight: 1.0e-5,
+    };
+    let mut reduced = ptr::null_mut();
+    assert_eq!(
+        unsafe {
+            mmd_runtime_reduced_pose_create_from_dense(
+                model,
+                77,
+                dense_world.as_ptr(),
+                dense_world.len(),
+                dense_morph.as_ptr(),
+                dense_morph.len(),
+                5,
+                0.0,
+                1.0,
+                target,
+                tolerances,
+                &mut reduced,
+            )
+        },
+        MmdRuntimeStatus::Ok
+    );
+    unsafe { mmd_runtime_model_free(model) };
+    assert!(!reduced.is_null());
+    reduced
+}
+
+fn copy_unity_curve_keys(
+    reduced: *const MmdRuntimeReducedPose,
+    frames_per_second: f32,
+    flip_z: bool,
+    curve_index: usize,
+) -> Vec<MmdRuntimeFfiUnityCurveKey> {
+    let mut required = 0;
+    assert_eq!(
+        unsafe {
+            mmd_runtime_reduced_pose_unity_curve_keys(
+                reduced,
+                frames_per_second,
+                flip_z,
+                curve_index,
+                ptr::null_mut(),
+                0,
+                &mut required,
+            )
+        },
+        MmdRuntimeStatus::BufferTooSmall
+    );
+    let mut keys = vec![MmdRuntimeFfiUnityCurveKey::default(); required];
+    assert_eq!(
+        unsafe {
+            mmd_runtime_reduced_pose_unity_curve_keys(
+                reduced,
+                frames_per_second,
+                flip_z,
+                curve_index,
+                keys.as_mut_ptr(),
+                keys.len(),
+                &mut required,
+            )
+        },
+        MmdRuntimeStatus::Ok
+    );
+    keys
+}
+
+#[test]
+fn reduced_pose_unity_curves_are_two_call_and_match_rust_dto_after_model_free() {
+    let reduced = reduced_pose_curve_fixture(2);
+    let frames_per_second = 60.0;
+    let flip_z = true;
+
+    let mut curve_count = usize::MAX;
+    assert_eq!(
+        unsafe {
+            mmd_runtime_reduced_pose_unity_curve_count(
+                reduced,
+                frames_per_second,
+                flip_z,
+                &mut curve_count,
+            )
+        },
+        MmdRuntimeStatus::Ok
+    );
+    assert_eq!(curve_count, 7);
+
+    let sequence = unsafe { &(*reduced).sequence };
+    let expected = mmd_anim_format::fbx::reduced_pose_to_unity_animation_clip_with_fps(
+        sequence,
+        &mmd_anim_format::fbx::UnityReducedPoseBindings {
+            model_identity: 77,
+            bone_paths: vec![String::new()],
+            morph_bindings: vec![Some(mmd_anim_format::fbx::UnityMorphBinding {
+                path: String::new(),
+                property: String::new(),
+            })],
+        },
+        frames_per_second,
+        flip_z,
+    )
+    .unwrap();
+    assert_eq!(expected.curves.len(), curve_count);
+
+    for (curve_index, expected_curve) in expected.curves.iter().enumerate() {
+        let mut descriptor = MmdRuntimeFfiUnityCurveDescriptor::default();
+        assert_eq!(
+            unsafe {
+                mmd_runtime_reduced_pose_unity_curve_descriptor(
+                    reduced,
+                    frames_per_second,
+                    flip_z,
+                    curve_index,
+                    &mut descriptor,
+                )
+            },
+            MmdRuntimeStatus::Ok
+        );
+        assert_eq!(descriptor.key_count, expected_curve.keys.len());
+        if curve_index < 3 {
+            assert_eq!(
+                descriptor.semantic,
+                MMD_RUNTIME_UNITY_CURVE_BONE_LOCAL_TRANSLATION
+            );
+            assert_eq!(descriptor.target_index, 0);
+            assert_eq!(descriptor.axis, curve_index as u32);
+        } else if curve_index < 6 {
+            assert_eq!(
+                descriptor.semantic,
+                MMD_RUNTIME_UNITY_CURVE_BONE_LOCAL_EULER
+            );
+            assert_eq!(descriptor.target_index, 0);
+            assert_eq!(descriptor.axis, (curve_index - 3) as u32);
+        } else {
+            assert_eq!(descriptor.semantic, MMD_RUNTIME_UNITY_CURVE_MORPH_WEIGHT);
+            assert_eq!(descriptor.target_index, 0);
+            assert_eq!(descriptor.axis, MMD_RUNTIME_UNITY_CURVE_AXIS_NONE);
+        }
+
+        let mut required = usize::MAX;
+        assert_eq!(
+            unsafe {
+                mmd_runtime_reduced_pose_unity_curve_keys(
+                    reduced,
+                    frames_per_second,
+                    flip_z,
+                    curve_index,
+                    ptr::null_mut(),
+                    0,
+                    &mut required,
+                )
+            },
+            MmdRuntimeStatus::BufferTooSmall
+        );
+        assert_eq!(required, descriptor.key_count);
+
+        let mut keys = vec![MmdRuntimeFfiUnityCurveKey::default(); required];
+        if required > 0 {
+            assert_eq!(
+                unsafe {
+                    mmd_runtime_reduced_pose_unity_curve_keys(
+                        reduced,
+                        frames_per_second,
+                        flip_z,
+                        curve_index,
+                        keys.as_mut_ptr(),
+                        required - 1,
+                        &mut required,
+                    )
+                },
+                MmdRuntimeStatus::BufferTooSmall
+            );
+        }
+        assert_eq!(
+            unsafe {
+                mmd_runtime_reduced_pose_unity_curve_keys(
+                    reduced,
+                    frames_per_second,
+                    flip_z,
+                    curve_index,
+                    keys.as_mut_ptr(),
+                    keys.len(),
+                    &mut required,
+                )
+            },
+            MmdRuntimeStatus::Ok
+        );
+        for (actual, expected) in keys.iter().zip(&expected_curve.keys) {
+            assert_eq!(actual.time_seconds, expected.time_seconds);
+            assert_eq!(actual.value, expected.value);
+            assert_eq!(actual.in_tangent, expected.in_tangent);
+            assert_eq!(actual.out_tangent, expected.out_tangent);
+        }
+    }
+
+    let mut descriptor = MmdRuntimeFfiUnityCurveDescriptor::default();
+    assert_eq!(
+        unsafe {
+            mmd_runtime_reduced_pose_unity_curve_descriptor(
+                reduced,
+                frames_per_second,
+                flip_z,
+                curve_count,
+                &mut descriptor,
+            )
+        },
+        MmdRuntimeStatus::InvalidInput
+    );
+    unsafe { mmd_runtime_reduced_pose_free(reduced) };
+}
+
+#[test]
+fn reduced_pose_unity_curves_validate_handle_fps_outputs_and_target() {
+    let dcc = reduced_pose_curve_fixture(2);
+    let mut count = usize::MAX;
+    assert_eq!(
+        unsafe { mmd_runtime_reduced_pose_unity_curve_count(ptr::null(), 30.0, false, &mut count) },
+        MmdRuntimeStatus::InvalidInput
+    );
+    assert_eq!(count, 0);
+    assert_eq!(
+        unsafe { mmd_runtime_reduced_pose_unity_curve_count(dcc, f32::NAN, false, &mut count) },
+        MmdRuntimeStatus::InvalidInput
+    );
+    assert_eq!(count, 0);
+    assert_eq!(
+        unsafe { mmd_runtime_reduced_pose_unity_curve_count(dcc, 0.0, false, &mut count) },
+        MmdRuntimeStatus::InvalidInput
+    );
+    for frames_per_second in [f32::MAX, f32::from_bits(1)] {
+        let mut descriptor = MmdRuntimeFfiUnityCurveDescriptor {
+            semantic: u32::MAX,
+            target_index: u32::MAX,
+            axis: u32::MAX,
+            key_count: usize::MAX,
+        };
+        let mut required = usize::MAX;
+        assert_eq!(
+            unsafe {
+                mmd_runtime_reduced_pose_unity_curve_count(
+                    dcc,
+                    frames_per_second,
+                    false,
+                    &mut count,
+                )
+            },
+            MmdRuntimeStatus::InvalidInput
+        );
+        assert_eq!(count, 0);
+        assert_eq!(
+            unsafe {
+                mmd_runtime_reduced_pose_unity_curve_descriptor(
+                    dcc,
+                    frames_per_second,
+                    false,
+                    0,
+                    &mut descriptor,
+                )
+            },
+            MmdRuntimeStatus::InvalidInput
+        );
+        assert_eq!(descriptor, MmdRuntimeFfiUnityCurveDescriptor::default());
+        assert_eq!(
+            unsafe {
+                mmd_runtime_reduced_pose_unity_curve_keys(
+                    dcc,
+                    frames_per_second,
+                    false,
+                    0,
+                    ptr::null_mut(),
+                    0,
+                    &mut required,
+                )
+            },
+            MmdRuntimeStatus::InvalidInput
+        );
+        assert_eq!(required, 0);
+    }
+    assert_eq!(
+        unsafe { mmd_runtime_reduced_pose_unity_curve_count(dcc, 30.0, false, ptr::null_mut()) },
+        MmdRuntimeStatus::InvalidInput
+    );
+    unsafe { mmd_runtime_reduced_pose_free(dcc) };
+
+    let linear = reduced_pose_curve_fixture(0);
+    assert_eq!(
+        unsafe { mmd_runtime_reduced_pose_unity_curve_count(linear, 30.0, false, &mut count) },
+        MmdRuntimeStatus::Unsupported
+    );
+    assert_eq!(count, 0);
+    unsafe { mmd_runtime_reduced_pose_free(linear) };
+}
+
+#[test]
+fn reduced_pose_unity_curve_cache_invalidates_for_fps_and_flip_z() {
+    let reduced = reduced_pose_curve_fixture(2);
+    let z_30 = copy_unity_curve_keys(reduced, 30.0, false, 2);
+    let z_60 = copy_unity_curve_keys(reduced, 60.0, false, 2);
+    let z_60_flipped = copy_unity_curve_keys(reduced, 60.0, true, 2);
+    let z_30_again = copy_unity_curve_keys(reduced, 30.0, false, 2);
+
+    assert_eq!(z_30_again, z_30);
+    assert_near(z_30.last().unwrap().time_seconds, 4.0 / 30.0, 1.0e-7);
+    assert_near(z_60.last().unwrap().time_seconds, 4.0 / 60.0, 1.0e-7);
+    assert_near(z_30.last().unwrap().value, 0.5, 1.0e-6);
+    assert_near(z_60_flipped.last().unwrap().value, -0.5, 1.0e-6);
+
+    let tangent_index = z_30
+        .iter()
+        .position(|key| key.out_tangent.abs() > 1.0e-5)
+        .expect("fixture must contain a non-zero translation tangent");
+    assert_near(
+        z_60[tangent_index].out_tangent,
+        z_30[tangent_index].out_tangent * 2.0,
+        1.0e-5,
+    );
+    assert_near(
+        z_60_flipped[tangent_index].out_tangent,
+        -z_60[tangent_index].out_tangent,
+        1.0e-5,
+    );
+
+    unsafe { mmd_runtime_reduced_pose_free(reduced) };
+}
+
 #[test]
 fn reduced_pose_handle_samples_after_model_free_and_rejects_short_buffer() {
     let parents = [-1_i32];

--- a/crates/mmd-anim-ffi/src/tests.rs
+++ b/crates/mmd-anim-ffi/src/tests.rs
@@ -79,6 +79,115 @@ fn assert_slice_near(actual: &[f32], expected: &[f32], tolerance: f32) {
     }
 }
 
+#[test]
+fn reduced_pose_handle_samples_after_model_free_and_rejects_short_buffer() {
+    let parents = [-1_i32];
+    let rest = [0.0_f32, 0.0, 0.0];
+    let model = unsafe { mmd_runtime_model_create(parents.as_ptr(), rest.as_ptr(), 1) };
+    assert!(!model.is_null());
+
+    let mut dense_world = Vec::new();
+    for x in [0.0_f32, 1.0, 2.0] {
+        dense_world
+            .extend_from_slice(&glam::Mat4::from_translation(glam::Vec3::X * x).to_cols_array());
+    }
+    let dense_morph = [0.0_f32, 0.5, 1.0];
+    let tolerances = MmdRuntimeFfiReductionTolerances {
+        local_position: 1.0e-4,
+        local_rotation_radians: 1.0e-4,
+        world_position: 1.0e-4,
+        world_rotation_radians: 1.0e-4,
+        morph_weight: 1.0e-4,
+    };
+    let mut reduced = ptr::null_mut();
+    let status = unsafe {
+        mmd_runtime_reduced_pose_create_from_dense(
+            model,
+            42,
+            dense_world.as_ptr(),
+            dense_world.len(),
+            dense_morph.as_ptr(),
+            dense_morph.len(),
+            3,
+            0.0,
+            30.0,
+            0,
+            tolerances,
+            &mut reduced,
+        )
+    };
+    assert_eq!(status, MmdRuntimeStatus::Ok);
+    assert!(!reduced.is_null());
+
+    let mut invalid = std::ptr::NonNull::<MmdRuntimeReducedPose>::dangling().as_ptr();
+    assert_eq!(
+        unsafe {
+            mmd_runtime_reduced_pose_create_from_dense(
+                model,
+                42,
+                dense_world.as_ptr(),
+                dense_world.len(),
+                dense_morph.as_ptr(),
+                dense_morph.len(),
+                3,
+                0.0,
+                30.0,
+                99,
+                tolerances,
+                &mut invalid,
+            )
+        },
+        MmdRuntimeStatus::InvalidInput
+    );
+    assert!(invalid.is_null());
+    unsafe { mmd_runtime_model_free(model) };
+
+    let mut report = MmdRuntimeFfiPoseReductionReport::default();
+    assert_eq!(
+        unsafe { mmd_runtime_reduced_pose_report(reduced, &mut report) },
+        MmdRuntimeStatus::Ok
+    );
+    assert_eq!(report.source_bone_key_count, 3);
+    assert_eq!(report.reduced_bone_key_count, 2);
+    assert_eq!(report.source_morph_key_count, 3);
+    assert_eq!(report.reduced_morph_key_count, 2);
+
+    let mut short_world = [0.0_f32; 15];
+    assert_eq!(
+        unsafe {
+            mmd_runtime_reduced_pose_sample(
+                reduced,
+                30.0,
+                short_world.as_mut_ptr(),
+                short_world.len(),
+                ptr::null_mut(),
+                0,
+            )
+        },
+        MmdRuntimeStatus::BufferTooSmall
+    );
+
+    let mut world = [0.0_f32; 16];
+    let mut morph = [0.0_f32; 1];
+    assert_eq!(
+        unsafe {
+            mmd_runtime_reduced_pose_sample(
+                reduced,
+                30.0,
+                world.as_mut_ptr(),
+                world.len(),
+                morph.as_mut_ptr(),
+                morph.len(),
+            )
+        },
+        MmdRuntimeStatus::Ok
+    );
+    assert_near(world[12], 1.0, 1.0e-5);
+    assert_near(morph[0], 0.5, 1.0e-5);
+    unsafe { mmd_runtime_reduced_pose_free(reduced) };
+    unsafe { mmd_runtime_reduced_pose_free(ptr::null_mut()) };
+}
+
 fn simple_ik_chain() -> *mut MmdRuntimeIkChain {
     let bones = [
         MmdRuntimeFfiRigBone {

--- a/crates/mmd-anim-format/src/fbx/mod.rs
+++ b/crates/mmd-anim-format/src/fbx/mod.rs
@@ -11,7 +11,11 @@ use fbxcel::{
     writer::v7400::binary::{AttributesWriter, FbxFooter, Writer},
 };
 use glam::Mat4;
-use mmd_anim_runtime::{AnimationClip, BoneIndex, ModelArena, MorphIndex, RuntimeInstance};
+use mmd_anim_runtime::{
+    AnimationClip, BoneIndex, DensePoseSequenceView, ModelArena, MorphIndex, PoseReductionError,
+    PoseReductionReport, ReducedBoneKey, ReducedMorphKey, ReducedPoseSequence, ReductionTarget,
+    ReductionTolerances, RuntimeInstance, SkeletonSnapshot, reduce_dense_pose_sequence,
+};
 
 use crate::{
     pmx::{PmxParsedBone, PmxParsedMaterial, PmxParsedModel, PmxParsedMorph},
@@ -125,11 +129,64 @@ pub enum FbxExportError {
         expected: usize,
         actual: usize,
     },
+    #[error("reduced pose must use the DccCubic target")]
+    ReducedPoseTarget,
+    #[error("reduced pose model identity or skeleton/morph counts do not match the FBX model")]
+    ReducedPoseBinding,
+    #[error("reduced pose frame {frame} cannot be represented as FBX time")]
+    ReducedPoseTime { frame: f32 },
+    #[error("pose reduction failed: {0}")]
+    PoseReduction(#[from] PoseReductionError),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct FbxReducedPoseExport {
+    pub bytes: Vec<u8>,
+    pub report: PoseReductionReport,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct UnityReducedPoseBindings {
+    pub model_identity: u64,
+    pub bone_paths: Vec<String>,
+    pub morph_bindings: Vec<Option<UnityMorphBinding>>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct UnityMorphBinding {
+    pub path: String,
+    pub property: String,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct UnityAnimationClipDto {
+    pub frame_rate: f32,
+    pub curves: Vec<UnityAnimationCurveDto>,
+    pub source_key_count: usize,
+    pub reduced_key_count: usize,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct UnityAnimationCurveDto {
+    pub path: String,
+    pub property: String,
+    pub keys: Vec<UnityAnimationKeyDto>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct UnityAnimationKeyDto {
+    pub time_seconds: f32,
+    pub value: f32,
+    pub in_tangent: f32,
+    pub out_tangent: f32,
 }
 
 /// Supplies one evaluated set of runtime bone world matrices per FBX frame.
 pub trait FbxPoseSource {
     fn world_matrices(&mut self, frame: u32) -> Result<&[Mat4], String>;
+    fn morph_weights(&self) -> Option<&[f32]> {
+        None
+    }
 }
 
 struct RuntimeBakePoseSource<'a> {
@@ -141,6 +198,10 @@ impl FbxPoseSource for RuntimeBakePoseSource<'_> {
     fn world_matrices(&mut self, frame: u32) -> Result<&[Mat4], String> {
         self.runtime.evaluate_clip_frame(self.clip, frame as f32);
         Ok(self.runtime.world_matrices())
+    }
+
+    fn morph_weights(&self) -> Option<&[f32]> {
+        Some(self.runtime.morph_weights())
     }
 }
 
@@ -187,6 +248,29 @@ pub fn export_pmx_fbx_binary_with_runtime_bake(
     )
 }
 
+pub fn export_pmx_fbx_binary_with_reduced_runtime_bake(
+    model: &PmxParsedModel,
+    runtime_model: Arc<ModelArena>,
+    clip: &AnimationClip,
+    last_frame: u32,
+    tolerances: ReductionTolerances,
+    options: &FbxExportOptions,
+) -> Result<FbxReducedPoseExport, FbxExportError> {
+    let mut pose_source = RuntimeBakePoseSource {
+        runtime: RuntimeInstance::new(Arc::clone(&runtime_model)),
+        clip,
+    };
+    export_pmx_fbx_binary_with_reduced_pose_source(
+        model,
+        runtime_model,
+        last_frame,
+        0,
+        tolerances,
+        options,
+        &mut pose_source,
+    )
+}
+
 /// Exports runtime-baked animation using caller-supplied world matrices.
 ///
 /// The source is called exactly once for every integer frame in `0..=last_frame`.
@@ -211,6 +295,179 @@ where
         pose_source,
     )?);
     export_pmx_fbx_binary_with_animation(model, animation, options)
+}
+
+/// Collects a dense final-pose source, reduces it with `DccCubic`, and exports sparse FBX curves.
+pub fn export_pmx_fbx_binary_with_reduced_pose_source<P>(
+    model: &PmxParsedModel,
+    runtime_model: Arc<ModelArena>,
+    last_frame: u32,
+    model_identity: u64,
+    tolerances: ReductionTolerances,
+    options: &FbxExportOptions,
+    pose_source: &mut P,
+) -> Result<FbxReducedPoseExport, FbxExportError>
+where
+    P: FbxPoseSource,
+{
+    let frame_count = last_frame as usize + 1;
+    let bone_count = runtime_model.bone_count();
+    let morph_count = runtime_model.morph_count() as usize;
+    let mut world_matrices = Vec::with_capacity(frame_count.saturating_mul(bone_count));
+    let mut morph_weights = Vec::with_capacity(frame_count.saturating_mul(morph_count));
+    for frame in 0..=last_frame {
+        let matrices = pose_source
+            .world_matrices(frame)
+            .map_err(|message| FbxExportError::PoseSource { frame, message })?;
+        if matrices.len() < bone_count {
+            return Err(FbxExportError::PoseBoneCount {
+                frame,
+                expected: bone_count,
+                actual: matrices.len(),
+            });
+        }
+        world_matrices.extend_from_slice(&matrices[..bone_count]);
+        let weights = pose_source
+            .morph_weights()
+            .ok_or_else(|| FbxExportError::PoseSource {
+                frame,
+                message: "reduced pose source must expose morph weights".to_owned(),
+            })?;
+        if weights.len() < morph_count {
+            return Err(FbxExportError::PoseSource {
+                frame,
+                message: format!(
+                    "reduced pose source returned {} morphs, expected {morph_count}",
+                    weights.len()
+                ),
+            });
+        }
+        morph_weights.extend_from_slice(&weights[..morph_count]);
+    }
+    let snapshot = SkeletonSnapshot::from_model(&runtime_model, model_identity)?;
+    let reduced = reduce_dense_pose_sequence(
+        DensePoseSequenceView::new(
+            &world_matrices,
+            &morph_weights,
+            frame_count,
+            bone_count,
+            morph_count,
+            0.0,
+            1.0,
+        )?,
+        snapshot,
+        tolerances,
+        ReductionTarget::DccCubic,
+    )?;
+    let report = reduced.report();
+    let bytes = export_pmx_fbx_binary_with_reduced_pose(model, &reduced, model_identity, options)?;
+    Ok(FbxReducedPoseExport { bytes, report })
+}
+
+/// Exports a target-native sparse DCC pose result as FBX user/broken tangent curves.
+pub fn export_pmx_fbx_binary_with_reduced_pose(
+    model: &PmxParsedModel,
+    reduced: &ReducedPoseSequence,
+    model_identity: u64,
+    options: &FbxExportOptions,
+) -> Result<Vec<u8>, FbxExportError> {
+    let animation = FbxAnimationData::from_reduced_pose(model, reduced, model_identity, options)?;
+    export_pmx_fbx_binary_with_animation(model, Some(animation), options)
+}
+
+/// Projects a sparse DCC pose result into flat Unity `AnimationCurve` bindings.
+///
+/// Euler XYZ curves are emitted deliberately; quaternion-component and FBX-import
+/// resampling profiles are separate concerns and are not implied by this DTO.
+pub fn reduced_pose_to_unity_animation_clip(
+    reduced: &ReducedPoseSequence,
+    bindings: &UnityReducedPoseBindings,
+    flip_z: bool,
+) -> Result<UnityAnimationClipDto, FbxExportError> {
+    validate_reduced_pose(
+        reduced,
+        bindings.model_identity,
+        bindings.bone_paths.len(),
+        bindings.morph_bindings.len(),
+    )?;
+    let mut curves = Vec::new();
+    let position_sign = [1.0, 1.0, if flip_z { -1.0 } else { 1.0 }];
+    let rotation_sign = [
+        if flip_z { -1.0 } else { 1.0 },
+        if flip_z { -1.0 } else { 1.0 },
+        1.0,
+    ];
+    for (bone, track) in reduced.bone_tracks().iter().enumerate() {
+        for (axis, sign) in position_sign.iter().copied().enumerate() {
+            let values = track
+                .keys()
+                .iter()
+                .map(|key| key.translation.to_array()[axis] * sign)
+                .collect::<Vec<_>>();
+            let tangents = bone_segment_tangents(track.keys(), axis, false, sign);
+            curves.push(UnityAnimationCurveDto {
+                path: bindings.bone_paths[bone].clone(),
+                property: format!("localPosition.{}", axis_name(axis)),
+                keys: unity_keys(reduced, track.keys(), &values, &tangents)?,
+            });
+        }
+        let mut previous = None;
+        let euler_values = track
+            .keys()
+            .iter()
+            .map(|key| {
+                let q = key.rotation;
+                let converted = convert_quat_to_fbx(
+                    [q.x as f64, q.y as f64, q.z as f64, q.w as f64],
+                    &FbxExportOptions {
+                        flip_z,
+                        ..FbxExportOptions::default()
+                    },
+                );
+                let euler = quat_to_euler_xyz(converted);
+                let filtered = previous
+                    .map(|value| euler_filter(euler, value))
+                    .unwrap_or(euler);
+                previous = Some(filtered);
+                filtered
+            })
+            .collect::<Vec<_>>();
+        for (axis, sign) in rotation_sign.iter().copied().enumerate() {
+            let values = euler_values
+                .iter()
+                .map(|value| value[axis] as f32)
+                .collect::<Vec<_>>();
+            let tangents = bone_segment_tangents(track.keys(), axis, true, sign);
+            curves.push(UnityAnimationCurveDto {
+                path: bindings.bone_paths[bone].clone(),
+                property: format!("localEulerAnglesRaw.{}", axis_name(axis)),
+                keys: unity_keys(reduced, track.keys(), &values, &tangents)?,
+            });
+        }
+    }
+    for (morph, track) in reduced.morph_tracks().iter().enumerate() {
+        let Some(binding) = &bindings.morph_bindings[morph] else {
+            continue;
+        };
+        let values = track
+            .keys()
+            .iter()
+            .map(|key| key.weight * 100.0)
+            .collect::<Vec<_>>();
+        let tangents = morph_segment_tangents(track.keys());
+        curves.push(UnityAnimationCurveDto {
+            path: binding.path.clone(),
+            property: binding.property.clone(),
+            keys: unity_morph_keys(reduced, track.keys(), &values, &tangents)?,
+        });
+    }
+    let report = reduced.report();
+    Ok(UnityAnimationClipDto {
+        frame_rate: 30.0,
+        curves,
+        source_key_count: report.source_bone_key_count + report.source_morph_key_count,
+        reduced_key_count: report.reduced_bone_key_count + report.reduced_morph_key_count,
+    })
 }
 
 fn export_pmx_fbx_binary_with_animation(
@@ -477,12 +734,22 @@ struct FbxAnimationTrack {
     frame_times: Vec<i64>,
     rotation_values: [Vec<f32>; 3],
     translation_values: [Vec<f32>; 3],
+    rotation_attributes: [Option<FbxCurveAttributes>; 3],
+    translation_attributes: [Option<FbxCurveAttributes>; 3],
 }
 
 struct FbxMorphAnimationTrack {
     export_index: usize,
     frame_times: Vec<i64>,
     weight_values: Vec<f32>,
+    attributes: Option<FbxCurveAttributes>,
+}
+
+#[derive(Clone)]
+struct FbxCurveAttributes {
+    flags: Vec<i32>,
+    data: Vec<f32>,
+    ref_counts: Vec<i32>,
 }
 
 struct RuntimeBakeTrack {
@@ -527,6 +794,128 @@ struct SortedKeyframe {
 }
 
 impl FbxAnimationData {
+    fn from_reduced_pose(
+        model: &PmxParsedModel,
+        reduced: &ReducedPoseSequence,
+        model_identity: u64,
+        options: &FbxExportOptions,
+    ) -> Result<Self, FbxExportError> {
+        validate_reduced_pose(
+            reduced,
+            model_identity,
+            model.skeleton.bones.len(),
+            model.morphs.len(),
+        )?;
+        let last_frame = *reduced.sample_frames().last().unwrap();
+        if last_frame < 0.0 || last_frame > u32::MAX as f32 {
+            return Err(FbxExportError::ReducedPoseTime { frame: last_frame });
+        }
+        let position_sign = [1.0, 1.0, if options.flip_z { -1.0 } else { 1.0 }];
+        let rotation_sign = [
+            if options.flip_z { -1.0 } else { 1.0 },
+            if options.flip_z { -1.0 } else { 1.0 },
+            1.0,
+        ];
+        let mut tracks = Vec::new();
+        for (bone_index, track) in reduced.bone_tracks().iter().enumerate() {
+            let rest_translation = reduced.snapshot().rest_local_translations()[bone_index];
+            let rest_rotation = reduced.snapshot().rest_local_rotations()[bone_index];
+            if track.keys().iter().all(|key| {
+                key.translation.distance(rest_translation) <= STATIC_BONE_EPSILON
+                    && key.rotation.dot(rest_rotation).abs() >= 1.0 - STATIC_BONE_EPSILON
+            }) {
+                continue;
+            }
+            let frame_times = track
+                .keys()
+                .iter()
+                .map(|key| reduced_key_time(reduced, key.sample_index))
+                .collect::<Result<Vec<_>, _>>()?;
+            let mut translation_values: [Vec<f32>; 3] = std::array::from_fn(|_| Vec::new());
+            let mut rotation_values: [Vec<f32>; 3] = std::array::from_fn(|_| Vec::new());
+            let mut previous_euler = None;
+            for key in track.keys() {
+                for axis in 0..3 {
+                    translation_values[axis]
+                        .push(key.translation.to_array()[axis] * position_sign[axis]);
+                }
+                let q = key.rotation;
+                let converted =
+                    convert_quat_to_fbx([q.x as f64, q.y as f64, q.z as f64, q.w as f64], options);
+                let euler = quat_to_euler_xyz(converted);
+                let filtered = previous_euler
+                    .map(|previous| euler_filter(euler, previous))
+                    .unwrap_or(euler);
+                previous_euler = Some(filtered);
+                for axis in 0..3 {
+                    rotation_values[axis].push(filtered[axis] as f32);
+                }
+            }
+            let rotation_attributes = std::array::from_fn(|axis| {
+                Some(curve_attributes(&bone_segment_tangents(
+                    track.keys(),
+                    axis,
+                    true,
+                    rotation_sign[axis],
+                )))
+            });
+            let translation_attributes = std::array::from_fn(|axis| {
+                Some(curve_attributes(&bone_segment_tangents(
+                    track.keys(),
+                    axis,
+                    false,
+                    position_sign[axis],
+                )))
+            });
+            tracks.push(FbxAnimationTrack {
+                bone_index,
+                frame_times,
+                rotation_values,
+                translation_values,
+                rotation_attributes,
+                translation_attributes,
+            });
+        }
+
+        let exported_morphs = exported_vertex_morph_indices(model);
+        let mut morph_tracks = Vec::new();
+        if !options.bones_only {
+            for (morph_index, track) in reduced.morph_tracks().iter().enumerate() {
+                let Some(export_index) = exported_morphs
+                    .iter()
+                    .position(|candidate| *candidate == morph_index)
+                else {
+                    continue;
+                };
+                if !track
+                    .keys()
+                    .iter()
+                    .any(|key| key.weight.abs() > STATIC_BONE_EPSILON)
+                {
+                    continue;
+                }
+                let frame_times = track
+                    .keys()
+                    .iter()
+                    .map(|key| reduced_key_time(reduced, key.sample_index))
+                    .collect::<Result<Vec<_>, _>>()?;
+                let weight_values = track.keys().iter().map(|key| key.weight * 100.0).collect();
+                let attributes = Some(curve_attributes(&morph_segment_tangents(track.keys())));
+                morph_tracks.push(FbxMorphAnimationTrack {
+                    export_index,
+                    frame_times,
+                    weight_values,
+                    attributes,
+                });
+            }
+        }
+        Ok(Self {
+            max_frame: last_frame.ceil() as u32,
+            tracks,
+            morph_tracks,
+        })
+    }
+
     fn from_pose_source<P>(
         model: &PmxParsedModel,
         runtime_model: Arc<ModelArena>,
@@ -631,6 +1020,8 @@ impl FbxAnimationData {
                 frame_times: frame_times.clone(),
                 rotation_values: track.rotation_values,
                 translation_values: track.translation_values,
+                rotation_attributes: [None, None, None],
+                translation_attributes: [None, None, None],
             })
             .collect();
         let morph_tracks = if options.bones_only {
@@ -719,6 +1110,8 @@ impl FbxAnimationData {
                 frame_times: frame_times.clone(),
                 rotation_values,
                 translation_values,
+                rotation_attributes: [None, None, None],
+                translation_attributes: [None, None, None],
             });
         }
 
@@ -732,6 +1125,176 @@ impl FbxAnimationData {
     fn last_time(&self) -> i64 {
         self.max_frame as i64 * FBX_FRAME_DURATION
     }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct SegmentTangents {
+    out_tangent: f32,
+    next_in_tangent: f32,
+}
+
+fn validate_reduced_pose(
+    reduced: &ReducedPoseSequence,
+    model_identity: u64,
+    bone_count: usize,
+    morph_count: usize,
+) -> Result<(), FbxExportError> {
+    if reduced.target() != ReductionTarget::DccCubic {
+        return Err(FbxExportError::ReducedPoseTarget);
+    }
+    if !reduced.validate_model(model_identity, bone_count, morph_count) {
+        return Err(FbxExportError::ReducedPoseBinding);
+    }
+    Ok(())
+}
+
+fn reduced_key_time(
+    reduced: &ReducedPoseSequence,
+    sample_index: usize,
+) -> Result<i64, FbxExportError> {
+    let frame = reduced.sample_frames()[sample_index];
+    let time = frame as f64 * FBX_TIME_ONE_SECOND as f64 / 30.0;
+    if frame < 0.0 || !time.is_finite() || time < i64::MIN as f64 || time > i64::MAX as f64 {
+        Err(FbxExportError::ReducedPoseTime { frame })
+    } else {
+        Ok(time.round() as i64)
+    }
+}
+
+fn bone_segment_tangents(
+    keys: &[ReducedBoneKey],
+    axis: usize,
+    rotation: bool,
+    sign: f32,
+) -> Vec<SegmentTangents> {
+    (0..keys.len())
+        .map(|key| {
+            let Some(next) = keys.get(key + 1) else {
+                return SegmentTangents {
+                    out_tangent: 0.0,
+                    next_in_tangent: 0.0,
+                };
+            };
+            let segment = next.dcc_segment;
+            let (out_tangent, next_in_tangent, scale) = if rotation {
+                (
+                    segment.rotation_out_tangent.to_array()[axis],
+                    segment.rotation_in_tangent.to_array()[axis],
+                    sign * 30.0 * 180.0 / std::f32::consts::PI,
+                )
+            } else {
+                (
+                    segment.translation_out_tangent.to_array()[axis],
+                    segment.translation_in_tangent.to_array()[axis],
+                    sign * 30.0,
+                )
+            };
+            SegmentTangents {
+                out_tangent: out_tangent * scale,
+                next_in_tangent: next_in_tangent * scale,
+            }
+        })
+        .collect()
+}
+
+fn morph_segment_tangents(keys: &[ReducedMorphKey]) -> Vec<SegmentTangents> {
+    (0..keys.len())
+        .map(|key| {
+            let Some(next) = keys.get(key + 1) else {
+                return SegmentTangents {
+                    out_tangent: 0.0,
+                    next_in_tangent: 0.0,
+                };
+            };
+            SegmentTangents {
+                out_tangent: next.dcc_segment.out_tangent * 3_000.0,
+                next_in_tangent: next.dcc_segment.in_tangent * 3_000.0,
+            }
+        })
+        .collect()
+}
+
+fn curve_attributes(tangents: &[SegmentTangents]) -> FbxCurveAttributes {
+    const CUBIC_USER: i32 = 0x0000_0408;
+    const LINEAR_USER: i32 = 0x0000_0404;
+    const DEFAULT_WEIGHT_TOKEN: f32 = f32::from_bits(218_434_821);
+    let mut flags = Vec::with_capacity(tangents.len());
+    let mut data = Vec::with_capacity(tangents.len() * 4);
+    for (index, tangent) in tangents.iter().enumerate() {
+        flags.push(if index + 1 < tangents.len() {
+            CUBIC_USER
+        } else {
+            LINEAR_USER
+        });
+        data.extend_from_slice(&[
+            tangent.out_tangent,
+            tangent.next_in_tangent,
+            DEFAULT_WEIGHT_TOKEN,
+            0.0,
+        ]);
+    }
+    FbxCurveAttributes {
+        flags,
+        data,
+        ref_counts: vec![1; tangents.len()],
+    }
+}
+
+fn unity_keys(
+    reduced: &ReducedPoseSequence,
+    source_keys: &[ReducedBoneKey],
+    values: &[f32],
+    tangents: &[SegmentTangents],
+) -> Result<Vec<UnityAnimationKeyDto>, FbxExportError> {
+    unity_keys_from_indices(
+        reduced,
+        source_keys.iter().map(|key| key.sample_index),
+        values,
+        tangents,
+    )
+}
+
+fn unity_morph_keys(
+    reduced: &ReducedPoseSequence,
+    source_keys: &[ReducedMorphKey],
+    values: &[f32],
+    tangents: &[SegmentTangents],
+) -> Result<Vec<UnityAnimationKeyDto>, FbxExportError> {
+    unity_keys_from_indices(
+        reduced,
+        source_keys.iter().map(|key| key.sample_index),
+        values,
+        tangents,
+    )
+}
+
+fn unity_keys_from_indices(
+    reduced: &ReducedPoseSequence,
+    sample_indices: impl Iterator<Item = usize>,
+    values: &[f32],
+    tangents: &[SegmentTangents],
+) -> Result<Vec<UnityAnimationKeyDto>, FbxExportError> {
+    sample_indices
+        .enumerate()
+        .map(|(index, sample_index)| {
+            let frame = reduced.sample_frames()[sample_index];
+            if frame < 0.0 || !frame.is_finite() {
+                return Err(FbxExportError::ReducedPoseTime { frame });
+            }
+            Ok(UnityAnimationKeyDto {
+                time_seconds: frame / 30.0,
+                value: values[index],
+                in_tangent: index
+                    .checked_sub(1)
+                    .map_or(0.0, |previous| tangents[previous].next_in_tangent),
+                out_tangent: tangents[index].out_tangent,
+            })
+        })
+        .collect()
+}
+
+fn axis_name(axis: usize) -> char {
+    ['x', 'y', 'z'][axis]
 }
 
 fn translation_changed(translation: glam::Vec3, rest: glam::Vec3A) -> bool {
@@ -868,6 +1431,7 @@ fn collect_runtime_bake_morph_tracks(
             export_index,
             frame_times: frame_times.to_vec(),
             weight_values,
+            attributes: None,
         });
     }
     morph_tracks
@@ -913,6 +1477,7 @@ fn collect_vmd_morph_tracks(
             export_index,
             frame_times,
             weight_values,
+            attributes: None,
         });
     }
     morph_tracks.sort_by_key(|track| track.export_index);
@@ -2367,6 +2932,7 @@ fn write_animation<W: Write + Seek>(
                 animation_curve_id(track.bone_index, channel),
                 &track.frame_times,
                 &track.rotation_values[channel],
+                track.rotation_attributes[channel].as_ref(),
             )?;
         }
         for channel in 0..3 {
@@ -2375,6 +2941,7 @@ fn write_animation<W: Write + Seek>(
                 animation_curve_id(track.bone_index, channel + 3),
                 &track.frame_times,
                 &track.translation_values[channel],
+                track.translation_attributes[channel].as_ref(),
             )?;
         }
     }
@@ -2385,6 +2952,7 @@ fn write_animation<W: Write + Seek>(
             animation_curve_morph_id(track_index),
             &track.frame_times,
             &track.weight_values,
+            track.attributes.as_ref(),
         )?;
     }
     Ok(())
@@ -2465,6 +3033,7 @@ fn write_animation_curve<W: Write + Seek>(
     id: i64,
     frame_times: &[i64],
     values: &[f32],
+    attributes: Option<&FbxCurveAttributes>,
 ) -> Result<(), FbxExportError> {
     begin_node(writer, "AnimationCurve", |attrs| {
         attrs.append_i64(id)?;
@@ -2476,13 +3045,19 @@ fn write_animation_curve<W: Write + Seek>(
     write_i32_node(writer, "KeyVer", 4009)?;
     write_arr_i64_node(writer, "KeyTime", frame_times)?;
     write_arr_f32_node(writer, "KeyValueFloat", values)?;
-    write_arr_i32_node(writer, "KeyAttrFlags", &[0x00006108_i32])?;
-    write_arr_f32_node(
-        writer,
-        "KeyAttrDataFloat",
-        &[0.0_f32, 0.0_f32, 0.0_f32, 0.0_f32],
-    )?;
-    write_arr_i32_node(writer, "KeyAttrRefCount", &[values.len() as i32])?;
+    if let Some(attributes) = attributes {
+        write_arr_i32_node(writer, "KeyAttrFlags", &attributes.flags)?;
+        write_arr_f32_node(writer, "KeyAttrDataFloat", &attributes.data)?;
+        write_arr_i32_node(writer, "KeyAttrRefCount", &attributes.ref_counts)?;
+    } else {
+        write_arr_i32_node(writer, "KeyAttrFlags", &[0x00006108_i32])?;
+        write_arr_f32_node(
+            writer,
+            "KeyAttrDataFloat",
+            &[0.0_f32, 0.0_f32, 0.0_f32, 0.0_f32],
+        )?;
+        write_arr_i32_node(writer, "KeyAttrRefCount", &[values.len() as i32])?;
+    }
     writer.close_node()?;
     Ok(())
 }
@@ -2972,6 +3547,10 @@ mod tests {
     use std::sync::Arc;
 
     use fbxcel::{low::v7400::AttributeValue, tree::any::AnyTree};
+    use glam::Vec3;
+    use mmd_anim_runtime::{
+        DensePoseSequenceView, ReductionTolerances, SkeletonSnapshot, reduce_dense_pose_sequence,
+    };
 
     use super::*;
 
@@ -3006,6 +3585,181 @@ mod tests {
         )
         .expect("runtime-baked FBX should export");
         (model, fbx)
+    }
+
+    fn reduced_fbx_fixture() -> (PmxParsedModel, ReducedPoseSequence, usize) {
+        let pmx_data = include_bytes!("../../fixtures/pmx/ik_multi_axis_limit.pmx");
+        let model = crate::parse_pmx_model(pmx_data).unwrap();
+        let runtime = crate::import_pmx_runtime(pmx_data).unwrap().model;
+        let snapshot = SkeletonSnapshot::from_model(&runtime, 123).unwrap();
+        let root = snapshot
+            .parent_indices()
+            .iter()
+            .position(|parent| *parent < 0)
+            .unwrap();
+        let frame_count = 9;
+        let mut world = Vec::with_capacity(frame_count * snapshot.bone_count());
+        for frame in 0..frame_count {
+            let t = frame as f32 / (frame_count - 1) as f32;
+            let peak = 4.0 * t * (1.0 - t);
+            let mut frame_world = vec![Mat4::IDENTITY; snapshot.bone_count()];
+            let mut resolved = vec![false; snapshot.bone_count()];
+            fn resolve(
+                bone: usize,
+                root: usize,
+                peak: f32,
+                snapshot: &SkeletonSnapshot,
+                world: &mut [Mat4],
+                resolved: &mut [bool],
+            ) {
+                if resolved[bone] {
+                    return;
+                }
+                let parent = snapshot.parent_indices()[bone];
+                if parent >= 0 {
+                    resolve(parent as usize, root, peak, snapshot, world, resolved);
+                }
+                let mut translation = snapshot.rest_local_translations()[bone];
+                if bone == root {
+                    translation.x += peak;
+                }
+                let local = Mat4::from_rotation_translation(
+                    snapshot.rest_local_rotations()[bone],
+                    Vec3::from(translation),
+                );
+                world[bone] = if parent < 0 {
+                    local
+                } else {
+                    world[parent as usize] * local
+                };
+                resolved[bone] = true;
+            }
+            for bone in 0..snapshot.bone_count() {
+                resolve(bone, root, peak, &snapshot, &mut frame_world, &mut resolved);
+            }
+            world.extend(frame_world);
+        }
+        let morphs = vec![0.0; frame_count * snapshot.morph_count()];
+        let reduced = reduce_dense_pose_sequence(
+            DensePoseSequenceView::new(
+                &world,
+                &morphs,
+                frame_count,
+                snapshot.bone_count(),
+                snapshot.morph_count(),
+                0.0,
+                1.0,
+            )
+            .unwrap(),
+            snapshot,
+            ReductionTolerances {
+                local_position: 0.01,
+                world_position: 0.01,
+                ..Default::default()
+            },
+            ReductionTarget::DccCubic,
+        )
+        .unwrap();
+        (model, reduced, root)
+    }
+
+    #[test]
+    fn reduced_pose_writes_sparse_per_key_user_tangents_and_replays_samples() {
+        let (model, reduced, root) = reduced_fbx_fixture();
+        let fbx = export_pmx_fbx_binary_with_reduced_pose(
+            &model,
+            &reduced,
+            123,
+            &FbxExportOptions {
+                flip_z: false,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let tree = load_tree(&fbx);
+        let root_node = tree.root();
+        let objects = root_node.first_child_by_name("Objects").unwrap();
+        let curve = objects
+            .children_by_name("AnimationCurve")
+            .find(|node| {
+                node.attributes().first().and_then(AttributeValue::get_i64)
+                    == Some(animation_curve_id(root, 3))
+            })
+            .unwrap();
+        let times = child_arr_i64(curve, "KeyTime");
+        let values = child_arr_f32(curve, "KeyValueFloat");
+        let flags = child_arr_i32(curve, "KeyAttrFlags");
+        let data = child_arr_f32(curve, "KeyAttrDataFloat");
+        let refs = child_arr_i32(curve, "KeyAttrRefCount");
+        assert_eq!(times.len(), 3);
+        assert_eq!(times.len(), values.len());
+        assert_eq!(flags.len(), values.len());
+        assert_eq!(data.len(), values.len() * 4);
+        assert_eq!(refs, vec![1; values.len()]);
+        assert!(flags[..flags.len() - 1].iter().all(|flag| *flag == 0x408));
+        assert_eq!(flags[flags.len() - 1], 0x404);
+
+        for frame in 0..9 {
+            let time = frame as f32 / 30.0;
+            let upper = times
+                .partition_point(|key| (*key as f64 / FBX_TIME_ONE_SECOND as f64) <= time as f64);
+            let actual = if upper == 0 {
+                values[0]
+            } else if upper == values.len() {
+                values[values.len() - 1]
+            } else {
+                let left = upper - 1;
+                let right = upper;
+                let left_time = times[left] as f32 / FBX_TIME_ONE_SECOND as f32;
+                let right_time = times[right] as f32 / FBX_TIME_ONE_SECOND as f32;
+                let amount = (time - left_time) / (right_time - left_time);
+                let duration = right_time - left_time;
+                let t2 = amount * amount;
+                let t3 = t2 * amount;
+                (2.0 * t3 - 3.0 * t2 + 1.0) * values[left]
+                    + (t3 - 2.0 * t2 + amount) * duration * data[left * 4]
+                    + (-2.0 * t3 + 3.0 * t2) * values[right]
+                    + (t3 - t2) * duration * data[left * 4 + 1]
+            };
+            let t = frame as f32 / 8.0;
+            let expected =
+                reduced.snapshot().rest_local_translations()[root].x + 4.0 * t * (1.0 - t);
+            assert!(
+                (actual - expected).abs() <= 0.01,
+                "{frame}: {actual} {expected}"
+            );
+        }
+    }
+
+    #[test]
+    fn unity_direct_clip_dto_keeps_sparse_times_and_tangents_separate_from_fbx_import() {
+        let (_model, reduced, root) = reduced_fbx_fixture();
+        let mut bone_paths = (0..reduced.snapshot().bone_count())
+            .map(|bone| format!("root/bone{bone}"))
+            .collect::<Vec<_>>();
+        bone_paths[root] = "root/moving".to_owned();
+        let dto = reduced_pose_to_unity_animation_clip(
+            &reduced,
+            &UnityReducedPoseBindings {
+                model_identity: 123,
+                bone_paths,
+                morph_bindings: vec![None; reduced.snapshot().morph_count()],
+            },
+            false,
+        )
+        .unwrap();
+        let curve = dto
+            .curves
+            .iter()
+            .find(|curve| curve.path == "root/moving" && curve.property == "localPosition.x")
+            .unwrap();
+        assert_eq!(curve.keys.len(), 3);
+        assert_eq!(curve.keys[0].time_seconds, 0.0);
+        assert!((curve.keys[2].time_seconds - 8.0 / 30.0).abs() <= f32::EPSILON);
+        assert!(curve.keys.iter().all(|key| {
+            key.in_tangent.is_finite() && key.out_tangent.is_finite() && key.value.is_finite()
+        }));
+        assert!(dto.reduced_key_count < dto.source_key_count);
     }
 
     #[test]
@@ -3164,6 +3918,14 @@ mod tests {
             .and_then(AttributeValue::get_arr_i32)
             .map(|values| values.to_vec())
             .unwrap_or_else(|| panic!("missing i32 array child node {name}"))
+    }
+
+    fn child_arr_i64(node: fbxcel::tree::v7400::NodeHandle<'_>, name: &str) -> Vec<i64> {
+        node.first_child_by_name(name)
+            .and_then(|child| child.attributes().first())
+            .and_then(AttributeValue::get_arr_i64)
+            .map(|values| values.to_vec())
+            .unwrap_or_else(|| panic!("missing i64 array child node {name}"))
     }
 
     fn child_arr_f64(node: fbxcel::tree::v7400::NodeHandle<'_>, name: &str) -> Vec<f64> {

--- a/crates/mmd-anim-format/src/fbx/mod.rs
+++ b/crates/mmd-anim-format/src/fbx/mod.rs
@@ -136,6 +136,14 @@ pub enum FbxExportError {
     ReducedPoseBinding,
     #[error("reduced pose frame {frame} cannot be represented as FBX time")]
     ReducedPoseTime { frame: f32 },
+    #[error("frames per second must be finite and greater than zero")]
+    InvalidFramesPerSecond,
+    #[error("Unity curve {curve_index} key {key_index} has non-finite {field}")]
+    NonFiniteUnityKey {
+        curve_index: usize,
+        key_index: usize,
+        field: &'static str,
+    },
     #[error("pose reduction failed: {0}")]
     PoseReduction(#[from] PoseReductionError),
 }
@@ -402,6 +410,23 @@ pub fn reduced_pose_to_unity_animation_clip(
     bindings: &UnityReducedPoseBindings,
     flip_z: bool,
 ) -> Result<UnityAnimationClipDto, FbxExportError> {
+    reduced_pose_to_unity_animation_clip_with_fps(reduced, bindings, 30.0, flip_z)
+}
+
+/// Projects a sparse DCC pose result into flat Unity `AnimationCurve` bindings
+/// using an explicit host frame rate.
+///
+/// Times and Hermite tangents are converted to seconds here so native callers
+/// do not need to duplicate the reducer's target-specific conversion rules.
+pub fn reduced_pose_to_unity_animation_clip_with_fps(
+    reduced: &ReducedPoseSequence,
+    bindings: &UnityReducedPoseBindings,
+    frames_per_second: f32,
+    flip_z: bool,
+) -> Result<UnityAnimationClipDto, FbxExportError> {
+    if !frames_per_second.is_finite() || frames_per_second <= 0.0 {
+        return Err(FbxExportError::InvalidFramesPerSecond);
+    }
     validate_reduced_pose(
         reduced,
         bindings.model_identity,
@@ -422,11 +447,12 @@ pub fn reduced_pose_to_unity_animation_clip(
                 .iter()
                 .map(|key| key.translation.to_array()[axis] * sign)
                 .collect::<Vec<_>>();
-            let tangents = bone_segment_tangents(track.keys(), axis, false, sign);
+            let tangents =
+                bone_segment_tangents(track.keys(), axis, false, sign, frames_per_second);
             curves.push(UnityAnimationCurveDto {
                 path: bindings.bone_paths[bone].clone(),
                 property: format!("localPosition.{}", axis_name(axis)),
-                keys: unity_keys(reduced, track.keys(), &values, &tangents)?,
+                keys: unity_keys(reduced, track.keys(), &values, &tangents, frames_per_second)?,
             });
         }
         let mut previous = None;
@@ -455,11 +481,11 @@ pub fn reduced_pose_to_unity_animation_clip(
                 .iter()
                 .map(|value| value[axis] as f32)
                 .collect::<Vec<_>>();
-            let tangents = bone_segment_tangents(track.keys(), axis, true, sign);
+            let tangents = bone_segment_tangents(track.keys(), axis, true, sign, frames_per_second);
             curves.push(UnityAnimationCurveDto {
                 path: bindings.bone_paths[bone].clone(),
                 property: format!("localEulerAnglesRaw.{}", axis_name(axis)),
-                keys: unity_keys(reduced, track.keys(), &values, &tangents)?,
+                keys: unity_keys(reduced, track.keys(), &values, &tangents, frames_per_second)?,
             });
         }
     }
@@ -472,16 +498,34 @@ pub fn reduced_pose_to_unity_animation_clip(
             .iter()
             .map(|key| key.weight * 100.0)
             .collect::<Vec<_>>();
-        let tangents = morph_segment_tangents(track.keys());
+        let tangents = morph_segment_tangents(track.keys(), frames_per_second);
         curves.push(UnityAnimationCurveDto {
             path: binding.path.clone(),
             property: binding.property.clone(),
-            keys: unity_morph_keys(reduced, track.keys(), &values, &tangents)?,
+            keys: unity_morph_keys(reduced, track.keys(), &values, &tangents, frames_per_second)?,
         });
+    }
+    for (curve_index, curve) in curves.iter().enumerate() {
+        for (key_index, key) in curve.keys.iter().enumerate() {
+            for (field, value) in [
+                ("time_seconds", key.time_seconds),
+                ("value", key.value),
+                ("in_tangent", key.in_tangent),
+                ("out_tangent", key.out_tangent),
+            ] {
+                if !value.is_finite() {
+                    return Err(FbxExportError::NonFiniteUnityKey {
+                        curve_index,
+                        key_index,
+                        field,
+                    });
+                }
+            }
+        }
     }
     let report = reduced.report();
     Ok(UnityAnimationClipDto {
-        frame_rate: 30.0,
+        frame_rate: frames_per_second,
         curves,
         source_key_count: report.source_bone_key_count + report.source_morph_key_count,
         reduced_key_count: report.reduced_bone_key_count + report.reduced_morph_key_count,
@@ -875,6 +919,7 @@ impl FbxAnimationData {
                     axis,
                     true,
                     rotation_sign[axis],
+                    30.0,
                 )))
             });
             let translation_attributes = std::array::from_fn(|axis| {
@@ -883,6 +928,7 @@ impl FbxAnimationData {
                     axis,
                     false,
                     position_sign[axis],
+                    30.0,
                 )))
             });
             tracks.push(FbxAnimationTrack {
@@ -918,7 +964,10 @@ impl FbxAnimationData {
                     .map(|key| reduced_key_time(reduced, key.sample_index))
                     .collect::<Result<Vec<_>, _>>()?;
                 let weight_values = track.keys().iter().map(|key| key.weight * 100.0).collect();
-                let attributes = Some(curve_attributes(&morph_segment_tangents(track.keys())));
+                let attributes = Some(curve_attributes(&morph_segment_tangents(
+                    track.keys(),
+                    30.0,
+                )));
                 morph_tracks.push(FbxMorphAnimationTrack {
                     export_index,
                     frame_times,
@@ -1184,6 +1233,7 @@ fn bone_segment_tangents(
     axis: usize,
     rotation: bool,
     sign: f32,
+    frames_per_second: f32,
 ) -> Vec<SegmentTangents> {
     (0..keys.len())
         .map(|key| {
@@ -1198,13 +1248,13 @@ fn bone_segment_tangents(
                 (
                     segment.rotation_out_tangent.to_array()[axis],
                     segment.rotation_in_tangent.to_array()[axis],
-                    sign * 30.0 * 180.0 / std::f32::consts::PI,
+                    sign * frames_per_second * 180.0 / std::f32::consts::PI,
                 )
             } else {
                 (
                     segment.translation_out_tangent.to_array()[axis],
                     segment.translation_in_tangent.to_array()[axis],
-                    sign * 30.0,
+                    sign * frames_per_second,
                 )
             };
             SegmentTangents {
@@ -1215,7 +1265,11 @@ fn bone_segment_tangents(
         .collect()
 }
 
-fn morph_segment_tangents(keys: &[ReducedMorphKey]) -> Vec<SegmentTangents> {
+fn morph_segment_tangents(
+    keys: &[ReducedMorphKey],
+    frames_per_second: f32,
+) -> Vec<SegmentTangents> {
+    let tangent_scale = frames_per_second * 100.0;
     (0..keys.len())
         .map(|key| {
             let Some(next) = keys.get(key + 1) else {
@@ -1225,8 +1279,8 @@ fn morph_segment_tangents(keys: &[ReducedMorphKey]) -> Vec<SegmentTangents> {
                 };
             };
             SegmentTangents {
-                out_tangent: next.dcc_segment.out_tangent * 3_000.0,
-                next_in_tangent: next.dcc_segment.in_tangent * 3_000.0,
+                out_tangent: next.dcc_segment.out_tangent * tangent_scale,
+                next_in_tangent: next.dcc_segment.in_tangent * tangent_scale,
             }
         })
         .collect()
@@ -1263,12 +1317,14 @@ fn unity_keys(
     source_keys: &[ReducedBoneKey],
     values: &[f32],
     tangents: &[SegmentTangents],
+    frames_per_second: f32,
 ) -> Result<Vec<UnityAnimationKeyDto>, FbxExportError> {
     unity_keys_from_indices(
         reduced,
         source_keys.iter().map(|key| key.sample_index),
         values,
         tangents,
+        frames_per_second,
     )
 }
 
@@ -1277,12 +1333,14 @@ fn unity_morph_keys(
     source_keys: &[ReducedMorphKey],
     values: &[f32],
     tangents: &[SegmentTangents],
+    frames_per_second: f32,
 ) -> Result<Vec<UnityAnimationKeyDto>, FbxExportError> {
     unity_keys_from_indices(
         reduced,
         source_keys.iter().map(|key| key.sample_index),
         values,
         tangents,
+        frames_per_second,
     )
 }
 
@@ -1291,6 +1349,7 @@ fn unity_keys_from_indices(
     sample_indices: impl Iterator<Item = usize>,
     values: &[f32],
     tangents: &[SegmentTangents],
+    frames_per_second: f32,
 ) -> Result<Vec<UnityAnimationKeyDto>, FbxExportError> {
     sample_indices
         .enumerate()
@@ -1300,7 +1359,7 @@ fn unity_keys_from_indices(
                 return Err(FbxExportError::ReducedPoseTime { frame });
             }
             Ok(UnityAnimationKeyDto {
-                time_seconds: frame / 30.0,
+                time_seconds: frame / frames_per_second,
                 value: values[index],
                 in_tangent: index
                     .checked_sub(1)
@@ -3802,6 +3861,55 @@ mod tests {
             key.in_tangent.is_finite() && key.out_tangent.is_finite() && key.value.is_finite()
         }));
         assert!(dto.reduced_key_count < dto.source_key_count);
+
+        let sixty_fps = reduced_pose_to_unity_animation_clip_with_fps(
+            &reduced,
+            &UnityReducedPoseBindings {
+                model_identity: 123,
+                bone_paths: (0..reduced.snapshot().bone_count())
+                    .map(|bone| format!("root/bone{bone}"))
+                    .collect(),
+                morph_bindings: vec![None; reduced.snapshot().morph_count()],
+            },
+            60.0,
+            false,
+        )
+        .unwrap();
+        let sixty_curve = &sixty_fps.curves[root * 6];
+        assert_eq!(sixty_fps.frame_rate, 60.0);
+        assert_eq!(sixty_curve.keys[2].time_seconds, 8.0 / 60.0);
+        assert_eq!(
+            sixty_curve.keys[0].out_tangent,
+            curve.keys[0].out_tangent * 2.0
+        );
+        assert!(matches!(
+            reduced_pose_to_unity_animation_clip_with_fps(
+                &reduced,
+                &UnityReducedPoseBindings {
+                    model_identity: 123,
+                    bone_paths: vec![String::new(); reduced.snapshot().bone_count()],
+                    morph_bindings: vec![None; reduced.snapshot().morph_count()],
+                },
+                f32::NAN,
+                false,
+            ),
+            Err(FbxExportError::InvalidFramesPerSecond)
+        ));
+        for frames_per_second in [f32::MAX, f32::from_bits(1)] {
+            assert!(matches!(
+                reduced_pose_to_unity_animation_clip_with_fps(
+                    &reduced,
+                    &UnityReducedPoseBindings {
+                        model_identity: 123,
+                        bone_paths: vec![String::new(); reduced.snapshot().bone_count()],
+                        morph_bindings: vec![None; reduced.snapshot().morph_count()],
+                    },
+                    frames_per_second,
+                    false,
+                ),
+                Err(FbxExportError::NonFiniteUnityKey { .. })
+            ));
+        }
     }
 
     #[test]

--- a/crates/mmd-anim-format/src/fbx/mod.rs
+++ b/crates/mmd-anim-format/src/fbx/mod.rs
@@ -14,7 +14,8 @@ use glam::Mat4;
 use mmd_anim_runtime::{
     AnimationClip, BoneIndex, DensePoseSequenceView, ModelArena, MorphIndex, PoseReductionError,
     PoseReductionReport, ReducedBoneKey, ReducedMorphKey, ReducedPoseSequence, ReductionTarget,
-    ReductionTolerances, RuntimeInstance, SkeletonSnapshot, reduce_dense_pose_sequence,
+    ReductionTimings, ReductionTolerances, ReductionWorkStats, RuntimeInstance, SkeletonSnapshot,
+    reduce_dense_pose_sequence,
 };
 
 use crate::{
@@ -139,10 +140,20 @@ pub enum FbxExportError {
     PoseReduction(#[from] PoseReductionError),
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone)]
 pub struct FbxReducedPoseExport {
     pub bytes: Vec<u8>,
     pub report: PoseReductionReport,
+    pub work_stats: ReductionWorkStats,
+    pub timings: ReductionTimings,
+}
+
+impl PartialEq for FbxReducedPoseExport {
+    fn eq(&self, other: &Self) -> bool {
+        self.bytes == other.bytes
+            && self.report == other.report
+            && self.work_stats == other.work_stats
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -360,8 +371,15 @@ where
         ReductionTarget::DccCubic,
     )?;
     let report = reduced.report();
+    let work_stats = reduced.work_stats().clone();
+    let timings = reduced.timings();
     let bytes = export_pmx_fbx_binary_with_reduced_pose(model, &reduced, model_identity, options)?;
-    Ok(FbxReducedPoseExport { bytes, report })
+    Ok(FbxReducedPoseExport {
+        bytes,
+        report,
+        work_stats,
+        timings,
+    })
 }
 
 /// Exports a target-native sparse DCC pose result as FBX user/broken tangent curves.
@@ -3545,6 +3563,7 @@ fn write_property_color<W: Write + Seek>(
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
+    use std::time::Duration;
 
     use fbxcel::{low::v7400::AttributeValue, tree::any::AnyTree};
     use glam::Vec3;
@@ -3553,6 +3572,27 @@ mod tests {
     };
 
     use super::*;
+
+    #[test]
+    fn reduced_export_equality_ignores_nondeterministic_timings() {
+        let first = FbxReducedPoseExport {
+            bytes: vec![1, 2, 3],
+            report: PoseReductionReport::default(),
+            work_stats: ReductionWorkStats::default(),
+            timings: ReductionTimings {
+                candidate_build: Duration::from_millis(1),
+                error_measure: Duration::from_millis(2),
+                dcc_fit: Duration::from_millis(1),
+            },
+        };
+        let mut second = first.clone();
+        second.timings = ReductionTimings {
+            candidate_build: Duration::from_secs(1),
+            error_measure: Duration::from_secs(2),
+            dcc_fit: Duration::from_secs(1),
+        };
+        assert_eq!(first, second);
+    }
 
     fn runtime_baked_fixture_fbx() -> (PmxParsedModel, Vec<u8>) {
         let pmx_data = include_bytes!("../../fixtures/pmx/ik_multi_axis_limit.pmx");

--- a/crates/mmd-anim-format/src/fbx/mod.rs
+++ b/crates/mmd-anim-format/src/fbx/mod.rs
@@ -3580,6 +3580,7 @@ mod tests {
             report: PoseReductionReport::default(),
             work_stats: ReductionWorkStats::default(),
             timings: ReductionTimings {
+                local_prefit: Duration::from_millis(3),
                 candidate_build: Duration::from_millis(1),
                 error_measure: Duration::from_millis(2),
                 dcc_fit: Duration::from_millis(1),
@@ -3587,6 +3588,7 @@ mod tests {
         };
         let mut second = first.clone();
         second.timings = ReductionTimings {
+            local_prefit: Duration::from_secs(3),
             candidate_build: Duration::from_secs(1),
             error_measure: Duration::from_secs(2),
             dcc_fit: Duration::from_secs(1),

--- a/crates/mmd-anim-format/src/fbx/skin_diff.rs
+++ b/crates/mmd-anim-format/src/fbx/skin_diff.rs
@@ -12,7 +12,10 @@ use std::{collections::HashMap, io::Cursor};
 
 use fbxcel::{
     low::v7400::AttributeValue,
-    tree::{any::AnyTree, v7400::{NodeHandle, Tree}},
+    tree::{
+        any::AnyTree,
+        v7400::{NodeHandle, Tree},
+    },
 };
 
 /// One parsed FBX skin cluster (per-bone deformer).
@@ -94,8 +97,8 @@ pub fn read_fbx_skin_clusters(bytes: &[u8]) -> Result<Vec<FbxSkinClusterData>, F
             .unwrap_or_else(|| format!("<unresolved-cluster-{cluster_id}>"));
         let indices = arr_i32_child(deformer, "Indexes").unwrap_or_default();
         let weights = arr_f64_child(deformer, "Weights").unwrap_or_default();
-        let transform =
-            arr_f64_child(deformer, "Transform").and_then(|values| <[f64; 16]>::try_from(values.as_slice()).ok());
+        let transform = arr_f64_child(deformer, "Transform")
+            .and_then(|values| <[f64; 16]>::try_from(values.as_slice()).ok());
         let transform_link = arr_f64_child(deformer, "TransformLink")
             .and_then(|values| <[f64; 16]>::try_from(values.as_slice()).ok());
         clusters.push(FbxSkinClusterData {
@@ -339,7 +342,12 @@ fn diff_one_bone(
         transform_b,
         transform_link_a,
         transform_link_b,
-        transform_differs: matrix_differs(transform_max_abs_delta, transform_a, transform_b, options.matrix_epsilon),
+        transform_differs: matrix_differs(
+            transform_max_abs_delta,
+            transform_a,
+            transform_b,
+            options.matrix_epsilon,
+        ),
         transform_link_differs: matrix_differs(
             transform_link_max_abs_delta,
             transform_link_a,
@@ -366,7 +374,9 @@ fn matrix_max_abs_delta(a: Option<[f64; 16]>, b: Option<[f64; 16]>) -> Option<f6
             .iter()
             .zip(b.iter())
             .map(|(x, y)| (x - y).abs())
-            .fold(None, |max, delta| Some(max.map_or(delta, |max: f64| max.max(delta)))),
+            .fold(None, |max, delta| {
+                Some(max.map_or(delta, |max: f64| max.max(delta)))
+            }),
         _ => None,
     }
 }
@@ -455,10 +465,18 @@ mod tests {
         let b = vec![cluster("OnlyB", &[0], &[1.0])];
         let report = diff_fbx_skin_clusters(&a, &b, FbxSkinDiffOptions::default());
         assert_eq!(report.bones.len(), 2);
-        let only_a = report.bones.iter().find(|bone| bone.bone_name == "OnlyA").unwrap();
+        let only_a = report
+            .bones
+            .iter()
+            .find(|bone| bone.bone_name == "OnlyA")
+            .unwrap();
         assert!(only_a.in_a && !only_a.in_b);
         assert!(only_a.has_differences());
-        let only_b = report.bones.iter().find(|bone| bone.bone_name == "OnlyB").unwrap();
+        let only_b = report
+            .bones
+            .iter()
+            .find(|bone| bone.bone_name == "OnlyB")
+            .unwrap();
         assert!(!only_b.in_a && only_b.in_b);
         assert!(only_b.has_differences());
     }

--- a/crates/mmd-anim-format/src/lib.rs
+++ b/crates/mmd-anim-format/src/lib.rs
@@ -43,11 +43,13 @@ pub use pmx::{
     split_pmx_model_by_material, validate_pmx_export_model,
 };
 pub use vmd::{
-    VmdCameraState, VmdClipBuildOptions, VmdIkEntry, VmdImportResult, VmdLightState,
-    VmdParsedAnimation, VmdPropertyIkFrame, VmdSelfShadowState, build_clip_from_import,
-    build_pair_clip, build_pair_clip_with_options, build_property_binding_with_ik_resolver,
-    export_vmd_animation, import_vmd_motion, parse_vmd_animation, sample_vmd_camera_frames,
-    sample_vmd_light_frames, sample_vmd_self_shadow_frames,
+    VmdCameraState, VmdClipBuildOptions, VmdExportMorphKind, VmdExportName, VmdIkEntry,
+    VmdImportResult, VmdLightState, VmdParsedAnimation, VmdPoseExport, VmdPoseExportBindings,
+    VmdPoseExportError, VmdPoseExportReport, VmdPropertyIkFrame, VmdSelfShadowState,
+    build_clip_from_import, build_pair_clip, build_pair_clip_with_options,
+    build_property_binding_with_ik_resolver, export_reduced_pose_to_vmd, export_vmd_animation,
+    import_vmd_motion, parse_vmd_animation, sample_vmd_camera_frames, sample_vmd_light_frames,
+    sample_vmd_self_shadow_frames,
 };
 pub use vpd::{VpdParsedPose, export_vpd_pose, parse_vpd_pose};
 pub use xfile::{AccessoryParsedManifest, export_accessory_manifest, parse_accessory_manifest};

--- a/crates/mmd-anim-format/src/vmd/mod.rs
+++ b/crates/mmd-anim-format/src/vmd/mod.rs
@@ -14,6 +14,12 @@ use crate::error::ImportError;
 use crate::normalize::normalize_vmd_name;
 use crate::sjis::{decode_sjis_fixed_trimmed, encode_sjis};
 
+mod reduced;
+pub use reduced::{
+    VmdExportMorphKind, VmdExportName, VmdPoseExport, VmdPoseExportBindings, VmdPoseExportError,
+    VmdPoseExportReport, export_reduced_pose_to_vmd,
+};
+
 type Reader<'a> = ByteReader<'a>;
 
 const VMD_MAGIC: [u8; 30] = *b"Vocaloid Motion Data 0002\0\0\0\0\0";

--- a/crates/mmd-anim-format/src/vmd/reduced.rs
+++ b/crates/mmd-anim-format/src/vmd/reduced.rs
@@ -1,0 +1,309 @@
+use mmd_anim_runtime::{
+    QuantizedBezier, ReducedBoneKey, ReducedPoseSequence, ReductionTarget, VmdBoneInterpolation,
+};
+use thiserror::Error;
+
+use super::{
+    VmdParsedAnimation, VmdParsedBoneFrame, VmdParsedCounts, VmdParsedIkState, VmdParsedMetadata,
+    VmdParsedMorphFrame, VmdParsedPropertyFrame,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VmdExportName {
+    pub text: String,
+    pub bytes: Vec<u8>,
+}
+
+impl VmdExportName {
+    pub fn new(text: impl Into<String>, bytes: Vec<u8>) -> Self {
+        Self {
+            text: text.into(),
+            bytes,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VmdExportMorphKind {
+    Vertex,
+    Uv,
+    Other,
+    Bone,
+    Group,
+    Material,
+}
+
+#[derive(Debug, Clone)]
+pub struct VmdPoseExportBindings {
+    pub model_identity: u64,
+    pub model_name: VmdExportName,
+    pub bone_names: Vec<VmdExportName>,
+    pub morph_names: Vec<VmdExportName>,
+    pub ik_names: Vec<VmdExportName>,
+    pub ik_solver_count: usize,
+    pub append_affected_bones: Vec<bool>,
+    pub morph_kinds: Vec<VmdExportMorphKind>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct VmdPoseExportReport {
+    pub physics_must_be_disabled_by_host: bool,
+    pub ik_disabled_in_vmd: bool,
+    pub skipped_constant_bone_tracks: usize,
+    pub skipped_zero_morph_tracks: usize,
+}
+
+#[derive(Debug, Clone)]
+pub struct VmdPoseExport {
+    pub animation: VmdParsedAnimation,
+    pub report: VmdPoseExportReport,
+}
+
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+pub enum VmdPoseExportError {
+    #[error("reduced pose target must be VmdBezier")]
+    WrongTarget,
+    #[error("export binding model identity or counts do not match reduced pose")]
+    BindingMismatch,
+    #[error("sample {sample} has non-integer VMD frame {frame}")]
+    NonIntegerFrame { sample: usize, frame: String },
+    #[error("sample {sample} frame is outside the VMD u32 range")]
+    FrameOutOfRange { sample: usize },
+    #[error("{kind} name {index} exceeds the VMD byte limit {limit}")]
+    NameTooLong {
+        kind: &'static str,
+        index: usize,
+        limit: usize,
+    },
+    #[error("bone {bone} has baked motion but also participates in append transform")]
+    AppendTransformWouldDoubleApply { bone: usize },
+    #[error("morph {morph} of kind {kind:?} would double-apply baked deformation")]
+    MorphWouldDoubleApply {
+        morph: usize,
+        kind: VmdExportMorphKind,
+    },
+    #[error("morph {morph} of kind {kind:?} cannot be emitted by the VMD pose adapter")]
+    UnsupportedMorphKind {
+        morph: usize,
+        kind: VmdExportMorphKind,
+    },
+}
+
+pub fn export_reduced_pose_to_vmd(
+    sequence: &ReducedPoseSequence,
+    bindings: &VmdPoseExportBindings,
+) -> Result<VmdPoseExport, VmdPoseExportError> {
+    if sequence.target() != ReductionTarget::VmdBezier {
+        return Err(VmdPoseExportError::WrongTarget);
+    }
+    let snapshot = sequence.snapshot();
+    if !sequence.validate_model(
+        bindings.model_identity,
+        bindings.bone_names.len(),
+        bindings.morph_names.len(),
+    ) || bindings.append_affected_bones.len() != snapshot.bone_count()
+        || bindings.morph_kinds.len() != snapshot.morph_count()
+        || bindings.ik_names.len() != bindings.ik_solver_count
+    {
+        return Err(VmdPoseExportError::BindingMismatch);
+    }
+    validate_name(&bindings.model_name, "model", 0, 20)?;
+    for (index, name) in bindings.bone_names.iter().enumerate() {
+        validate_name(name, "bone", index, 15)?;
+    }
+    for (index, name) in bindings.morph_names.iter().enumerate() {
+        validate_name(name, "morph", index, 15)?;
+    }
+    for (index, name) in bindings.ik_names.iter().enumerate() {
+        validate_name(name, "ik", index, 20)?;
+    }
+
+    let sample_frames = vmd_sample_frames(sequence)?;
+    let mut bone_frames = Vec::new();
+    let mut skipped_constant_bone_tracks = 0;
+    for (bone, track) in sequence.bone_tracks().iter().enumerate() {
+        let rest_translation = snapshot.rest_local_translations()[bone];
+        let rest_rotation = snapshot.rest_local_rotations()[bone];
+        let active = track.keys().iter().any(|key| {
+            key.translation.distance(rest_translation) > 1.0e-6
+                || rotation_error(key.rotation, rest_rotation) > 1.0e-6
+        });
+        if !active {
+            skipped_constant_bone_tracks += 1;
+            continue;
+        }
+        if bindings.append_affected_bones[bone] {
+            return Err(VmdPoseExportError::AppendTransformWouldDoubleApply { bone });
+        }
+        for key in track.keys() {
+            bone_frames.push(vmd_bone_frame(
+                &bindings.bone_names[bone],
+                sample_frames[key.sample_index],
+                key,
+                rest_translation,
+                rest_rotation,
+            ));
+        }
+    }
+
+    let mut morph_frames = Vec::new();
+    let mut skipped_zero_morph_tracks = 0;
+    for (morph, track) in sequence.morph_tracks().iter().enumerate() {
+        let active = track.keys().iter().any(|key| key.weight.abs() > 1.0e-6);
+        if !active {
+            skipped_zero_morph_tracks += 1;
+            continue;
+        }
+        let kind = bindings.morph_kinds[morph];
+        if matches!(
+            kind,
+            VmdExportMorphKind::Bone | VmdExportMorphKind::Group | VmdExportMorphKind::Material
+        ) {
+            return Err(VmdPoseExportError::MorphWouldDoubleApply { morph, kind });
+        }
+        if kind != VmdExportMorphKind::Vertex {
+            return Err(VmdPoseExportError::UnsupportedMorphKind { morph, kind });
+        }
+        for key in track.keys() {
+            morph_frames.push(VmdParsedMorphFrame {
+                morph_name: bindings.morph_names[morph].text.clone(),
+                morph_name_bytes: bindings.morph_names[morph].bytes.clone(),
+                frame: sample_frames[key.sample_index],
+                weight: key.weight,
+            });
+        }
+    }
+    bone_frames.sort_by(|a, b| (a.frame, &a.bone_name_bytes).cmp(&(b.frame, &b.bone_name_bytes)));
+    morph_frames
+        .sort_by(|a, b| (a.frame, &a.morph_name_bytes).cmp(&(b.frame, &b.morph_name_bytes)));
+
+    let property_frames = vec![VmdParsedPropertyFrame {
+        frame: sample_frames[0],
+        visible: true,
+        ik_states: bindings
+            .ik_names
+            .iter()
+            .map(|name| VmdParsedIkState {
+                bone_name: name.text.clone(),
+                bone_name_bytes: name.bytes.clone(),
+                enabled: false,
+            })
+            .collect(),
+    }];
+    let max_frame = *sample_frames.last().expect("validated non-empty sequence");
+    let animation = VmdParsedAnimation {
+        kind: "vmd",
+        metadata: VmdParsedMetadata {
+            format: "vmd",
+            model_name: bindings.model_name.text.clone(),
+            model_name_bytes: bindings.model_name.bytes.clone(),
+            counts: VmdParsedCounts {
+                bones: bone_frames.len(),
+                morphs: morph_frames.len(),
+                cameras: 0,
+                lights: 0,
+                self_shadows: 0,
+                properties: property_frames.len(),
+            },
+            max_frame,
+        },
+        bone_frames,
+        morph_frames,
+        camera_frames: Vec::new(),
+        light_frames: Vec::new(),
+        self_shadow_frames: Vec::new(),
+        property_frames,
+    };
+    Ok(VmdPoseExport {
+        animation,
+        report: VmdPoseExportReport {
+            physics_must_be_disabled_by_host: true,
+            ik_disabled_in_vmd: true,
+            skipped_constant_bone_tracks,
+            skipped_zero_morph_tracks,
+        },
+    })
+}
+
+fn validate_name(
+    name: &VmdExportName,
+    kind: &'static str,
+    index: usize,
+    limit: usize,
+) -> Result<(), VmdPoseExportError> {
+    if name.bytes.len() > limit {
+        Err(VmdPoseExportError::NameTooLong { kind, index, limit })
+    } else {
+        Ok(())
+    }
+}
+
+fn vmd_sample_frames(sequence: &ReducedPoseSequence) -> Result<Vec<u32>, VmdPoseExportError> {
+    (0..sequence.frame_count())
+        .map(|sample| {
+            let frame = sequence.start_frame() + sample as f32 * sequence.frame_step();
+            if frame < 0.0 || frame as f64 > u32::MAX as f64 {
+                return Err(VmdPoseExportError::FrameOutOfRange { sample });
+            }
+            let rounded = frame.round();
+            if frame != rounded {
+                return Err(VmdPoseExportError::NonIntegerFrame {
+                    sample,
+                    frame: frame.to_string(),
+                });
+            }
+            Ok(rounded as u32)
+        })
+        .collect()
+}
+
+fn vmd_bone_frame(
+    name: &VmdExportName,
+    frame: u32,
+    key: &ReducedBoneKey,
+    rest_translation: glam::Vec3A,
+    rest_rotation: glam::Quat,
+) -> VmdParsedBoneFrame {
+    let translation = key.translation - rest_translation;
+    let rotation = (rest_rotation.inverse() * key.rotation).normalize();
+    VmdParsedBoneFrame {
+        bone_name: name.text.clone(),
+        bone_name_bytes: name.bytes.clone(),
+        frame,
+        translation: translation.to_array(),
+        rotation: rotation.to_array(),
+        interpolation: vmd_interpolation_block(key.vmd_interpolation).to_vec(),
+    }
+}
+
+fn vmd_interpolation_block(curves: VmdBoneInterpolation) -> [u8; 64] {
+    let channels = [
+        curves.translation[0],
+        curves.translation[1],
+        curves.translation[2],
+        curves.rotation,
+    ];
+    let mut first = [0u8; 16];
+    for (channel, curve) in channels.into_iter().enumerate() {
+        write_curve(&mut first, channel, curve);
+    }
+    let mut block = [0u8; 64];
+    for chunk in block.chunks_exact_mut(16) {
+        chunk.copy_from_slice(&first);
+    }
+    block
+}
+
+fn write_curve(block: &mut [u8; 16], channel: usize, curve: QuantizedBezier) {
+    block[channel] = curve.x1.min(127);
+    block[4 + channel] = curve.y1.min(127);
+    block[8 + channel] = curve.x2.min(127);
+    block[12 + channel] = curve.y2.min(127);
+}
+
+fn rotation_error(a: glam::Quat, b: glam::Quat) -> f32 {
+    2.0 * a.dot(b).abs().clamp(-1.0, 1.0).acos()
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/mmd-anim-format/src/vmd/reduced.rs
+++ b/crates/mmd-anim-format/src/vmd/reduced.rs
@@ -302,7 +302,12 @@ fn write_curve(block: &mut [u8; 16], channel: usize, curve: QuantizedBezier) {
 }
 
 fn rotation_error(a: glam::Quat, b: glam::Quat) -> f32 {
-    2.0 * a.dot(b).abs().clamp(-1.0, 1.0).acos()
+    let a = a.normalize();
+    let mut b = b.normalize();
+    if a.dot(b) < 0.0 {
+        b = -b;
+    }
+    4.0 * (((a - b).length() * 0.5).clamp(0.0, 1.0)).asin()
 }
 
 #[cfg(test)]

--- a/crates/mmd-anim-format/src/vmd/reduced/tests.rs
+++ b/crates/mmd-anim-format/src/vmd/reduced/tests.rs
@@ -62,6 +62,14 @@ fn bindings(morph_kind: VmdExportMorphKind) -> VmdPoseExportBindings {
 }
 
 #[test]
+fn static_track_rotation_comparison_is_exact_and_hemisphere_invariant() {
+    let rotation =
+        Quat::from_xyzw(0.182_574_18, -0.365_148_37, 0.547_722_6, 0.730_296_73).normalize();
+    assert_eq!(rotation_error(rotation, rotation), 0.0);
+    assert_eq!(rotation_error(rotation, -rotation), 0.0);
+}
+
+#[test]
 fn exports_quantized_64_byte_curves_ik_off_and_roundtrips() {
     let sequence = reduced(0.0, 1.0, &[0.0, 0.5, 1.0]);
     let exported =

--- a/crates/mmd-anim-format/src/vmd/reduced/tests.rs
+++ b/crates/mmd-anim-format/src/vmd/reduced/tests.rs
@@ -1,0 +1,194 @@
+use glam::{Mat4, Quat, Vec3, Vec3A};
+use mmd_anim_runtime::{
+    BoneIndex, BoneInit, DensePoseSequenceView, ModelArena, MorphIndex, ReducedPoseSequence,
+    ReductionTarget, ReductionTolerances, RuntimeInstance, SkeletonSnapshot,
+    reduce_dense_pose_sequence,
+};
+use std::sync::Arc;
+
+use super::*;
+use crate::vmd::{
+    build_clip_from_import, export_vmd_animation, import_vmd_motion, parse_vmd_animation,
+};
+
+fn reduced(start_frame: f32, frame_step: f32, morphs: &[f32]) -> ReducedPoseSequence {
+    let world = [
+        Mat4::from_translation(Vec3::new(1.0, 0.0, 0.0)),
+        Mat4::from_translation(Vec3::new(2.0, 0.5, 0.0)),
+        Mat4::from_translation(Vec3::new(3.0, 0.0, 0.0)),
+    ];
+    let input = DensePoseSequenceView::new(
+        &world,
+        morphs,
+        3,
+        1,
+        usize::from(!morphs.is_empty()),
+        start_frame,
+        frame_step,
+    )
+    .unwrap();
+    let snapshot = SkeletonSnapshot::new(
+        vec![-1],
+        vec![Vec3A::ZERO],
+        vec![Quat::IDENTITY],
+        usize::from(!morphs.is_empty()),
+        99,
+    )
+    .unwrap();
+    reduce_dense_pose_sequence(
+        input,
+        snapshot,
+        ReductionTolerances {
+            local_position: 0.01,
+            world_position: 0.01,
+            ..Default::default()
+        },
+        ReductionTarget::VmdBezier,
+    )
+    .unwrap()
+}
+
+fn bindings(morph_kind: VmdExportMorphKind) -> VmdPoseExportBindings {
+    VmdPoseExportBindings {
+        model_identity: 99,
+        model_name: VmdExportName::new("model", b"model".to_vec()),
+        bone_names: vec![VmdExportName::new("bone", b"bone".to_vec())],
+        morph_names: vec![VmdExportName::new("morph", b"morph".to_vec())],
+        ik_names: vec![VmdExportName::new("ik", b"ik".to_vec())],
+        ik_solver_count: 1,
+        append_affected_bones: vec![false],
+        morph_kinds: vec![morph_kind],
+    }
+}
+
+#[test]
+fn exports_quantized_64_byte_curves_ik_off_and_roundtrips() {
+    let sequence = reduced(0.0, 1.0, &[0.0, 0.5, 1.0]);
+    let exported =
+        export_reduced_pose_to_vmd(&sequence, &bindings(VmdExportMorphKind::Vertex)).unwrap();
+    assert!(exported.report.physics_must_be_disabled_by_host);
+    assert!(exported.report.ik_disabled_in_vmd);
+    assert!(!exported.animation.bone_frames.is_empty());
+    for frame in &exported.animation.bone_frames {
+        assert_eq!(frame.interpolation.len(), 64);
+        assert!(frame.interpolation.iter().all(|value| *value <= 127));
+    }
+    assert_eq!(exported.animation.property_frames.len(), 1);
+    assert!(
+        exported.animation.property_frames[0]
+            .ik_states
+            .iter()
+            .all(|state| !state.enabled)
+    );
+    let bytes = export_vmd_animation(&exported.animation);
+    let reparsed = parse_vmd_animation(&bytes).unwrap();
+    assert_eq!(
+        reparsed.bone_frames.len(),
+        exported.animation.bone_frames.len()
+    );
+    assert_eq!(
+        reparsed.morph_frames.len(),
+        exported.animation.morph_frames.len()
+    );
+    assert!(!reparsed.property_frames[0].ik_states[0].enabled);
+    let mut unique = reparsed
+        .bone_frames
+        .iter()
+        .map(|frame| frame.frame)
+        .collect::<Vec<_>>();
+    unique.sort_unstable();
+    unique.dedup();
+    assert_eq!(unique.len(), reparsed.bone_frames.len());
+}
+
+#[test]
+fn rejects_fractional_frames_without_rounding() {
+    let sequence = reduced(0.5, 1.0, &[]);
+    let mut binding = bindings(VmdExportMorphKind::Vertex);
+    binding.morph_names.clear();
+    binding.morph_kinds.clear();
+    binding.ik_names.clear();
+    binding.ik_solver_count = 0;
+    assert!(matches!(
+        export_reduced_pose_to_vmd(&sequence, &binding),
+        Err(VmdPoseExportError::NonIntegerFrame { .. })
+    ));
+}
+
+#[test]
+fn rejects_append_and_baked_deformation_morph_double_application() {
+    let no_morph = reduced(0.0, 1.0, &[]);
+    let mut append_binding = bindings(VmdExportMorphKind::Vertex);
+    append_binding.morph_names.clear();
+    append_binding.morph_kinds.clear();
+    append_binding.append_affected_bones[0] = true;
+    assert_eq!(
+        export_reduced_pose_to_vmd(&no_morph, &append_binding).unwrap_err(),
+        VmdPoseExportError::AppendTransformWouldDoubleApply { bone: 0 }
+    );
+
+    for kind in [
+        VmdExportMorphKind::Bone,
+        VmdExportMorphKind::Group,
+        VmdExportMorphKind::Material,
+    ] {
+        let sequence = reduced(0.0, 1.0, &[0.0, 0.5, 1.0]);
+        assert_eq!(
+            export_reduced_pose_to_vmd(&sequence, &bindings(kind)).unwrap_err(),
+            VmdPoseExportError::MorphWouldDoubleApply { morph: 0, kind }
+        );
+    }
+
+    for kind in [VmdExportMorphKind::Uv, VmdExportMorphKind::Other] {
+        let sequence = reduced(0.0, 1.0, &[0.0, 0.5, 1.0]);
+        assert_eq!(
+            export_reduced_pose_to_vmd(&sequence, &bindings(kind)).unwrap_err(),
+            VmdPoseExportError::UnsupportedMorphKind { morph: 0, kind }
+        );
+    }
+}
+
+#[test]
+fn rejects_incomplete_ik_bindings() {
+    let sequence = reduced(0.0, 1.0, &[]);
+    let mut binding = bindings(VmdExportMorphKind::Vertex);
+    binding.morph_names.clear();
+    binding.morph_kinds.clear();
+    binding.ik_names.clear();
+
+    assert_eq!(
+        export_reduced_pose_to_vmd(&sequence, &binding).unwrap_err(),
+        VmdPoseExportError::BindingMismatch
+    );
+}
+
+#[test]
+fn reparsed_vmd_runtime_pose_matches_reducer_sampler() {
+    let sequence = reduced(0.0, 1.0, &[]);
+    let mut binding = bindings(VmdExportMorphKind::Vertex);
+    binding.morph_names.clear();
+    binding.morph_kinds.clear();
+    binding.ik_names.clear();
+    binding.ik_solver_count = 0;
+    let exported = export_reduced_pose_to_vmd(&sequence, &binding).unwrap();
+    let bytes = export_vmd_animation(&exported.animation);
+    let imported = import_vmd_motion(&bytes).unwrap();
+    let clip = build_clip_from_import(
+        imported,
+        &|name| (name == b"bone").then_some(BoneIndex(0)),
+        &|_name| None::<MorphIndex>,
+    );
+    let model = Arc::new(ModelArena::new(vec![BoneInit::new(None, Vec3A::ZERO)]).unwrap());
+    let mut runtime = RuntimeInstance::new(model);
+    for frame in 0..3 {
+        runtime.evaluate_clip_frame(&clip, frame as f32);
+        let expected = sequence.sample(frame as f32).unwrap();
+        for (actual, expected) in runtime.world_matrices()[0]
+            .to_cols_array()
+            .iter()
+            .zip(expected.world_matrices[0].to_cols_array())
+        {
+            assert!((actual - expected).abs() <= 0.01);
+        }
+    }
+}

--- a/crates/mmd-anim-runtime/Cargo.toml
+++ b/crates/mmd-anim-runtime/Cargo.toml
@@ -14,3 +14,6 @@ description = "Renderer-independent MMD animation runtime core"
 glam.workspace = true
 thiserror.workspace = true
 
+[target.'cfg(not(target_family = "wasm"))'.dependencies]
+rayon.workspace = true
+

--- a/crates/mmd-anim-runtime/src/lib.rs
+++ b/crates/mmd-anim-runtime/src/lib.rs
@@ -10,6 +10,10 @@ mod flat_model;
 pub mod ik_primitive;
 mod model;
 mod pose;
+// The reducer remains crate-private until its Rust shape is stabilized by the
+// format targets and wrapper parity work in later POSE-REDUCE phases.
+#[allow(dead_code)]
+pub(crate) mod reduce;
 mod runtime;
 
 pub use animation::{

--- a/crates/mmd-anim-runtime/src/lib.rs
+++ b/crates/mmd-anim-runtime/src/lib.rs
@@ -39,6 +39,12 @@ pub use model::{
     ModelBuildError, MorphIndex, MorphInit, MorphOffsetSpan, VertexMorphOffset,
 };
 pub use pose::PoseArena;
+pub use reduce::{
+    DensePoseSequenceView, PoseReductionError, PoseReductionReport, QuantizedBezier,
+    ReducedBoneKey, ReducedBoneTrack, ReducedMorphKey, ReducedMorphTrack, ReducedPoseSample,
+    ReducedPoseSequence, ReductionTarget, ReductionTolerances, SkeletonSnapshot,
+    VmdBoneInterpolation, reduce_dense_pose_sequence,
+};
 pub use runtime::{
     HostPoseError, HostPoseView, IkSolveOptions, IkSolverRuntimeStats, PhysicsMode,
     PhysicsStepStats, PhysicsTickConfig, RuntimeInstance,

--- a/crates/mmd-anim-runtime/src/lib.rs
+++ b/crates/mmd-anim-runtime/src/lib.rs
@@ -44,7 +44,7 @@ pub use reduce::{
     PoseReductionReport, QuantizedBezier, ReducedBoneKey, ReducedBoneTrack, ReducedMorphKey,
     ReducedMorphTrack, ReducedPoseSample, ReducedPoseSequence, ReductionTarget, ReductionTimings,
     ReductionTolerances, ReductionWorkStats, SkeletonSnapshot, VmdBoneInterpolation,
-    reduce_dense_pose_sequence,
+    reduce_dense_pose_sequence, reduce_dense_pose_sequence_with_worker_count,
 };
 pub use runtime::{
     HostPoseError, HostPoseView, IkSolveOptions, IkSolverRuntimeStats, PhysicsMode,

--- a/crates/mmd-anim-runtime/src/lib.rs
+++ b/crates/mmd-anim-runtime/src/lib.rs
@@ -42,8 +42,9 @@ pub use pose::PoseArena;
 pub use reduce::{
     DccCubicSegment, DccScalarSegment, DensePoseSequenceView, PoseReductionError,
     PoseReductionReport, QuantizedBezier, ReducedBoneKey, ReducedBoneTrack, ReducedMorphKey,
-    ReducedMorphTrack, ReducedPoseSample, ReducedPoseSequence, ReductionTarget,
-    ReductionTolerances, SkeletonSnapshot, VmdBoneInterpolation, reduce_dense_pose_sequence,
+    ReducedMorphTrack, ReducedPoseSample, ReducedPoseSequence, ReductionTarget, ReductionTimings,
+    ReductionTolerances, ReductionWorkStats, SkeletonSnapshot, VmdBoneInterpolation,
+    reduce_dense_pose_sequence,
 };
 pub use runtime::{
     HostPoseError, HostPoseView, IkSolveOptions, IkSolverRuntimeStats, PhysicsMode,

--- a/crates/mmd-anim-runtime/src/lib.rs
+++ b/crates/mmd-anim-runtime/src/lib.rs
@@ -40,10 +40,10 @@ pub use model::{
 };
 pub use pose::PoseArena;
 pub use reduce::{
-    DensePoseSequenceView, PoseReductionError, PoseReductionReport, QuantizedBezier,
-    ReducedBoneKey, ReducedBoneTrack, ReducedMorphKey, ReducedMorphTrack, ReducedPoseSample,
-    ReducedPoseSequence, ReductionTarget, ReductionTolerances, SkeletonSnapshot,
-    VmdBoneInterpolation, reduce_dense_pose_sequence,
+    DccCubicSegment, DccScalarSegment, DensePoseSequenceView, PoseReductionError,
+    PoseReductionReport, QuantizedBezier, ReducedBoneKey, ReducedBoneTrack, ReducedMorphKey,
+    ReducedMorphTrack, ReducedPoseSample, ReducedPoseSequence, ReductionTarget,
+    ReductionTolerances, SkeletonSnapshot, VmdBoneInterpolation, reduce_dense_pose_sequence,
 };
 pub use runtime::{
     HostPoseError, HostPoseView, IkSolveOptions, IkSolverRuntimeStats, PhysicsMode,

--- a/crates/mmd-anim-runtime/src/reduce/mod.rs
+++ b/crates/mmd-anim-runtime/src/reduce/mod.rs
@@ -376,6 +376,9 @@ impl ReducedPoseSequence {
     pub fn frame_count(&self) -> usize {
         self.frame_count
     }
+    pub fn sample_frames(&self) -> &[f32] {
+        &self.sample_frames
+    }
     pub fn bone_tracks(&self) -> &[ReducedBoneTrack] {
         &self.bone_tracks
     }
@@ -530,14 +533,19 @@ pub fn reduce_dense_pose_sequence(
             &bone_key_indices,
             &morph_key_indices,
         );
-        let (report, worst) = measure_error(
+        let (report, worst_by_track) = measure_error(
             &candidate,
             input,
             &local_translations,
             &local_rotations,
             tolerances,
         )?;
-        let Some(worst) = worst.filter(|worst| worst.normalized_error > 1.0) else {
+        let failing = worst_by_track
+            .into_iter()
+            .flatten()
+            .filter(|worst| worst.normalized_error > 1.0)
+            .collect::<Vec<_>>();
+        if failing.is_empty() {
             let mut result = candidate;
             result.report = PoseReductionReport {
                 source_bone_key_count: input.frame_count * input.bone_count,
@@ -555,23 +563,28 @@ pub fn reduce_dense_pose_sequence(
                 ..report
             };
             return Ok(result);
-        };
+        }
         let mut inserted = false;
-        match worst.track {
-            ErrorTrack::Bone(bone) => {
-                let mut cursor = Some(bone);
-                while let Some(index) = cursor {
-                    inserted |= insert_key(&mut bone_key_indices[index], worst.frame);
-                    let parent = snapshot.parent_indices[index];
-                    cursor = (parent >= 0).then_some(parent as usize);
+        let first_failure_frame = failing[0].frame;
+        for worst in failing {
+            match worst.track {
+                ErrorTrack::Bone(bone) => {
+                    let mut cursor = Some(bone);
+                    while let Some(index) = cursor {
+                        inserted |= insert_key(&mut bone_key_indices[index], worst.frame);
+                        let parent = snapshot.parent_indices[index];
+                        cursor = (parent >= 0).then_some(parent as usize);
+                    }
                 }
-            }
-            ErrorTrack::Morph(morph) => {
-                inserted = insert_key(&mut morph_key_indices[morph], worst.frame);
+                ErrorTrack::Morph(morph) => {
+                    inserted |= insert_key(&mut morph_key_indices[morph], worst.frame);
+                }
             }
         }
         if !inserted {
-            return Err(PoseReductionError::ToleranceUnattainable { frame: worst.frame });
+            return Err(PoseReductionError::ToleranceUnattainable {
+                frame: first_failure_frame,
+            });
         }
     }
 }
@@ -880,7 +893,7 @@ fn measure_error(
     translations: &[Vec3A],
     rotations: &[Quat],
     tolerances: ReductionTolerances,
-) -> Result<(PoseReductionReport, Option<WorstError>), PoseReductionError> {
+) -> Result<(PoseReductionReport, Vec<Option<WorstError>>), PoseReductionError> {
     measure_error_with_tolerances(sequence, input, translations, rotations, tolerances)
 }
 
@@ -890,12 +903,12 @@ fn measure_error_with_tolerances(
     translations: &[Vec3A],
     rotations: &[Quat],
     tolerances: ReductionTolerances,
-) -> Result<(PoseReductionReport, Option<WorstError>), PoseReductionError> {
+) -> Result<(PoseReductionReport, Vec<Option<WorstError>>), PoseReductionError> {
     let mut report = PoseReductionReport::default();
-    let mut worst: Option<WorstError> = None;
+    let mut worst = vec![None; input.bone_count + input.morph_count];
     for frame in 0..input.frame_count {
         let sample = sequence.sample(input.sample_frame(frame))?;
-        for bone in 0..input.bone_count {
+        for (bone, bone_worst) in worst[..input.bone_count].iter_mut().enumerate() {
             let index = frame * input.bone_count + bone;
             let local_position = translations[index].distance(sample.local_translations[bone]);
             let local_rotation = quat_angle(rotations[index], sample.local_rotations[bone]);
@@ -918,14 +931,14 @@ fn measure_error_with_tolerances(
                 normalized_error(world_position, tolerances.world_position),
                 normalized_error(world_rotation, tolerances.world_rotation_radians),
             ] {
-                update_worst(&mut worst, normalized, frame, ErrorTrack::Bone(bone));
+                update_worst(bone_worst, normalized, frame, ErrorTrack::Bone(bone));
             }
         }
         for morph in 0..input.morph_count {
             let error = (input.morph_weight(frame, morph) - sample.morph_weights[morph]).abs();
             report.max_morph_weight_error = report.max_morph_weight_error.max(error);
             update_worst(
-                &mut worst,
+                &mut worst[input.bone_count + morph],
                 normalized_error(error, tolerances.morph_weight),
                 frame,
                 ErrorTrack::Morph(morph),

--- a/crates/mmd-anim-runtime/src/reduce/mod.rs
+++ b/crates/mmd-anim-runtime/src/reduce/mod.rs
@@ -1,0 +1,955 @@
+use std::cmp::Ordering;
+
+use glam::{Mat3, Mat4, Quat, Vec3, Vec3A};
+use thiserror::Error;
+
+use crate::{BoneIndex, ModelArena};
+
+const AFFINE_EPSILON: f32 = 1.0e-4;
+
+#[derive(Debug, Clone, Copy)]
+pub struct DensePoseSequenceView<'a> {
+    world_matrices: &'a [Mat4],
+    morph_weights: &'a [f32],
+    frame_count: usize,
+    bone_count: usize,
+    morph_count: usize,
+    start_frame: f32,
+    frame_step: f32,
+}
+
+impl<'a> DensePoseSequenceView<'a> {
+    pub fn new(
+        world_matrices: &'a [Mat4],
+        morph_weights: &'a [f32],
+        frame_count: usize,
+        bone_count: usize,
+        morph_count: usize,
+        start_frame: f32,
+        frame_step: f32,
+    ) -> Result<Self, PoseReductionError> {
+        if frame_count == 0 {
+            return Err(PoseReductionError::EmptySequence);
+        }
+        if bone_count == 0 {
+            return Err(PoseReductionError::EmptySkeleton);
+        }
+        if !start_frame.is_finite() || !frame_step.is_finite() || frame_step <= 0.0 {
+            return Err(PoseReductionError::InvalidTimeBase);
+        }
+        let mut previous_frame = start_frame;
+        for sample_index in 1..frame_count {
+            let frame = start_frame + sample_index as f32 * frame_step;
+            if !frame.is_finite() || frame <= previous_frame {
+                return Err(PoseReductionError::InvalidTimeBase);
+            }
+            previous_frame = frame;
+        }
+        let expected_world = frame_count
+            .checked_mul(bone_count)
+            .ok_or(PoseReductionError::LengthOverflow)?;
+        let expected_morph = frame_count
+            .checked_mul(morph_count)
+            .ok_or(PoseReductionError::LengthOverflow)?;
+        if world_matrices.len() != expected_world {
+            return Err(PoseReductionError::InvalidWorldMatrixCount {
+                actual: world_matrices.len(),
+                expected: expected_world,
+            });
+        }
+        if morph_weights.len() != expected_morph {
+            return Err(PoseReductionError::InvalidMorphWeightCount {
+                actual: morph_weights.len(),
+                expected: expected_morph,
+            });
+        }
+        Ok(Self {
+            world_matrices,
+            morph_weights,
+            frame_count,
+            bone_count,
+            morph_count,
+            start_frame,
+            frame_step,
+        })
+    }
+
+    pub fn frame_count(&self) -> usize {
+        self.frame_count
+    }
+    pub fn bone_count(&self) -> usize {
+        self.bone_count
+    }
+    pub fn morph_count(&self) -> usize {
+        self.morph_count
+    }
+    pub fn start_frame(&self) -> f32 {
+        self.start_frame
+    }
+    pub fn frame_step(&self) -> f32 {
+        self.frame_step
+    }
+
+    fn world_matrix(&self, frame: usize, bone: usize) -> Mat4 {
+        self.world_matrices[frame * self.bone_count + bone]
+    }
+
+    fn morph_weight(&self, frame: usize, morph: usize) -> f32 {
+        self.morph_weights[frame * self.morph_count + morph]
+    }
+
+    fn sample_frame(&self, sample_index: usize) -> f32 {
+        self.start_frame + sample_index as f32 * self.frame_step
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct SkeletonSnapshot {
+    parent_indices: Box<[i32]>,
+    rest_local_translations: Box<[Vec3A]>,
+    rest_local_rotations: Box<[Quat]>,
+    evaluation_order: Box<[usize]>,
+    morph_count: usize,
+    model_identity: u64,
+}
+
+impl SkeletonSnapshot {
+    pub fn new(
+        parent_indices: Vec<i32>,
+        rest_local_translations: Vec<Vec3A>,
+        rest_local_rotations: Vec<Quat>,
+        morph_count: usize,
+        model_identity: u64,
+    ) -> Result<Self, PoseReductionError> {
+        if parent_indices.is_empty() {
+            return Err(PoseReductionError::EmptySkeleton);
+        }
+        if rest_local_translations.len() != parent_indices.len()
+            || rest_local_rotations.len() != parent_indices.len()
+        {
+            return Err(PoseReductionError::InvalidSkeletonLengths);
+        }
+        for (bone, &parent) in parent_indices.iter().enumerate() {
+            if parent < -1 || parent >= parent_indices.len() as i32 || parent == bone as i32 {
+                return Err(PoseReductionError::InvalidParent { bone, parent });
+            }
+            if !rest_local_translations[bone].is_finite()
+                || !quat_is_finite(rest_local_rotations[bone])
+            {
+                return Err(PoseReductionError::NonFiniteSkeleton { bone });
+            }
+        }
+        let evaluation_order = build_evaluation_order(&parent_indices)?;
+        Ok(Self {
+            parent_indices: parent_indices.into_boxed_slice(),
+            rest_local_translations: rest_local_translations.into_boxed_slice(),
+            rest_local_rotations: rest_local_rotations
+                .into_iter()
+                .map(normalize_quat)
+                .collect::<Vec<_>>()
+                .into_boxed_slice(),
+            evaluation_order: evaluation_order.into_boxed_slice(),
+            morph_count,
+            model_identity,
+        })
+    }
+
+    pub fn from_model(model: &ModelArena, model_identity: u64) -> Result<Self, PoseReductionError> {
+        let mut parents = Vec::with_capacity(model.bone_count());
+        let mut translations = Vec::with_capacity(model.bone_count());
+        for bone in 0..model.bone_count() {
+            let bone_index = BoneIndex(bone as u32);
+            let parent = model.parent_index(bone_index);
+            parents.push(parent.map_or(-1, |value| value.0 as i32));
+            let parent_position = parent.map_or(Vec3A::ZERO, |value| model.rest_position(value));
+            translations.push(model.rest_position(bone_index) - parent_position);
+        }
+        Self::new(
+            parents,
+            translations,
+            vec![Quat::IDENTITY; model.bone_count()],
+            model.morph_count() as usize,
+            model_identity,
+        )
+    }
+
+    pub fn bone_count(&self) -> usize {
+        self.parent_indices.len()
+    }
+    pub fn morph_count(&self) -> usize {
+        self.morph_count
+    }
+    pub fn model_identity(&self) -> u64 {
+        self.model_identity
+    }
+    pub fn parent_indices(&self) -> &[i32] {
+        &self.parent_indices
+    }
+    pub fn rest_local_translations(&self) -> &[Vec3A] {
+        &self.rest_local_translations
+    }
+    pub fn rest_local_rotations(&self) -> &[Quat] {
+        &self.rest_local_rotations
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReductionTarget {
+    LinearSlerp,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ReductionTolerances {
+    pub local_position: f32,
+    pub local_rotation_radians: f32,
+    pub world_position: f32,
+    pub world_rotation_radians: f32,
+    pub morph_weight: f32,
+}
+
+impl ReductionTolerances {
+    fn validate(self) -> Result<Self, PoseReductionError> {
+        let values = [
+            self.local_position,
+            self.local_rotation_radians,
+            self.world_position,
+            self.world_rotation_radians,
+            self.morph_weight,
+        ];
+        if values
+            .iter()
+            .any(|value| !value.is_finite() || *value < 0.0)
+        {
+            return Err(PoseReductionError::InvalidTolerance);
+        }
+        Ok(self)
+    }
+}
+
+impl Default for ReductionTolerances {
+    fn default() -> Self {
+        Self {
+            local_position: 1.0e-4,
+            local_rotation_radians: 1.0e-4,
+            world_position: 1.0e-4,
+            world_rotation_radians: 1.0e-4,
+            morph_weight: 1.0e-4,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ReducedBoneKey {
+    pub sample_index: usize,
+    pub translation: Vec3A,
+    pub rotation: Quat,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ReducedBoneTrack {
+    keys: Box<[ReducedBoneKey]>,
+}
+
+impl ReducedBoneTrack {
+    pub fn keys(&self) -> &[ReducedBoneKey] {
+        &self.keys
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ReducedMorphKey {
+    pub sample_index: usize,
+    pub weight: f32,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ReducedMorphTrack {
+    keys: Box<[ReducedMorphKey]>,
+}
+
+impl ReducedMorphTrack {
+    pub fn keys(&self) -> &[ReducedMorphKey] {
+        &self.keys
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
+pub struct PoseReductionReport {
+    pub source_bone_key_count: usize,
+    pub reduced_bone_key_count: usize,
+    pub source_morph_key_count: usize,
+    pub reduced_morph_key_count: usize,
+    pub max_local_position_error: f32,
+    pub max_local_rotation_error_radians: f32,
+    pub max_world_position_error: f32,
+    pub max_world_rotation_error_radians: f32,
+    pub max_morph_weight_error: f32,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ReducedPoseSequence {
+    snapshot: SkeletonSnapshot,
+    target: ReductionTarget,
+    start_frame: f32,
+    frame_step: f32,
+    frame_count: usize,
+    sample_frames: Box<[f32]>,
+    bone_tracks: Box<[ReducedBoneTrack]>,
+    morph_tracks: Box<[ReducedMorphTrack]>,
+    report: PoseReductionReport,
+}
+
+impl ReducedPoseSequence {
+    pub fn snapshot(&self) -> &SkeletonSnapshot {
+        &self.snapshot
+    }
+    pub fn target(&self) -> ReductionTarget {
+        self.target
+    }
+    pub fn start_frame(&self) -> f32 {
+        self.start_frame
+    }
+    pub fn frame_step(&self) -> f32 {
+        self.frame_step
+    }
+    pub fn frame_count(&self) -> usize {
+        self.frame_count
+    }
+    pub fn bone_tracks(&self) -> &[ReducedBoneTrack] {
+        &self.bone_tracks
+    }
+    pub fn morph_tracks(&self) -> &[ReducedMorphTrack] {
+        &self.morph_tracks
+    }
+    pub fn report(&self) -> PoseReductionReport {
+        self.report
+    }
+
+    pub fn sample(&self, frame: f32) -> Result<ReducedPoseSample, PoseReductionError> {
+        if !frame.is_finite() {
+            return Err(PoseReductionError::InvalidSampleTime);
+        }
+        let local_translations = self
+            .bone_tracks
+            .iter()
+            .map(|track| sample_bone_track(track, &self.sample_frames, frame).0)
+            .collect::<Vec<_>>();
+        let local_rotations = self
+            .bone_tracks
+            .iter()
+            .map(|track| sample_bone_track(track, &self.sample_frames, frame).1)
+            .collect::<Vec<_>>();
+        let morph_weights = self
+            .morph_tracks
+            .iter()
+            .map(|track| sample_morph_track(track, &self.sample_frames, frame))
+            .collect::<Vec<_>>();
+        let world_matrices =
+            build_world_matrices(&self.snapshot, &local_translations, &local_rotations);
+        Ok(ReducedPoseSample {
+            local_translations,
+            local_rotations,
+            world_matrices,
+            morph_weights,
+        })
+    }
+
+    pub fn validate_model(
+        &self,
+        model_identity: u64,
+        bone_count: usize,
+        morph_count: usize,
+    ) -> bool {
+        self.snapshot.model_identity == model_identity
+            && self.snapshot.bone_count() == bone_count
+            && self.snapshot.morph_count == morph_count
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ReducedPoseSample {
+    pub local_translations: Vec<Vec3A>,
+    pub local_rotations: Vec<Quat>,
+    pub world_matrices: Vec<Mat4>,
+    pub morph_weights: Vec<f32>,
+}
+
+#[derive(Debug, Error, Clone, PartialEq)]
+pub enum PoseReductionError {
+    #[error("dense pose sequence must contain at least one frame")]
+    EmptySequence,
+    #[error("skeleton must contain at least one bone")]
+    EmptySkeleton,
+    #[error("invalid or non-positive dense pose time base")]
+    InvalidTimeBase,
+    #[error("dense pose buffer length overflow")]
+    LengthOverflow,
+    #[error("world matrix count {actual} does not match expected {expected}")]
+    InvalidWorldMatrixCount { actual: usize, expected: usize },
+    #[error("morph weight count {actual} does not match expected {expected}")]
+    InvalidMorphWeightCount { actual: usize, expected: usize },
+    #[error("skeleton arrays have inconsistent lengths")]
+    InvalidSkeletonLengths,
+    #[error("bone {bone} has invalid parent index {parent}")]
+    InvalidParent { bone: usize, parent: i32 },
+    #[error("skeleton hierarchy contains a cycle at bone {bone}")]
+    SkeletonCycle { bone: usize },
+    #[error("bone {bone} has non-finite rest data")]
+    NonFiniteSkeleton { bone: usize },
+    #[error("dense pose skeleton counts do not match snapshot")]
+    SnapshotMismatch,
+    #[error("reduction tolerance must be finite and non-negative")]
+    InvalidTolerance,
+    #[error("frame {frame}, bone {bone} contains a non-finite matrix")]
+    NonFiniteMatrix { frame: usize, bone: usize },
+    #[error("frame {frame}, bone {bone} contains scale or shear")]
+    ScaleOrShear { frame: usize, bone: usize },
+    #[error("frame {frame}, bone {bone} has a singular parent transform")]
+    SingularParent { frame: usize, bone: usize },
+    #[error("frame {frame}, morph {morph} contains a non-finite weight")]
+    NonFiniteMorph { frame: usize, morph: usize },
+    #[error("sample time must be finite")]
+    InvalidSampleTime,
+    #[error("requested tolerance cannot be attained at source frame {frame}")]
+    ToleranceUnattainable { frame: usize },
+}
+
+pub fn reduce_dense_pose_sequence(
+    input: DensePoseSequenceView<'_>,
+    snapshot: SkeletonSnapshot,
+    tolerances: ReductionTolerances,
+    target: ReductionTarget,
+) -> Result<ReducedPoseSequence, PoseReductionError> {
+    let tolerances = tolerances.validate()?;
+    if input.bone_count != snapshot.bone_count() || input.morph_count != snapshot.morph_count() {
+        return Err(PoseReductionError::SnapshotMismatch);
+    }
+
+    let (local_translations, local_rotations) = decompose_dense_pose(input, &snapshot)?;
+    for frame in 0..input.frame_count {
+        for morph in 0..input.morph_count {
+            if !input.morph_weight(frame, morph).is_finite() {
+                return Err(PoseReductionError::NonFiniteMorph { frame, morph });
+            }
+        }
+    }
+
+    let mut bone_key_indices = vec![endpoint_indices(input.frame_count); input.bone_count];
+    let mut morph_key_indices = vec![endpoint_indices(input.frame_count); input.morph_count];
+
+    for (bone, keys) in bone_key_indices.iter_mut().enumerate() {
+        split_bone_track(
+            keys,
+            input,
+            bone,
+            &local_translations,
+            &local_rotations,
+            tolerances,
+        );
+    }
+    for (morph, keys) in morph_key_indices.iter_mut().enumerate() {
+        split_morph_track(keys, input, morph, tolerances.morph_weight);
+    }
+
+    loop {
+        let candidate = build_sequence(
+            &snapshot,
+            target,
+            input,
+            &local_translations,
+            &local_rotations,
+            &bone_key_indices,
+            &morph_key_indices,
+        );
+        let (report, worst) = measure_error(
+            &candidate,
+            input,
+            &local_translations,
+            &local_rotations,
+            tolerances,
+        )?;
+        let Some(worst) = worst.filter(|worst| worst.normalized_error > 1.0) else {
+            let mut result = candidate;
+            result.report = PoseReductionReport {
+                source_bone_key_count: input.frame_count * input.bone_count,
+                reduced_bone_key_count: result
+                    .bone_tracks
+                    .iter()
+                    .map(|track| track.keys.len())
+                    .sum(),
+                source_morph_key_count: input.frame_count * input.morph_count,
+                reduced_morph_key_count: result
+                    .morph_tracks
+                    .iter()
+                    .map(|track| track.keys.len())
+                    .sum(),
+                ..report
+            };
+            return Ok(result);
+        };
+        let mut inserted = false;
+        match worst.track {
+            ErrorTrack::Bone(bone) => {
+                let mut cursor = Some(bone);
+                while let Some(index) = cursor {
+                    inserted |= insert_key(&mut bone_key_indices[index], worst.frame);
+                    let parent = snapshot.parent_indices[index];
+                    cursor = (parent >= 0).then_some(parent as usize);
+                }
+            }
+            ErrorTrack::Morph(morph) => {
+                inserted = insert_key(&mut morph_key_indices[morph], worst.frame);
+            }
+        }
+        if !inserted {
+            return Err(PoseReductionError::ToleranceUnattainable { frame: worst.frame });
+        }
+    }
+}
+
+fn endpoint_indices(frame_count: usize) -> Vec<usize> {
+    if frame_count == 1 {
+        vec![0]
+    } else {
+        vec![0, frame_count - 1]
+    }
+}
+
+fn decompose_dense_pose(
+    input: DensePoseSequenceView<'_>,
+    snapshot: &SkeletonSnapshot,
+) -> Result<(Vec<Vec3A>, Vec<Quat>), PoseReductionError> {
+    let mut translations = vec![Vec3A::ZERO; input.frame_count * input.bone_count];
+    let mut rotations = vec![Quat::IDENTITY; input.frame_count * input.bone_count];
+    for frame in 0..input.frame_count {
+        for &bone in snapshot.evaluation_order.iter() {
+            let world = input.world_matrix(frame, bone);
+            validate_finite_matrix(world, frame, bone)?;
+            let local = if snapshot.parent_indices[bone] < 0 {
+                world
+            } else {
+                let parent = snapshot.parent_indices[bone] as usize;
+                let parent_world = input.world_matrix(frame, parent);
+                validate_finite_matrix(parent_world, frame, parent)?;
+                let determinant = Mat3::from_mat4(parent_world).determinant();
+                if !determinant.is_finite() || determinant.abs() <= f32::EPSILON {
+                    return Err(PoseReductionError::SingularParent { frame, bone });
+                }
+                parent_world.inverse() * world
+            };
+            let (translation, rotation) = decompose_rigid(local, frame, bone)?;
+            let index = frame * input.bone_count + bone;
+            translations[index] = translation;
+            rotations[index] = if frame > 0 {
+                let previous = rotations[index - input.bone_count];
+                if previous.dot(rotation) < 0.0 {
+                    -rotation
+                } else {
+                    rotation
+                }
+            } else {
+                rotation
+            };
+        }
+    }
+    Ok((translations, rotations))
+}
+
+fn decompose_rigid(
+    matrix: Mat4,
+    frame: usize,
+    bone: usize,
+) -> Result<(Vec3A, Quat), PoseReductionError> {
+    validate_finite_matrix(matrix, frame, bone)?;
+    let x = matrix.x_axis.truncate();
+    let y = matrix.y_axis.truncate();
+    let z = matrix.z_axis.truncate();
+    let unit = |v: Vec3| (v.length_squared() - 1.0).abs() <= AFFINE_EPSILON;
+    if !unit(x)
+        || !unit(y)
+        || !unit(z)
+        || x.dot(y).abs() > AFFINE_EPSILON
+        || x.dot(z).abs() > AFFINE_EPSILON
+        || y.dot(z).abs() > AFFINE_EPSILON
+        || Mat3::from_cols(x, y, z).determinant() < 0.0
+        || matrix.x_axis.w.abs() > AFFINE_EPSILON
+        || matrix.y_axis.w.abs() > AFFINE_EPSILON
+        || matrix.z_axis.w.abs() > AFFINE_EPSILON
+        || (matrix.w_axis.w - 1.0).abs() > AFFINE_EPSILON
+    {
+        return Err(PoseReductionError::ScaleOrShear { frame, bone });
+    }
+    let rotation = normalize_quat(Quat::from_mat3(&Mat3::from_cols(x, y, z)));
+    Ok((Vec3A::from(matrix.w_axis.truncate()), rotation))
+}
+
+fn validate_finite_matrix(
+    matrix: Mat4,
+    frame: usize,
+    bone: usize,
+) -> Result<(), PoseReductionError> {
+    if matrix
+        .to_cols_array()
+        .iter()
+        .any(|value| !value.is_finite())
+    {
+        Err(PoseReductionError::NonFiniteMatrix { frame, bone })
+    } else {
+        Ok(())
+    }
+}
+
+fn split_bone_track(
+    keys: &mut Vec<usize>,
+    input: DensePoseSequenceView<'_>,
+    bone: usize,
+    translations: &[Vec3A],
+    rotations: &[Quat],
+    tolerances: ReductionTolerances,
+) {
+    if input.frame_count <= 2 {
+        return;
+    }
+    let bone_count = translations.len() / input.frame_count;
+    let mut stack = vec![(0usize, input.frame_count - 1)];
+    while let Some((start, end)) = stack.pop() {
+        if end <= start + 1 {
+            continue;
+        }
+        let start_index = start * bone_count + bone;
+        let end_index = end * bone_count + bone;
+        let mut worst: Option<(f32, usize)> = None;
+        for frame in start + 1..end {
+            let amount = segment_amount(start, end, frame, |sample| input.sample_frame(sample));
+            let index = frame * bone_count + bone;
+            let position_error = translations[index]
+                .distance(translations[start_index].lerp(translations[end_index], amount));
+            let rotation_error = quat_angle(
+                rotations[index],
+                rotations[start_index].slerp(rotations[end_index], amount),
+            );
+            let normalized = normalized_error(position_error, tolerances.local_position).max(
+                normalized_error(rotation_error, tolerances.local_rotation_radians),
+            );
+            if is_worse(worst, normalized, frame) {
+                worst = Some((normalized, frame));
+            }
+        }
+        if let Some((normalized, frame)) = worst.filter(|value| value.0 > 1.0) {
+            let _ = normalized;
+            insert_key(keys, frame);
+            stack.push((frame, end));
+            stack.push((start, frame));
+        }
+    }
+}
+
+fn split_morph_track(
+    keys: &mut Vec<usize>,
+    input: DensePoseSequenceView<'_>,
+    morph: usize,
+    tolerance: f32,
+) {
+    if input.frame_count <= 2 {
+        return;
+    }
+    let mut stack = vec![(0usize, input.frame_count - 1)];
+    while let Some((start, end)) = stack.pop() {
+        if end <= start + 1 {
+            continue;
+        }
+        let mut worst: Option<(f32, usize)> = None;
+        for frame in start + 1..end {
+            let amount = segment_amount(start, end, frame, |sample| input.sample_frame(sample));
+            let expected = input.morph_weight(start, morph)
+                + (input.morph_weight(end, morph) - input.morph_weight(start, morph)) * amount;
+            let normalized = normalized_error(
+                (input.morph_weight(frame, morph) - expected).abs(),
+                tolerance,
+            );
+            if is_worse(worst, normalized, frame) {
+                worst = Some((normalized, frame));
+            }
+        }
+        if let Some((_, frame)) = worst.filter(|value| value.0 > 1.0) {
+            insert_key(keys, frame);
+            stack.push((frame, end));
+            stack.push((start, frame));
+        }
+    }
+}
+
+fn insert_key(keys: &mut Vec<usize>, frame: usize) -> bool {
+    if let Err(position) = keys.binary_search(&frame) {
+        keys.insert(position, frame);
+        true
+    } else {
+        false
+    }
+}
+
+fn build_sequence(
+    snapshot: &SkeletonSnapshot,
+    target: ReductionTarget,
+    input: DensePoseSequenceView<'_>,
+    translations: &[Vec3A],
+    rotations: &[Quat],
+    bone_key_indices: &[Vec<usize>],
+    morph_key_indices: &[Vec<usize>],
+) -> ReducedPoseSequence {
+    let bone_tracks = bone_key_indices
+        .iter()
+        .enumerate()
+        .map(|(bone, indices)| ReducedBoneTrack {
+            keys: indices
+                .iter()
+                .map(|&frame| {
+                    let index = frame * input.bone_count + bone;
+                    ReducedBoneKey {
+                        sample_index: frame,
+                        translation: translations[index],
+                        rotation: rotations[index],
+                    }
+                })
+                .collect::<Vec<_>>()
+                .into_boxed_slice(),
+        })
+        .collect::<Vec<_>>()
+        .into_boxed_slice();
+    let morph_tracks = morph_key_indices
+        .iter()
+        .enumerate()
+        .map(|(morph, indices)| ReducedMorphTrack {
+            keys: indices
+                .iter()
+                .map(|&frame| ReducedMorphKey {
+                    sample_index: frame,
+                    weight: input.morph_weight(frame, morph),
+                })
+                .collect::<Vec<_>>()
+                .into_boxed_slice(),
+        })
+        .collect::<Vec<_>>()
+        .into_boxed_slice();
+    ReducedPoseSequence {
+        snapshot: snapshot.clone(),
+        target,
+        start_frame: input.start_frame,
+        frame_step: input.frame_step,
+        frame_count: input.frame_count,
+        sample_frames: (0..input.frame_count)
+            .map(|sample| input.sample_frame(sample))
+            .collect::<Vec<_>>()
+            .into_boxed_slice(),
+        bone_tracks,
+        morph_tracks,
+        report: PoseReductionReport::default(),
+    }
+}
+
+#[derive(Clone, Copy)]
+enum ErrorTrack {
+    Bone(usize),
+    Morph(usize),
+}
+
+#[derive(Clone, Copy)]
+struct WorstError {
+    normalized_error: f32,
+    frame: usize,
+    track: ErrorTrack,
+}
+
+fn measure_error(
+    sequence: &ReducedPoseSequence,
+    input: DensePoseSequenceView<'_>,
+    translations: &[Vec3A],
+    rotations: &[Quat],
+    tolerances: ReductionTolerances,
+) -> Result<(PoseReductionReport, Option<WorstError>), PoseReductionError> {
+    measure_error_with_tolerances(sequence, input, translations, rotations, tolerances)
+}
+
+fn measure_error_with_tolerances(
+    sequence: &ReducedPoseSequence,
+    input: DensePoseSequenceView<'_>,
+    translations: &[Vec3A],
+    rotations: &[Quat],
+    tolerances: ReductionTolerances,
+) -> Result<(PoseReductionReport, Option<WorstError>), PoseReductionError> {
+    let mut report = PoseReductionReport::default();
+    let mut worst: Option<WorstError> = None;
+    for frame in 0..input.frame_count {
+        let sample = sequence.sample(input.sample_frame(frame))?;
+        for bone in 0..input.bone_count {
+            let index = frame * input.bone_count + bone;
+            let local_position = translations[index].distance(sample.local_translations[bone]);
+            let local_rotation = quat_angle(rotations[index], sample.local_rotations[bone]);
+            let world_position = Vec3A::from(input.world_matrix(frame, bone).w_axis.truncate())
+                .distance(Vec3A::from(sample.world_matrices[bone].w_axis.truncate()));
+            let expected_world_rotation =
+                decompose_rigid(input.world_matrix(frame, bone), frame, bone)?.1;
+            let sampled_world_rotation =
+                decompose_rigid(sample.world_matrices[bone], frame, bone)?.1;
+            let world_rotation = quat_angle(expected_world_rotation, sampled_world_rotation);
+            report.max_local_position_error = report.max_local_position_error.max(local_position);
+            report.max_local_rotation_error_radians =
+                report.max_local_rotation_error_radians.max(local_rotation);
+            report.max_world_position_error = report.max_world_position_error.max(world_position);
+            report.max_world_rotation_error_radians =
+                report.max_world_rotation_error_radians.max(world_rotation);
+            for normalized in [
+                normalized_error(local_position, tolerances.local_position),
+                normalized_error(local_rotation, tolerances.local_rotation_radians),
+                normalized_error(world_position, tolerances.world_position),
+                normalized_error(world_rotation, tolerances.world_rotation_radians),
+            ] {
+                update_worst(&mut worst, normalized, frame, ErrorTrack::Bone(bone));
+            }
+        }
+        for morph in 0..input.morph_count {
+            let error = (input.morph_weight(frame, morph) - sample.morph_weights[morph]).abs();
+            report.max_morph_weight_error = report.max_morph_weight_error.max(error);
+            update_worst(
+                &mut worst,
+                normalized_error(error, tolerances.morph_weight),
+                frame,
+                ErrorTrack::Morph(morph),
+            );
+        }
+    }
+    Ok((report, worst))
+}
+
+fn update_worst(worst: &mut Option<WorstError>, normalized: f32, frame: usize, track: ErrorTrack) {
+    let replace = worst
+        .is_none_or(|current| normalized.total_cmp(&current.normalized_error) == Ordering::Greater);
+    if replace {
+        *worst = Some(WorstError {
+            normalized_error: normalized,
+            frame,
+            track,
+        });
+    }
+}
+
+fn sample_bone_track(track: &ReducedBoneTrack, sample_frames: &[f32], frame: f32) -> (Vec3A, Quat) {
+    let upper = track
+        .keys
+        .partition_point(|key| sample_frames[key.sample_index] <= frame);
+    if upper == 0 {
+        return (track.keys[0].translation, track.keys[0].rotation);
+    }
+    if upper == track.keys.len() {
+        let key = track.keys[track.keys.len() - 1];
+        return (key.translation, key.rotation);
+    }
+    let left = track.keys[upper - 1];
+    let right = track.keys[upper];
+    let amount = ((frame - sample_frames[left.sample_index])
+        / (sample_frames[right.sample_index] - sample_frames[left.sample_index]))
+        .clamp(0.0, 1.0);
+    (
+        left.translation.lerp(right.translation, amount),
+        normalize_quat(left.rotation.slerp(right.rotation, amount)),
+    )
+}
+
+fn sample_morph_track(track: &ReducedMorphTrack, sample_frames: &[f32], frame: f32) -> f32 {
+    let upper = track
+        .keys
+        .partition_point(|key| sample_frames[key.sample_index] <= frame);
+    if upper == 0 {
+        return track.keys[0].weight;
+    }
+    if upper == track.keys.len() {
+        return track.keys[track.keys.len() - 1].weight;
+    }
+    let left = track.keys[upper - 1];
+    let right = track.keys[upper];
+    let amount = ((frame - sample_frames[left.sample_index])
+        / (sample_frames[right.sample_index] - sample_frames[left.sample_index]))
+        .clamp(0.0, 1.0);
+    left.weight + (right.weight - left.weight) * amount
+}
+
+fn build_world_matrices(
+    snapshot: &SkeletonSnapshot,
+    translations: &[Vec3A],
+    rotations: &[Quat],
+) -> Vec<Mat4> {
+    let mut result = vec![Mat4::IDENTITY; snapshot.bone_count()];
+    for &bone in snapshot.evaluation_order.iter() {
+        let local = Mat4::from_rotation_translation(rotations[bone], translations[bone].into());
+        result[bone] = if snapshot.parent_indices[bone] < 0 {
+            local
+        } else {
+            result[snapshot.parent_indices[bone] as usize] * local
+        };
+    }
+    result
+}
+
+fn build_evaluation_order(parents: &[i32]) -> Result<Vec<usize>, PoseReductionError> {
+    fn visit(
+        bone: usize,
+        parents: &[i32],
+        state: &mut [u8],
+        order: &mut Vec<usize>,
+    ) -> Result<(), PoseReductionError> {
+        match state[bone] {
+            1 => return Err(PoseReductionError::SkeletonCycle { bone }),
+            2 => return Ok(()),
+            _ => {}
+        }
+        state[bone] = 1;
+        if parents[bone] >= 0 {
+            visit(parents[bone] as usize, parents, state, order)?;
+        }
+        state[bone] = 2;
+        order.push(bone);
+        Ok(())
+    }
+    let mut state = vec![0u8; parents.len()];
+    let mut order = Vec::with_capacity(parents.len());
+    for bone in 0..parents.len() {
+        visit(bone, parents, &mut state, &mut order)?;
+    }
+    Ok(order)
+}
+
+fn normalize_quat(value: Quat) -> Quat {
+    if value.length_squared() <= f32::EPSILON {
+        Quat::IDENTITY
+    } else {
+        value.normalize()
+    }
+}
+
+fn quat_is_finite(value: Quat) -> bool {
+    value.to_array().iter().all(|value| value.is_finite()) && value.length_squared() > f32::EPSILON
+}
+
+fn quat_angle(a: Quat, b: Quat) -> f32 {
+    2.0 * a.dot(b).abs().clamp(-1.0, 1.0).acos()
+}
+
+fn normalized_error(error: f32, tolerance: f32) -> f32 {
+    if tolerance == 0.0 {
+        if error == 0.0 { 0.0 } else { f32::INFINITY }
+    } else {
+        error / tolerance
+    }
+}
+
+fn segment_amount(start: usize, end: usize, sample: usize, frame_at: impl Fn(usize) -> f32) -> f32 {
+    let start_frame = frame_at(start);
+    (frame_at(sample) - start_frame) / (frame_at(end) - start_frame)
+}
+
+fn is_worse(current: Option<(f32, usize)>, error: f32, frame: usize) -> bool {
+    current.is_none_or(|(best, best_frame)| error > best || (error == best && frame < best_frame))
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/mmd-anim-runtime/src/reduce/mod.rs
+++ b/crates/mmd-anim-runtime/src/reduce/mod.rs
@@ -155,6 +155,14 @@ impl SkeletonSnapshot {
     }
 
     pub fn from_model(model: &ModelArena, model_identity: u64) -> Result<Self, PoseReductionError> {
+        Self::from_model_with_morph_count(model, model_identity, model.morph_count() as usize)
+    }
+
+    pub fn from_model_with_morph_count(
+        model: &ModelArena,
+        model_identity: u64,
+        morph_count: usize,
+    ) -> Result<Self, PoseReductionError> {
         let mut parents = Vec::with_capacity(model.bone_count());
         let mut translations = Vec::with_capacity(model.bone_count());
         for bone in 0..model.bone_count() {
@@ -168,7 +176,7 @@ impl SkeletonSnapshot {
             parents,
             translations,
             vec![Quat::IDENTITY; model.bone_count()],
-            model.morph_count() as usize,
+            morph_count,
             model_identity,
         )
     }

--- a/crates/mmd-anim-runtime/src/reduce/mod.rs
+++ b/crates/mmd-anim-runtime/src/reduce/mod.rs
@@ -2354,7 +2354,16 @@ fn quat_is_finite(value: Quat) -> bool {
 }
 
 fn quat_angle(a: Quat, b: Quat) -> f32 {
-    2.0 * a.dot(b).abs().clamp(-1.0, 1.0).acos()
+    let a = normalize_quat(a);
+    let mut b = normalize_quat(b);
+    if a.dot(b) < 0.0 {
+        b = -b;
+    }
+    // For unit quaternions, the hemisphere-aligned chord length is
+    // `2 * sin(theta / 4)`. Unlike `acos(dot)`, this remains stable for tiny
+    // angles and returns exactly zero for identical f32 quaternions.
+    let half_chord = ((a - b).length() * 0.5).clamp(0.0, 1.0);
+    4.0 * half_chord.asin()
 }
 
 fn normalized_error(error: f32, tolerance: f32) -> f32 {

--- a/crates/mmd-anim-runtime/src/reduce/mod.rs
+++ b/crates/mmd-anim-runtime/src/reduce/mod.rs
@@ -2,6 +2,10 @@ use std::cmp::Ordering;
 use std::time::{Duration, Instant};
 
 use glam::{EulerRot, Mat3, Mat4, Quat, Vec3, Vec3A};
+#[cfg(not(target_family = "wasm"))]
+use rayon::prelude::*;
+#[cfg(not(target_family = "wasm"))]
+use rayon::{ThreadPool, ThreadPoolBuilder};
 use thiserror::Error;
 
 use crate::{BoneIndex, InterpolationScalar, ModelArena};
@@ -378,6 +382,12 @@ pub struct ReductionTimings {
     pub dcc_fit: Duration,
 }
 
+#[cfg(not(target_family = "wasm"))]
+type ReductionThreadPool = ThreadPool;
+
+#[cfg(target_family = "wasm")]
+struct ReductionThreadPool;
+
 #[derive(Debug, Clone)]
 pub struct ReducedPoseSequence {
     snapshot: SkeletonSnapshot,
@@ -557,6 +567,8 @@ pub enum PoseReductionError {
     InvalidSampleTime,
     #[error("requested tolerance cannot be attained at source frame {frame}")]
     ToleranceUnattainable { frame: usize },
+    #[error("failed to create pose reduction worker pool")]
+    WorkerPool,
 }
 
 pub fn reduce_dense_pose_sequence(
@@ -564,6 +576,16 @@ pub fn reduce_dense_pose_sequence(
     snapshot: SkeletonSnapshot,
     tolerances: ReductionTolerances,
     target: ReductionTarget,
+) -> Result<ReducedPoseSequence, PoseReductionError> {
+    reduce_dense_pose_sequence_with_worker_count(input, snapshot, tolerances, target, 0)
+}
+
+pub fn reduce_dense_pose_sequence_with_worker_count(
+    input: DensePoseSequenceView<'_>,
+    snapshot: SkeletonSnapshot,
+    tolerances: ReductionTolerances,
+    target: ReductionTarget,
+    worker_count: usize,
 ) -> Result<ReducedPoseSequence, PoseReductionError> {
     let tolerances = tolerances.validate()?;
     if input.bone_count != snapshot.bone_count() || input.morph_count != snapshot.morph_count() {
@@ -577,6 +599,8 @@ pub fn reduce_dense_pose_sequence(
         ..Default::default()
     };
     let mut timings = ReductionTimings::default();
+    let worker_count = resolve_reduction_worker_count(worker_count, input.frame_count);
+    let worker_pool = build_reduction_worker_pool(worker_count)?;
     let local_euler_xyz = unwrap_euler_xyz(&local_rotations, input.frame_count, input.bone_count);
     for frame in 0..input.frame_count {
         for morph in 0..input.morph_count {
@@ -640,13 +664,16 @@ pub fn reduce_dense_pose_sequence(
             },
             tolerances,
             &mut work_stats,
+            worker_pool.as_ref(),
+            worker_count,
         )?;
         timings.error_measure += error_measure_started.elapsed();
-        let failing = worst_by_track
+        let mut failing = worst_by_track
             .into_iter()
             .flatten()
             .filter(|worst| worst.normalized_error > 1.0)
             .collect::<Vec<_>>();
+        failing.sort_by(compare_worst_errors);
         if failing.is_empty() {
             work_stats.added_keys_per_pass.push(0);
             let mut result = candidate;
@@ -1041,7 +1068,7 @@ fn build_sequence(
     }
 }
 
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ErrorTrack {
     Bone(usize),
     Morph(usize),
@@ -1060,8 +1087,18 @@ fn measure_error(
     dense: DenseValidationPose<'_>,
     tolerances: ReductionTolerances,
     work_stats: &mut ReductionWorkStats,
+    worker_pool: Option<&ReductionThreadPool>,
+    worker_count: usize,
 ) -> Result<(PoseReductionReport, Vec<Option<WorstError>>), PoseReductionError> {
-    measure_error_with_tolerances(sequence, input, dense, tolerances, work_stats)
+    measure_error_with_tolerances(
+        sequence,
+        input,
+        dense,
+        tolerances,
+        work_stats,
+        worker_pool,
+        worker_count,
+    )
 }
 
 #[derive(Clone, Copy)]
@@ -1072,23 +1109,93 @@ struct DenseValidationPose<'a> {
     world_rotations: &'a [Quat],
 }
 
+struct FrameErrorResult {
+    report: PoseReductionReport,
+    worst: Vec<Option<WorstError>>,
+}
+
 fn measure_error_with_tolerances(
     sequence: &ReducedPoseSequence,
     input: DensePoseSequenceView<'_>,
     dense: DenseValidationPose<'_>,
     tolerances: ReductionTolerances,
     work_stats: &mut ReductionWorkStats,
+    worker_pool: Option<&ReductionThreadPool>,
+    worker_count: usize,
 ) -> Result<(PoseReductionReport, Vec<Option<WorstError>>), PoseReductionError> {
+    work_stats.bone_samples += input.frame_count * input.bone_count;
+    work_stats.morph_samples += input.frame_count * input.morph_count;
+    work_stats.world_rebuilds += input.frame_count;
+    work_stats.world_rotation_decompositions += input.frame_count * input.bone_count;
+
+    let chunk_size = input.frame_count.div_ceil(worker_count);
+    let ranges = (0..worker_count)
+        .map(|worker| {
+            let start = worker * chunk_size;
+            start..(start + chunk_size).min(input.frame_count)
+        })
+        .filter(|range| !range.is_empty())
+        .collect::<Vec<_>>();
+    #[cfg(not(target_family = "wasm"))]
+    let results = if let Some(pool) = worker_pool {
+        pool.install(|| {
+            ranges
+                .par_iter()
+                .map(|range| {
+                    measure_error_range(sequence, input, dense, tolerances, range.start, range.end)
+                })
+                .collect::<Result<Vec<_>, _>>()
+        })?
+    } else {
+        vec![measure_error_range(
+            sequence,
+            input,
+            dense,
+            tolerances,
+            0,
+            input.frame_count,
+        )?]
+    };
+    #[cfg(target_family = "wasm")]
+    let results = {
+        let _ = (worker_pool, ranges);
+        vec![measure_error_range(
+            sequence,
+            input,
+            dense,
+            tolerances,
+            0,
+            input.frame_count,
+        )?]
+    };
+
+    let mut report = PoseReductionReport::default();
+    let mut worst = vec![None; input.bone_count + input.morph_count];
+    for result in results {
+        merge_reduction_report(&mut report, result.report);
+        for (merged, candidate) in worst.iter_mut().zip(result.worst) {
+            if let Some(candidate) = candidate {
+                update_worst_candidate(merged, candidate);
+            }
+        }
+    }
+    Ok((report, worst))
+}
+
+fn measure_error_range(
+    sequence: &ReducedPoseSequence,
+    input: DensePoseSequenceView<'_>,
+    dense: DenseValidationPose<'_>,
+    tolerances: ReductionTolerances,
+    start_frame: usize,
+    end_frame: usize,
+) -> Result<FrameErrorResult, PoseReductionError> {
     let mut report = PoseReductionReport::default();
     let mut worst = vec![None; input.bone_count + input.morph_count];
     let mut scratch = ReducedPoseScratch::default();
     scratch.prepare(input.bone_count, input.morph_count);
-    for frame in 0..input.frame_count {
+    for frame in start_frame..end_frame {
         sequence.sample_into(input.sample_frame(frame), &mut scratch)?;
-        work_stats.bone_samples += input.bone_count;
-        work_stats.morph_samples += input.morph_count;
-        work_stats.world_rebuilds += 1;
-        work_stats.world_rotation_decompositions += input.bone_count;
         for (bone, bone_worst) in worst[..input.bone_count].iter_mut().enumerate() {
             let index = frame * input.bone_count + bone;
             let local_position =
@@ -1125,19 +1232,96 @@ fn measure_error_with_tolerances(
             );
         }
     }
-    Ok((report, worst))
+    Ok(FrameErrorResult { report, worst })
+}
+
+fn merge_reduction_report(report: &mut PoseReductionReport, candidate: PoseReductionReport) {
+    report.max_local_position_error = report
+        .max_local_position_error
+        .max(candidate.max_local_position_error);
+    report.max_local_rotation_error_radians = report
+        .max_local_rotation_error_radians
+        .max(candidate.max_local_rotation_error_radians);
+    report.max_world_position_error = report
+        .max_world_position_error
+        .max(candidate.max_world_position_error);
+    report.max_world_rotation_error_radians = report
+        .max_world_rotation_error_radians
+        .max(candidate.max_world_rotation_error_radians);
+    report.max_morph_weight_error = report
+        .max_morph_weight_error
+        .max(candidate.max_morph_weight_error);
 }
 
 fn update_worst(worst: &mut Option<WorstError>, normalized: f32, frame: usize, track: ErrorTrack) {
-    let replace = worst
-        .is_none_or(|current| normalized.total_cmp(&current.normalized_error) == Ordering::Greater);
-    if replace {
-        *worst = Some(WorstError {
+    update_worst_candidate(
+        worst,
+        WorstError {
             normalized_error: normalized,
             frame,
             track,
-        });
+        },
+    );
+}
+
+fn update_worst_candidate(worst: &mut Option<WorstError>, candidate: WorstError) {
+    if worst.is_none_or(|current| compare_worst_errors(&candidate, &current) == Ordering::Less) {
+        *worst = Some(candidate);
     }
+}
+
+fn compare_worst_errors(a: &WorstError, b: &WorstError) -> Ordering {
+    b.normalized_error
+        .total_cmp(&a.normalized_error)
+        .then_with(|| a.frame.cmp(&b.frame))
+        .then_with(|| error_track_sort_key(a.track).cmp(&error_track_sort_key(b.track)))
+}
+
+fn error_track_sort_key(track: ErrorTrack) -> (u8, usize) {
+    match track {
+        ErrorTrack::Bone(index) => (0, index),
+        ErrorTrack::Morph(index) => (1, index),
+    }
+}
+
+fn resolve_reduction_worker_count(requested: usize, frame_count: usize) -> usize {
+    #[cfg(target_family = "wasm")]
+    {
+        let _ = (requested, frame_count);
+        1
+    }
+    #[cfg(not(target_family = "wasm"))]
+    {
+        let workers = if requested == 0 {
+            std::thread::available_parallelism()
+                .map(usize::from)
+                .unwrap_or(1)
+        } else {
+            requested
+        };
+        workers.clamp(1, frame_count.max(1))
+    }
+}
+
+#[cfg(not(target_family = "wasm"))]
+fn build_reduction_worker_pool(
+    worker_count: usize,
+) -> Result<Option<ReductionThreadPool>, PoseReductionError> {
+    (worker_count > 1)
+        .then(|| {
+            ThreadPoolBuilder::new()
+                .num_threads(worker_count)
+                .build()
+                .map_err(|_| PoseReductionError::WorkerPool)
+        })
+        .transpose()
+}
+
+#[cfg(target_family = "wasm")]
+fn build_reduction_worker_pool(
+    _worker_count: usize,
+) -> Result<Option<ReductionThreadPool>, PoseReductionError> {
+    Ok(None)
 }
 
 fn fit_vmd_bone_interpolation(

--- a/crates/mmd-anim-runtime/src/reduce/mod.rs
+++ b/crates/mmd-anim-runtime/src/reduce/mod.rs
@@ -398,32 +398,42 @@ impl ReducedPoseSequence {
     }
 
     pub fn sample(&self, frame: f32) -> Result<ReducedPoseSample, PoseReductionError> {
+        let mut scratch = ReducedPoseScratch::default();
+        self.sample_into(frame, &mut scratch)?;
+        Ok(ReducedPoseSample {
+            local_translations: scratch.local_translations,
+            local_rotations: scratch.local_rotations,
+            world_matrices: scratch.world_matrices,
+            morph_weights: scratch.morph_weights,
+        })
+    }
+
+    fn sample_into(
+        &self,
+        frame: f32,
+        scratch: &mut ReducedPoseScratch,
+    ) -> Result<(), PoseReductionError> {
         if !frame.is_finite() {
             return Err(PoseReductionError::InvalidSampleTime);
         }
-        let local_translations = self
-            .bone_tracks
-            .iter()
-            .map(|track| sample_bone_track(track, &self.sample_frames, frame, self.target).0)
-            .collect::<Vec<_>>();
-        let local_rotations = self
-            .bone_tracks
-            .iter()
-            .map(|track| sample_bone_track(track, &self.sample_frames, frame, self.target).1)
-            .collect::<Vec<_>>();
-        let morph_weights = self
-            .morph_tracks
-            .iter()
-            .map(|track| sample_morph_track(track, &self.sample_frames, frame, self.target))
-            .collect::<Vec<_>>();
-        let world_matrices =
-            build_world_matrices(&self.snapshot, &local_translations, &local_rotations);
-        Ok(ReducedPoseSample {
-            local_translations,
-            local_rotations,
-            world_matrices,
-            morph_weights,
-        })
+        scratch.prepare(self.snapshot.bone_count(), self.snapshot.morph_count());
+        for (bone, track) in self.bone_tracks.iter().enumerate() {
+            let (translation, rotation) =
+                sample_bone_track(track, &self.sample_frames, frame, self.target);
+            scratch.local_translations[bone] = translation;
+            scratch.local_rotations[bone] = rotation;
+        }
+        for (morph, track) in self.morph_tracks.iter().enumerate() {
+            scratch.morph_weights[morph] =
+                sample_morph_track(track, &self.sample_frames, frame, self.target);
+        }
+        build_world_matrices_into(
+            &self.snapshot,
+            &scratch.local_translations,
+            &scratch.local_rotations,
+            &mut scratch.world_matrices,
+        );
+        Ok(())
     }
 
     pub fn validate_model(
@@ -435,6 +445,23 @@ impl ReducedPoseSequence {
         self.snapshot.model_identity == model_identity
             && self.snapshot.bone_count() == bone_count
             && self.snapshot.morph_count == morph_count
+    }
+}
+
+#[derive(Debug, Default)]
+struct ReducedPoseScratch {
+    local_translations: Vec<Vec3A>,
+    local_rotations: Vec<Quat>,
+    world_matrices: Vec<Mat4>,
+    morph_weights: Vec<f32>,
+}
+
+impl ReducedPoseScratch {
+    fn prepare(&mut self, bone_count: usize, morph_count: usize) {
+        self.local_translations.resize(bone_count, Vec3A::ZERO);
+        self.local_rotations.resize(bone_count, Quat::IDENTITY);
+        self.world_matrices.resize(bone_count, Mat4::IDENTITY);
+        self.morph_weights.resize(morph_count, 0.0);
     }
 }
 
@@ -498,6 +525,7 @@ pub fn reduce_dense_pose_sequence(
     }
 
     let (local_translations, local_rotations) = decompose_dense_pose(input, &snapshot)?;
+    let (world_positions, world_rotations) = cache_dense_world_components(input)?;
     let local_euler_xyz = unwrap_euler_xyz(&local_rotations, input.frame_count, input.bone_count);
     for frame in 0..input.frame_count {
         for morph in 0..input.morph_count {
@@ -546,6 +574,8 @@ pub fn reduce_dense_pose_sequence(
             input,
             &local_translations,
             &local_rotations,
+            &world_positions,
+            &world_rotations,
             tolerances,
         )?;
         let failing = worst_by_track
@@ -643,6 +673,22 @@ fn decompose_dense_pose(
         }
     }
     Ok((translations, rotations))
+}
+
+fn cache_dense_world_components(
+    input: DensePoseSequenceView<'_>,
+) -> Result<(Vec<Vec3A>, Vec<Quat>), PoseReductionError> {
+    let count = input.frame_count * input.bone_count;
+    let mut positions = Vec::with_capacity(count);
+    let mut rotations = Vec::with_capacity(count);
+    for frame in 0..input.frame_count {
+        for bone in 0..input.bone_count {
+            let world = input.world_matrix(frame, bone);
+            positions.push(Vec3A::from(world.w_axis.truncate()));
+            rotations.push(decompose_rigid(world, frame, bone)?.1);
+        }
+    }
+    Ok((positions, rotations))
 }
 
 fn decompose_rigid(
@@ -900,9 +946,19 @@ fn measure_error(
     input: DensePoseSequenceView<'_>,
     translations: &[Vec3A],
     rotations: &[Quat],
+    world_positions: &[Vec3A],
+    world_rotations: &[Quat],
     tolerances: ReductionTolerances,
 ) -> Result<(PoseReductionReport, Vec<Option<WorstError>>), PoseReductionError> {
-    measure_error_with_tolerances(sequence, input, translations, rotations, tolerances)
+    measure_error_with_tolerances(
+        sequence,
+        input,
+        translations,
+        rotations,
+        world_positions,
+        world_rotations,
+        tolerances,
+    )
 }
 
 fn measure_error_with_tolerances(
@@ -910,23 +966,25 @@ fn measure_error_with_tolerances(
     input: DensePoseSequenceView<'_>,
     translations: &[Vec3A],
     rotations: &[Quat],
+    world_positions: &[Vec3A],
+    world_rotations: &[Quat],
     tolerances: ReductionTolerances,
 ) -> Result<(PoseReductionReport, Vec<Option<WorstError>>), PoseReductionError> {
     let mut report = PoseReductionReport::default();
     let mut worst = vec![None; input.bone_count + input.morph_count];
+    let mut scratch = ReducedPoseScratch::default();
+    scratch.prepare(input.bone_count, input.morph_count);
     for frame in 0..input.frame_count {
-        let sample = sequence.sample(input.sample_frame(frame))?;
+        sequence.sample_into(input.sample_frame(frame), &mut scratch)?;
         for (bone, bone_worst) in worst[..input.bone_count].iter_mut().enumerate() {
             let index = frame * input.bone_count + bone;
-            let local_position = translations[index].distance(sample.local_translations[bone]);
-            let local_rotation = quat_angle(rotations[index], sample.local_rotations[bone]);
-            let world_position = Vec3A::from(input.world_matrix(frame, bone).w_axis.truncate())
-                .distance(Vec3A::from(sample.world_matrices[bone].w_axis.truncate()));
-            let expected_world_rotation =
-                decompose_rigid(input.world_matrix(frame, bone), frame, bone)?.1;
+            let local_position = translations[index].distance(scratch.local_translations[bone]);
+            let local_rotation = quat_angle(rotations[index], scratch.local_rotations[bone]);
+            let world_position = world_positions[index]
+                .distance(Vec3A::from(scratch.world_matrices[bone].w_axis.truncate()));
             let sampled_world_rotation =
-                decompose_rigid(sample.world_matrices[bone], frame, bone)?.1;
-            let world_rotation = quat_angle(expected_world_rotation, sampled_world_rotation);
+                decompose_rigid(scratch.world_matrices[bone], frame, bone)?.1;
+            let world_rotation = quat_angle(world_rotations[index], sampled_world_rotation);
             report.max_local_position_error = report.max_local_position_error.max(local_position);
             report.max_local_rotation_error_radians =
                 report.max_local_rotation_error_radians.max(local_rotation);
@@ -943,7 +1001,7 @@ fn measure_error_with_tolerances(
             }
         }
         for morph in 0..input.morph_count {
-            let error = (input.morph_weight(frame, morph) - sample.morph_weights[morph]).abs();
+            let error = (input.morph_weight(frame, morph) - scratch.morph_weights[morph]).abs();
             report.max_morph_weight_error = report.max_morph_weight_error.max(error);
             update_worst(
                 &mut worst[input.bone_count + morph],
@@ -1419,12 +1477,13 @@ fn sample_morph_track(
     left.weight + (right.weight - left.weight) * amount
 }
 
-fn build_world_matrices(
+fn build_world_matrices_into(
     snapshot: &SkeletonSnapshot,
     translations: &[Vec3A],
     rotations: &[Quat],
-) -> Vec<Mat4> {
-    let mut result = vec![Mat4::IDENTITY; snapshot.bone_count()];
+    result: &mut Vec<Mat4>,
+) {
+    result.resize(snapshot.bone_count(), Mat4::IDENTITY);
     for &bone in snapshot.evaluation_order.iter() {
         let local = Mat4::from_rotation_translation(rotations[bone], translations[bone].into());
         result[bone] = if snapshot.parent_indices[bone] < 0 {
@@ -1433,7 +1492,6 @@ fn build_world_matrices(
             result[snapshot.parent_indices[bone] as usize] * local
         };
     }
-    result
 }
 
 fn build_evaluation_order(parents: &[i32]) -> Result<Vec<usize>, PoseReductionError> {

--- a/crates/mmd-anim-runtime/src/reduce/mod.rs
+++ b/crates/mmd-anim-runtime/src/reduce/mod.rs
@@ -1,6 +1,6 @@
 use std::cmp::Ordering;
 
-use glam::{Mat3, Mat4, Quat, Vec3, Vec3A};
+use glam::{EulerRot, Mat3, Mat4, Quat, Vec3, Vec3A};
 use thiserror::Error;
 
 use crate::{BoneIndex, InterpolationScalar, ModelArena};
@@ -197,6 +197,23 @@ impl SkeletonSnapshot {
 pub enum ReductionTarget {
     LinearSlerp,
     VmdBezier,
+    DccCubic,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
+pub struct DccCubicSegment {
+    pub translation_out_tangent: Vec3A,
+    pub translation_in_tangent: Vec3A,
+    pub rotation_start_euler_xyz: Vec3A,
+    pub rotation_end_euler_xyz: Vec3A,
+    pub rotation_out_tangent: Vec3A,
+    pub rotation_in_tangent: Vec3A,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
+pub struct DccScalarSegment {
+    pub out_tangent: f32,
+    pub in_tangent: f32,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -285,6 +302,7 @@ pub struct ReducedBoneKey {
     pub translation: Vec3A,
     pub rotation: Quat,
     pub vmd_interpolation: VmdBoneInterpolation,
+    pub dcc_segment: DccCubicSegment,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -302,6 +320,7 @@ impl ReducedBoneTrack {
 pub struct ReducedMorphKey {
     pub sample_index: usize,
     pub weight: f32,
+    pub dcc_segment: DccScalarSegment,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -384,7 +403,7 @@ impl ReducedPoseSequence {
         let morph_weights = self
             .morph_tracks
             .iter()
-            .map(|track| sample_morph_track(track, &self.sample_frames, frame))
+            .map(|track| sample_morph_track(track, &self.sample_frames, frame, self.target))
             .collect::<Vec<_>>();
         let world_matrices =
             build_world_matrices(&self.snapshot, &local_translations, &local_rotations);
@@ -468,6 +487,7 @@ pub fn reduce_dense_pose_sequence(
     }
 
     let (local_translations, local_rotations) = decompose_dense_pose(input, &snapshot)?;
+    let local_euler_xyz = unwrap_euler_xyz(&local_rotations, input.frame_count, input.bone_count);
     for frame in 0..input.frame_count {
         for morph in 0..input.morph_count {
             if !input.morph_weight(frame, morph).is_finite() {
@@ -491,8 +511,10 @@ pub fn reduce_dense_pose_sequence(
             );
         }
     }
-    for (morph, keys) in morph_key_indices.iter_mut().enumerate() {
-        split_morph_track(keys, input, morph, tolerances.morph_weight);
+    if target != ReductionTarget::DccCubic {
+        for (morph, keys) in morph_key_indices.iter_mut().enumerate() {
+            split_morph_track(keys, input, morph, tolerances.morph_weight);
+        }
     }
 
     loop {
@@ -500,8 +522,11 @@ pub fn reduce_dense_pose_sequence(
             &snapshot,
             target,
             input,
-            &local_translations,
-            &local_rotations,
+            DenseLocalPose {
+                translations: &local_translations,
+                rotations: &local_rotations,
+                euler_xyz: &local_euler_xyz,
+            },
             &bone_key_indices,
             &morph_key_indices,
         );
@@ -732,12 +757,18 @@ fn insert_key(keys: &mut Vec<usize>, frame: usize) -> bool {
     }
 }
 
+#[derive(Clone, Copy)]
+struct DenseLocalPose<'a> {
+    translations: &'a [Vec3A],
+    rotations: &'a [Quat],
+    euler_xyz: &'a [Vec3A],
+}
+
 fn build_sequence(
     snapshot: &SkeletonSnapshot,
     target: ReductionTarget,
     input: DensePoseSequenceView<'_>,
-    translations: &[Vec3A],
-    rotations: &[Quat],
+    local_pose: DenseLocalPose<'_>,
     bone_key_indices: &[Vec<usize>],
     morph_key_indices: &[Vec<usize>],
 ) -> ReducedPoseSequence {
@@ -757,17 +788,30 @@ fn build_sequence(
                                 bone,
                                 indices[key_position - 1],
                                 frame,
-                                translations,
-                                rotations,
+                                local_pose.translations,
+                                local_pose.rotations,
                             )
                         } else {
                             VmdBoneInterpolation::LINEAR
                         };
+                    let dcc_segment = if target == ReductionTarget::DccCubic && key_position > 0 {
+                        fit_dcc_bone_segment(
+                            input,
+                            bone,
+                            indices[key_position - 1],
+                            frame,
+                            local_pose.translations,
+                            local_pose.euler_xyz,
+                        )
+                    } else {
+                        DccCubicSegment::default()
+                    };
                     ReducedBoneKey {
                         sample_index: frame,
-                        translation: translations[index],
-                        rotation: rotations[index],
+                        translation: local_pose.translations[index],
+                        rotation: local_pose.rotations[index],
                         vmd_interpolation,
+                        dcc_segment,
                     }
                 })
                 .collect::<Vec<_>>()
@@ -781,9 +825,20 @@ fn build_sequence(
         .map(|(morph, indices)| ReducedMorphTrack {
             keys: indices
                 .iter()
-                .map(|&frame| ReducedMorphKey {
+                .enumerate()
+                .map(|(key_position, &frame)| ReducedMorphKey {
                     sample_index: frame,
                     weight: input.morph_weight(frame, morph),
+                    dcc_segment: if target == ReductionTarget::DccCubic && key_position > 0 {
+                        fit_dcc_scalar_segment(
+                            indices[key_position - 1],
+                            frame,
+                            |sample| input.morph_weight(sample, morph),
+                            |sample| input.sample_frame(sample),
+                        )
+                    } else {
+                        DccScalarSegment::default()
+                    },
                 })
                 .collect::<Vec<_>>()
                 .into_boxed_slice(),
@@ -1034,6 +1089,176 @@ fn normalized_channel_value(start: f32, end: f32, value: f32) -> f32 {
     }
 }
 
+fn unwrap_euler_xyz(rotations: &[Quat], frame_count: usize, bone_count: usize) -> Vec<Vec3A> {
+    let mut result = vec![Vec3A::ZERO; rotations.len()];
+    for bone in 0..bone_count {
+        for frame in 0..frame_count {
+            let index = frame * bone_count + bone;
+            let (x, y, z) = rotations[index].to_euler(EulerRot::XYZ);
+            let mut value = Vec3A::new(x, y, z);
+            if frame > 0 {
+                let previous = result[index - bone_count];
+                value.x = unwrap_angle(previous.x, value.x);
+                value.y = unwrap_angle(previous.y, value.y);
+                value.z = unwrap_angle(previous.z, value.z);
+            }
+            result[index] = value;
+        }
+    }
+    result
+}
+
+fn unwrap_angle(previous: f32, value: f32) -> f32 {
+    let turns = ((previous - value) / std::f32::consts::TAU).round();
+    value + turns * std::f32::consts::TAU
+}
+
+fn fit_dcc_bone_segment(
+    input: DensePoseSequenceView<'_>,
+    bone: usize,
+    start: usize,
+    end: usize,
+    translations: &[Vec3A],
+    euler_xyz: &[Vec3A],
+) -> DccCubicSegment {
+    let bone_count = input.bone_count;
+    let translation = std::array::from_fn::<_, 3, _>(|axis| {
+        fit_dcc_scalar_segment(
+            start,
+            end,
+            |sample| translations[sample * bone_count + bone].to_array()[axis],
+            |sample| input.sample_frame(sample),
+        )
+    });
+    let rotation = std::array::from_fn::<_, 3, _>(|axis| {
+        fit_dcc_scalar_segment(
+            start,
+            end,
+            |sample| euler_xyz[sample * bone_count + bone].to_array()[axis],
+            |sample| input.sample_frame(sample),
+        )
+    });
+    DccCubicSegment {
+        translation_out_tangent: Vec3A::new(
+            translation[0].out_tangent,
+            translation[1].out_tangent,
+            translation[2].out_tangent,
+        ),
+        translation_in_tangent: Vec3A::new(
+            translation[0].in_tangent,
+            translation[1].in_tangent,
+            translation[2].in_tangent,
+        ),
+        rotation_start_euler_xyz: euler_xyz[start * bone_count + bone],
+        rotation_end_euler_xyz: euler_xyz[end * bone_count + bone],
+        rotation_out_tangent: Vec3A::new(
+            rotation[0].out_tangent,
+            rotation[1].out_tangent,
+            rotation[2].out_tangent,
+        ),
+        rotation_in_tangent: Vec3A::new(
+            rotation[0].in_tangent,
+            rotation[1].in_tangent,
+            rotation[2].in_tangent,
+        ),
+    }
+}
+
+fn fit_dcc_scalar_segment(
+    start: usize,
+    end: usize,
+    value_at: impl Fn(usize) -> f32,
+    frame_at: impl Fn(usize) -> f32,
+) -> DccScalarSegment {
+    let duration = frame_at(end) - frame_at(start);
+    let start_value = value_at(start);
+    let end_value = value_at(end);
+    let slope = (end_value - start_value) / duration;
+    if end <= start + 1 {
+        return DccScalarSegment {
+            out_tangent: slope,
+            in_tangent: slope,
+        };
+    }
+
+    let mut aa = 0.0;
+    let mut ab = 0.0;
+    let mut bb = 0.0;
+    let mut ar = 0.0;
+    let mut br = 0.0;
+    for sample in start + 1..end {
+        let t = segment_amount(start, end, sample, &frame_at);
+        let (h00, h10, h01, h11) = hermite_basis(t);
+        let a = h10 * duration;
+        let b = h11 * duration;
+        let residual = value_at(sample) - h00 * start_value - h01 * end_value;
+        aa += a * a;
+        ab += a * b;
+        bb += b * b;
+        ar += a * residual;
+        br += b * residual;
+    }
+    let determinant = aa * bb - ab * ab;
+    let (mut out_tangent, mut in_tangent) = if determinant.abs() > f32::EPSILON {
+        (
+            (ar * bb - br * ab) / determinant,
+            (br * aa - ar * ab) / determinant,
+        )
+    } else {
+        (slope, slope)
+    };
+    clamp_monotonic_tangents(slope, &mut out_tangent, &mut in_tangent);
+    DccScalarSegment {
+        out_tangent,
+        in_tangent,
+    }
+}
+
+fn clamp_monotonic_tangents(slope: f32, out_tangent: &mut f32, in_tangent: &mut f32) {
+    if slope.abs() <= f32::EPSILON {
+        *out_tangent = 0.0;
+        *in_tangent = 0.0;
+        return;
+    }
+    if *out_tangent * slope < 0.0 {
+        *out_tangent = 0.0;
+    }
+    if *in_tangent * slope < 0.0 {
+        *in_tangent = 0.0;
+    }
+    let alpha = *out_tangent / slope;
+    let beta = *in_tangent / slope;
+    let length = alpha.hypot(beta);
+    if length > 3.0 {
+        let scale = 3.0 / length;
+        *out_tangent = scale * alpha * slope;
+        *in_tangent = scale * beta * slope;
+    }
+}
+
+fn hermite_basis(t: f32) -> (f32, f32, f32, f32) {
+    let t2 = t * t;
+    let t3 = t2 * t;
+    (
+        2.0 * t3 - 3.0 * t2 + 1.0,
+        t3 - 2.0 * t2 + t,
+        -2.0 * t3 + 3.0 * t2,
+        t3 - t2,
+    )
+}
+
+fn sample_hermite(
+    start: f32,
+    end: f32,
+    out_tangent: f32,
+    in_tangent: f32,
+    duration: f32,
+    t: f32,
+) -> f32 {
+    let (h00, h10, h01, h11) = hermite_basis(t);
+    h00 * start + h10 * duration * out_tangent + h01 * end + h11 * duration * in_tangent
+}
+
 fn sample_bone_track(
     track: &ReducedBoneTrack,
     sample_frames: &[f32],
@@ -1055,6 +1280,66 @@ fn sample_bone_track(
     let amount = ((frame - sample_frames[left.sample_index])
         / (sample_frames[right.sample_index] - sample_frames[left.sample_index]))
         .clamp(0.0, 1.0);
+    if target == ReductionTarget::DccCubic {
+        let duration = sample_frames[right.sample_index] - sample_frames[left.sample_index];
+        let segment = right.dcc_segment;
+        let translation = Vec3A::new(
+            sample_hermite(
+                left.translation.x,
+                right.translation.x,
+                segment.translation_out_tangent.x,
+                segment.translation_in_tangent.x,
+                duration,
+                amount,
+            ),
+            sample_hermite(
+                left.translation.y,
+                right.translation.y,
+                segment.translation_out_tangent.y,
+                segment.translation_in_tangent.y,
+                duration,
+                amount,
+            ),
+            sample_hermite(
+                left.translation.z,
+                right.translation.z,
+                segment.translation_out_tangent.z,
+                segment.translation_in_tangent.z,
+                duration,
+                amount,
+            ),
+        );
+        let euler = Vec3A::new(
+            sample_hermite(
+                segment.rotation_start_euler_xyz.x,
+                segment.rotation_end_euler_xyz.x,
+                segment.rotation_out_tangent.x,
+                segment.rotation_in_tangent.x,
+                duration,
+                amount,
+            ),
+            sample_hermite(
+                segment.rotation_start_euler_xyz.y,
+                segment.rotation_end_euler_xyz.y,
+                segment.rotation_out_tangent.y,
+                segment.rotation_in_tangent.y,
+                duration,
+                amount,
+            ),
+            sample_hermite(
+                segment.rotation_start_euler_xyz.z,
+                segment.rotation_end_euler_xyz.z,
+                segment.rotation_out_tangent.z,
+                segment.rotation_in_tangent.z,
+                duration,
+                amount,
+            ),
+        );
+        return (
+            translation,
+            normalize_quat(Quat::from_euler(EulerRot::XYZ, euler.x, euler.y, euler.z)),
+        );
+    }
     let translation_amount = if target == ReductionTarget::VmdBezier {
         Vec3A::new(
             right.vmd_interpolation.translation[0].evaluate(amount),
@@ -1079,7 +1364,12 @@ fn sample_bone_track(
     )
 }
 
-fn sample_morph_track(track: &ReducedMorphTrack, sample_frames: &[f32], frame: f32) -> f32 {
+fn sample_morph_track(
+    track: &ReducedMorphTrack,
+    sample_frames: &[f32],
+    frame: f32,
+    target: ReductionTarget,
+) -> f32 {
     let upper = track
         .keys
         .partition_point(|key| sample_frames[key.sample_index] <= frame);
@@ -1094,6 +1384,17 @@ fn sample_morph_track(track: &ReducedMorphTrack, sample_frames: &[f32], frame: f
     let amount = ((frame - sample_frames[left.sample_index])
         / (sample_frames[right.sample_index] - sample_frames[left.sample_index]))
         .clamp(0.0, 1.0);
+    if target == ReductionTarget::DccCubic {
+        let duration = sample_frames[right.sample_index] - sample_frames[left.sample_index];
+        return sample_hermite(
+            left.weight,
+            right.weight,
+            right.dcc_segment.out_tangent,
+            right.dcc_segment.in_tangent,
+            duration,
+            amount,
+        );
+    }
     left.weight + (right.weight - left.weight) * amount
 }
 

--- a/crates/mmd-anim-runtime/src/reduce/mod.rs
+++ b/crates/mmd-anim-runtime/src/reduce/mod.rs
@@ -11,6 +11,8 @@ use thiserror::Error;
 use crate::{BoneIndex, InterpolationScalar, ModelArena};
 
 const AFFINE_EPSILON: f32 = 1.0e-4;
+// Below this point the one-time prefit costs more than the global passes it removes.
+const DCC_LOCAL_PREFIT_MIN_FRAMES: usize = 90;
 
 #[derive(Debug, Clone, Copy)]
 pub struct DensePoseSequenceView<'a> {
@@ -364,6 +366,12 @@ pub struct PoseReductionReport {
 pub struct ReductionWorkStats {
     pub global_validation_passes: usize,
     pub candidate_rebuilds: usize,
+    pub local_prefit_bone_segment_fits: usize,
+    pub local_prefit_morph_segment_fits: usize,
+    pub local_prefit_bone_key_additions: usize,
+    pub local_prefit_morph_key_additions: usize,
+    pub local_prefit_bone_samples: usize,
+    pub local_prefit_morph_samples: usize,
     pub dcc_bone_segment_fits: usize,
     pub dcc_morph_segment_fits: usize,
     pub bone_samples: usize,
@@ -377,6 +385,7 @@ pub struct ReductionWorkStats {
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct ReductionTimings {
+    pub local_prefit: Duration,
     pub candidate_build: Duration,
     pub error_measure: Duration,
     pub dcc_fit: Duration,
@@ -613,7 +622,30 @@ pub fn reduce_dense_pose_sequence_with_worker_count(
     let mut bone_key_indices = vec![endpoint_indices(input.frame_count); input.bone_count];
     let mut morph_key_indices = vec![endpoint_indices(input.frame_count); input.morph_count];
 
-    if target == ReductionTarget::LinearSlerp {
+    if target == ReductionTarget::DccCubic && input.frame_count >= DCC_LOCAL_PREFIT_MIN_FRAMES {
+        let dcc_prefit_started = Instant::now();
+        for (bone, keys) in bone_key_indices.iter_mut().enumerate() {
+            let prefit = split_dcc_bone_track(
+                keys,
+                input,
+                bone,
+                &local_translations,
+                &local_rotations,
+                &local_euler_xyz,
+                tolerances,
+            );
+            work_stats.local_prefit_bone_segment_fits += prefit.segment_fits;
+            work_stats.local_prefit_bone_key_additions += prefit.key_additions;
+            work_stats.local_prefit_bone_samples += prefit.samples;
+        }
+        for (morph, keys) in morph_key_indices.iter_mut().enumerate() {
+            let prefit = split_dcc_morph_track(keys, input, morph, tolerances.morph_weight);
+            work_stats.local_prefit_morph_segment_fits += prefit.segment_fits;
+            work_stats.local_prefit_morph_key_additions += prefit.key_additions;
+            work_stats.local_prefit_morph_samples += prefit.samples;
+        }
+        timings.local_prefit += dcc_prefit_started.elapsed();
+    } else if target == ReductionTarget::LinearSlerp {
         for (bone, keys) in bone_key_indices.iter_mut().enumerate() {
             split_bone_track(
                 keys,
@@ -888,6 +920,133 @@ fn split_bone_track(
             stack.push((start, frame));
         }
     }
+}
+
+#[derive(Default)]
+struct LocalPrefitStats {
+    segment_fits: usize,
+    key_additions: usize,
+    samples: usize,
+}
+
+fn split_dcc_bone_track(
+    keys: &mut Vec<usize>,
+    input: DensePoseSequenceView<'_>,
+    bone: usize,
+    translations: &[Vec3A],
+    rotations: &[Quat],
+    euler_xyz: &[Vec3A],
+    tolerances: ReductionTolerances,
+) -> LocalPrefitStats {
+    if input.frame_count <= 2 {
+        return LocalPrefitStats::default();
+    }
+    let bone_count = input.bone_count;
+    let mut stats = LocalPrefitStats::default();
+    let mut stack = vec![(0usize, input.frame_count - 1)];
+    while let Some((start, end)) = stack.pop() {
+        if end <= start + 1 {
+            continue;
+        }
+        let segment = fit_dcc_bone_segment(input, bone, start, end, translations, euler_xyz);
+        stats.segment_fits += 1;
+        let start_index = start * bone_count + bone;
+        let end_index = end * bone_count + bone;
+        let duration = input.sample_frame(end) - input.sample_frame(start);
+        let mut worst: Option<(f32, usize)> = None;
+        for frame in start + 1..end {
+            stats.samples += 1;
+            let amount = segment_amount(start, end, frame, |sample| input.sample_frame(sample));
+            let translation = sample_dcc_vec3(
+                translations[start_index],
+                translations[end_index],
+                segment.translation_out_tangent,
+                segment.translation_in_tangent,
+                duration,
+                amount,
+            );
+            let euler = sample_dcc_vec3(
+                segment.rotation_start_euler_xyz,
+                segment.rotation_end_euler_xyz,
+                segment.rotation_out_tangent,
+                segment.rotation_in_tangent,
+                duration,
+                amount,
+            );
+            let rotation =
+                normalize_quat(Quat::from_euler(EulerRot::XYZ, euler.x, euler.y, euler.z));
+            let index = frame * bone_count + bone;
+            let normalized = normalized_error(
+                translations[index].distance(translation),
+                tolerances.local_position,
+            )
+            .max(normalized_error(
+                quat_angle(rotations[index], rotation),
+                tolerances.local_rotation_radians,
+            ));
+            if is_worse(worst, normalized, frame) {
+                worst = Some((normalized, frame));
+            }
+        }
+        if let Some((_, frame)) = worst.filter(|value| value.0 > 1.0) {
+            stats.key_additions += usize::from(insert_key(keys, frame));
+            stack.push((frame, end));
+            stack.push((start, frame));
+        }
+    }
+    stats
+}
+
+fn split_dcc_morph_track(
+    keys: &mut Vec<usize>,
+    input: DensePoseSequenceView<'_>,
+    morph: usize,
+    tolerance: f32,
+) -> LocalPrefitStats {
+    if input.frame_count <= 2 {
+        return LocalPrefitStats::default();
+    }
+    let mut stats = LocalPrefitStats::default();
+    let mut stack = vec![(0usize, input.frame_count - 1)];
+    while let Some((start, end)) = stack.pop() {
+        if end <= start + 1 {
+            continue;
+        }
+        let segment = fit_dcc_scalar_segment(
+            start,
+            end,
+            |sample| input.morph_weight(sample, morph),
+            |sample| input.sample_frame(sample),
+        );
+        stats.segment_fits += 1;
+        let duration = input.sample_frame(end) - input.sample_frame(start);
+        let mut worst: Option<(f32, usize)> = None;
+        for frame in start + 1..end {
+            stats.samples += 1;
+            let amount = segment_amount(start, end, frame, |sample| input.sample_frame(sample));
+            let expected = sample_hermite(
+                input.morph_weight(start, morph),
+                input.morph_weight(end, morph),
+                segment.out_tangent,
+                segment.in_tangent,
+                duration,
+                amount,
+            );
+            let normalized = normalized_error(
+                (input.morph_weight(frame, morph) - expected).abs(),
+                tolerance,
+            );
+            if is_worse(worst, normalized, frame) {
+                worst = Some((normalized, frame));
+            }
+        }
+        if let Some((_, frame)) = worst.filter(|value| value.0 > 1.0) {
+            stats.key_additions += usize::from(insert_key(keys, frame));
+            stack.push((frame, end));
+            stack.push((start, frame));
+        }
+    }
+    stats
 }
 
 fn split_morph_track(
@@ -1634,6 +1793,21 @@ fn sample_hermite(
 ) -> f32 {
     let (h00, h10, h01, h11) = hermite_basis(t);
     h00 * start + h10 * duration * out_tangent + h01 * end + h11 * duration * in_tangent
+}
+
+fn sample_dcc_vec3(
+    start: Vec3A,
+    end: Vec3A,
+    out_tangent: Vec3A,
+    in_tangent: Vec3A,
+    duration: f32,
+    t: f32,
+) -> Vec3A {
+    Vec3A::new(
+        sample_hermite(start.x, end.x, out_tangent.x, in_tangent.x, duration, t),
+        sample_hermite(start.y, end.y, out_tangent.y, in_tangent.y, duration, t),
+        sample_hermite(start.z, end.z, out_tangent.z, in_tangent.z, duration, t),
+    )
 }
 
 fn sample_bone_track(

--- a/crates/mmd-anim-runtime/src/reduce/mod.rs
+++ b/crates/mmd-anim-runtime/src/reduce/mod.rs
@@ -1,4 +1,5 @@
 use std::cmp::Ordering;
+use std::time::{Duration, Instant};
 
 use glam::{EulerRot, Mat3, Mat4, Quat, Vec3, Vec3A};
 use thiserror::Error;
@@ -355,7 +356,29 @@ pub struct PoseReductionReport {
     pub max_morph_weight_error: f32,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ReductionWorkStats {
+    pub global_validation_passes: usize,
+    pub candidate_rebuilds: usize,
+    pub dcc_bone_segment_fits: usize,
+    pub dcc_morph_segment_fits: usize,
+    pub bone_samples: usize,
+    pub morph_samples: usize,
+    pub world_rebuilds: usize,
+    pub world_rotation_decompositions: usize,
+    pub normal_key_additions: usize,
+    pub ancestor_key_additions: usize,
+    pub added_keys_per_pass: Vec<usize>,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ReductionTimings {
+    pub candidate_build: Duration,
+    pub error_measure: Duration,
+    pub dcc_fit: Duration,
+}
+
+#[derive(Debug, Clone)]
 pub struct ReducedPoseSequence {
     snapshot: SkeletonSnapshot,
     target: ReductionTarget,
@@ -366,6 +389,23 @@ pub struct ReducedPoseSequence {
     bone_tracks: Box<[ReducedBoneTrack]>,
     morph_tracks: Box<[ReducedMorphTrack]>,
     report: PoseReductionReport,
+    work_stats: ReductionWorkStats,
+    timings: ReductionTimings,
+}
+
+impl PartialEq for ReducedPoseSequence {
+    fn eq(&self, other: &Self) -> bool {
+        self.snapshot == other.snapshot
+            && self.target == other.target
+            && self.start_frame == other.start_frame
+            && self.frame_step == other.frame_step
+            && self.frame_count == other.frame_count
+            && self.sample_frames == other.sample_frames
+            && self.bone_tracks == other.bone_tracks
+            && self.morph_tracks == other.morph_tracks
+            && self.report == other.report
+            && self.work_stats == other.work_stats
+    }
 }
 
 impl ReducedPoseSequence {
@@ -395,6 +435,12 @@ impl ReducedPoseSequence {
     }
     pub fn report(&self) -> PoseReductionReport {
         self.report
+    }
+    pub fn work_stats(&self) -> &ReductionWorkStats {
+        &self.work_stats
+    }
+    pub fn timings(&self) -> ReductionTimings {
+        self.timings
     }
 
     pub fn sample(&self, frame: f32) -> Result<ReducedPoseSample, PoseReductionError> {
@@ -526,6 +572,11 @@ pub fn reduce_dense_pose_sequence(
 
     let (local_translations, local_rotations) = decompose_dense_pose(input, &snapshot)?;
     let (world_positions, world_rotations) = cache_dense_world_components(input)?;
+    let mut work_stats = ReductionWorkStats {
+        world_rotation_decompositions: input.frame_count * input.bone_count,
+        ..Default::default()
+    };
+    let mut timings = ReductionTimings::default();
     let local_euler_xyz = unwrap_euler_xyz(&local_rotations, input.frame_count, input.bone_count);
     for frame in 0..input.frame_count {
         for morph in 0..input.morph_count {
@@ -557,6 +608,9 @@ pub fn reduce_dense_pose_sequence(
     }
 
     loop {
+        work_stats.global_validation_passes += 1;
+        work_stats.candidate_rebuilds += 1;
+        let candidate_started = Instant::now();
         let candidate = build_sequence(
             &snapshot,
             target,
@@ -568,22 +622,33 @@ pub fn reduce_dense_pose_sequence(
             },
             &bone_key_indices,
             &morph_key_indices,
+            ReductionInstrumentation {
+                work_stats: &mut work_stats,
+                timings: &mut timings,
+            },
         );
+        timings.candidate_build += candidate_started.elapsed();
+        let error_measure_started = Instant::now();
         let (report, worst_by_track) = measure_error(
             &candidate,
             input,
-            &local_translations,
-            &local_rotations,
-            &world_positions,
-            &world_rotations,
+            DenseValidationPose {
+                translations: &local_translations,
+                rotations: &local_rotations,
+                world_positions: &world_positions,
+                world_rotations: &world_rotations,
+            },
             tolerances,
+            &mut work_stats,
         )?;
+        timings.error_measure += error_measure_started.elapsed();
         let failing = worst_by_track
             .into_iter()
             .flatten()
             .filter(|worst| worst.normalized_error > 1.0)
             .collect::<Vec<_>>();
         if failing.is_empty() {
+            work_stats.added_keys_per_pass.push(0);
             let mut result = candidate;
             result.report = PoseReductionReport {
                 source_bone_key_count: input.frame_count * input.bone_count,
@@ -600,25 +665,43 @@ pub fn reduce_dense_pose_sequence(
                     .sum(),
                 ..report
             };
+            result.work_stats = work_stats;
+            result.timings = timings;
             return Ok(result);
         }
         let mut inserted = false;
+        let mut added_this_pass = 0;
         let first_failure_frame = failing[0].frame;
         for worst in failing {
             match worst.track {
                 ErrorTrack::Bone(bone) => {
                     let mut cursor = Some(bone);
+                    let mut is_origin = true;
                     while let Some(index) = cursor {
-                        inserted |= insert_key(&mut bone_key_indices[index], worst.frame);
+                        if insert_key(&mut bone_key_indices[index], worst.frame) {
+                            inserted = true;
+                            added_this_pass += 1;
+                            if is_origin {
+                                work_stats.normal_key_additions += 1;
+                            } else {
+                                work_stats.ancestor_key_additions += 1;
+                            }
+                        }
                         let parent = snapshot.parent_indices[index];
                         cursor = (parent >= 0).then_some(parent as usize);
+                        is_origin = false;
                     }
                 }
                 ErrorTrack::Morph(morph) => {
-                    inserted |= insert_key(&mut morph_key_indices[morph], worst.frame);
+                    if insert_key(&mut morph_key_indices[morph], worst.frame) {
+                        inserted = true;
+                        added_this_pass += 1;
+                        work_stats.normal_key_additions += 1;
+                    }
                 }
             }
         }
+        work_stats.added_keys_per_pass.push(added_this_pass);
         if !inserted {
             return Err(PoseReductionError::ToleranceUnattainable {
                 frame: first_failure_frame,
@@ -831,6 +914,11 @@ struct DenseLocalPose<'a> {
     euler_xyz: &'a [Vec3A],
 }
 
+struct ReductionInstrumentation<'a> {
+    work_stats: &'a mut ReductionWorkStats,
+    timings: &'a mut ReductionTimings,
+}
+
 fn build_sequence(
     snapshot: &SkeletonSnapshot,
     target: ReductionTarget,
@@ -838,7 +926,23 @@ fn build_sequence(
     local_pose: DenseLocalPose<'_>,
     bone_key_indices: &[Vec<usize>],
     morph_key_indices: &[Vec<usize>],
+    instrumentation: ReductionInstrumentation<'_>,
 ) -> ReducedPoseSequence {
+    let ReductionInstrumentation {
+        work_stats,
+        timings,
+    } = instrumentation;
+    if target == ReductionTarget::DccCubic {
+        work_stats.dcc_bone_segment_fits += bone_key_indices
+            .iter()
+            .map(|indices| indices.len().saturating_sub(1))
+            .sum::<usize>();
+        work_stats.dcc_morph_segment_fits += morph_key_indices
+            .iter()
+            .map(|indices| indices.len().saturating_sub(1))
+            .sum::<usize>();
+    }
+    let dcc_bone_started = (target == ReductionTarget::DccCubic).then(Instant::now);
     let bone_tracks = bone_key_indices
         .iter()
         .enumerate()
@@ -886,6 +990,10 @@ fn build_sequence(
         })
         .collect::<Vec<_>>()
         .into_boxed_slice();
+    if let Some(started) = dcc_bone_started {
+        timings.dcc_fit += started.elapsed();
+    }
+    let dcc_morph_started = (target == ReductionTarget::DccCubic).then(Instant::now);
     let morph_tracks = morph_key_indices
         .iter()
         .enumerate()
@@ -912,6 +1020,9 @@ fn build_sequence(
         })
         .collect::<Vec<_>>()
         .into_boxed_slice();
+    if let Some(started) = dcc_morph_started {
+        timings.dcc_fit += started.elapsed();
+    }
     ReducedPoseSequence {
         snapshot: snapshot.clone(),
         target,
@@ -925,6 +1036,8 @@ fn build_sequence(
         bone_tracks,
         morph_tracks,
         report: PoseReductionReport::default(),
+        work_stats: ReductionWorkStats::default(),
+        timings: ReductionTimings::default(),
     }
 }
 
@@ -944,31 +1057,27 @@ struct WorstError {
 fn measure_error(
     sequence: &ReducedPoseSequence,
     input: DensePoseSequenceView<'_>,
-    translations: &[Vec3A],
-    rotations: &[Quat],
-    world_positions: &[Vec3A],
-    world_rotations: &[Quat],
+    dense: DenseValidationPose<'_>,
     tolerances: ReductionTolerances,
+    work_stats: &mut ReductionWorkStats,
 ) -> Result<(PoseReductionReport, Vec<Option<WorstError>>), PoseReductionError> {
-    measure_error_with_tolerances(
-        sequence,
-        input,
-        translations,
-        rotations,
-        world_positions,
-        world_rotations,
-        tolerances,
-    )
+    measure_error_with_tolerances(sequence, input, dense, tolerances, work_stats)
+}
+
+#[derive(Clone, Copy)]
+struct DenseValidationPose<'a> {
+    translations: &'a [Vec3A],
+    rotations: &'a [Quat],
+    world_positions: &'a [Vec3A],
+    world_rotations: &'a [Quat],
 }
 
 fn measure_error_with_tolerances(
     sequence: &ReducedPoseSequence,
     input: DensePoseSequenceView<'_>,
-    translations: &[Vec3A],
-    rotations: &[Quat],
-    world_positions: &[Vec3A],
-    world_rotations: &[Quat],
+    dense: DenseValidationPose<'_>,
     tolerances: ReductionTolerances,
+    work_stats: &mut ReductionWorkStats,
 ) -> Result<(PoseReductionReport, Vec<Option<WorstError>>), PoseReductionError> {
     let mut report = PoseReductionReport::default();
     let mut worst = vec![None; input.bone_count + input.morph_count];
@@ -976,15 +1085,20 @@ fn measure_error_with_tolerances(
     scratch.prepare(input.bone_count, input.morph_count);
     for frame in 0..input.frame_count {
         sequence.sample_into(input.sample_frame(frame), &mut scratch)?;
+        work_stats.bone_samples += input.bone_count;
+        work_stats.morph_samples += input.morph_count;
+        work_stats.world_rebuilds += 1;
+        work_stats.world_rotation_decompositions += input.bone_count;
         for (bone, bone_worst) in worst[..input.bone_count].iter_mut().enumerate() {
             let index = frame * input.bone_count + bone;
-            let local_position = translations[index].distance(scratch.local_translations[bone]);
-            let local_rotation = quat_angle(rotations[index], scratch.local_rotations[bone]);
-            let world_position = world_positions[index]
+            let local_position =
+                dense.translations[index].distance(scratch.local_translations[bone]);
+            let local_rotation = quat_angle(dense.rotations[index], scratch.local_rotations[bone]);
+            let world_position = dense.world_positions[index]
                 .distance(Vec3A::from(scratch.world_matrices[bone].w_axis.truncate()));
             let sampled_world_rotation =
                 decompose_rigid(scratch.world_matrices[bone], frame, bone)?.1;
-            let world_rotation = quat_angle(world_rotations[index], sampled_world_rotation);
+            let world_rotation = quat_angle(dense.world_rotations[index], sampled_world_rotation);
             report.max_local_position_error = report.max_local_position_error.max(local_position);
             report.max_local_rotation_error_radians =
                 report.max_local_rotation_error_radians.max(local_rotation);

--- a/crates/mmd-anim-runtime/src/reduce/mod.rs
+++ b/crates/mmd-anim-runtime/src/reduce/mod.rs
@@ -3,6 +3,7 @@ use std::time::{Duration, Instant};
 
 use glam::{EulerRot, Mat3, Mat4, Quat, Vec3, Vec3A};
 #[cfg(not(target_family = "wasm"))]
+#[cfg(not(target_family = "wasm"))]
 use rayon::prelude::*;
 #[cfg(not(target_family = "wasm"))]
 use rayon::{ThreadPool, ThreadPoolBuilder};
@@ -366,6 +367,8 @@ pub struct PoseReductionReport {
 pub struct ReductionWorkStats {
     pub global_validation_passes: usize,
     pub candidate_rebuilds: usize,
+    pub candidate_bone_track_rebuilds: usize,
+    pub candidate_morph_track_rebuilds: usize,
     pub local_prefit_bone_segment_fits: usize,
     pub local_prefit_morph_segment_fits: usize,
     pub local_prefit_bone_key_additions: usize,
@@ -377,10 +380,69 @@ pub struct ReductionWorkStats {
     pub bone_samples: usize,
     pub morph_samples: usize,
     pub world_rebuilds: usize,
+    /// Number of cached candidate world transforms recomputed during validation.
+    pub world_bone_recomputes: usize,
     pub world_rotation_decompositions: usize,
     pub normal_key_additions: usize,
     pub ancestor_key_additions: usize,
     pub added_keys_per_pass: Vec<usize>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ValidationMode {
+    Incremental,
+    FullScan,
+}
+
+#[derive(Debug, Clone)]
+struct DirtyRanges {
+    bone_local: Vec<Vec<std::ops::RangeInclusive<usize>>>,
+    morph: Vec<Vec<std::ops::RangeInclusive<usize>>>,
+}
+
+impl DirtyRanges {
+    fn full(frame_count: usize, bone_count: usize, morph_count: usize) -> Self {
+        let range = || vec![0..=frame_count.saturating_sub(1)];
+        Self {
+            bone_local: (0..bone_count).map(|_| range()).collect(),
+            morph: (0..morph_count).map(|_| range()).collect(),
+        }
+    }
+
+    fn empty(bone_count: usize, morph_count: usize) -> Self {
+        Self {
+            bone_local: vec![Vec::new(); bone_count],
+            morph: vec![Vec::new(); morph_count],
+        }
+    }
+
+    fn mark_bone(&mut self, bone: usize, range: std::ops::RangeInclusive<usize>) {
+        insert_dirty_range(&mut self.bone_local[bone], range);
+    }
+
+    fn mark_morph(&mut self, morph: usize, range: std::ops::RangeInclusive<usize>) {
+        insert_dirty_range(&mut self.morph[morph], range);
+    }
+}
+
+fn insert_dirty_range(
+    target: &mut Vec<std::ops::RangeInclusive<usize>>,
+    range: std::ops::RangeInclusive<usize>,
+) {
+    target.push(range);
+    target.sort_by_key(|value| *value.start());
+    let mut merged: Vec<std::ops::RangeInclusive<usize>> = Vec::with_capacity(target.len());
+    for current in target.drain(..) {
+        if let Some(previous) = merged.last_mut()
+            && *current.start() <= previous.end().saturating_add(1)
+        {
+            let start = *previous.start();
+            *previous = start..=(*previous.end()).max(*current.end());
+        } else {
+            merged.push(current);
+        }
+    }
+    *target = merged;
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -596,6 +658,24 @@ pub fn reduce_dense_pose_sequence_with_worker_count(
     target: ReductionTarget,
     worker_count: usize,
 ) -> Result<ReducedPoseSequence, PoseReductionError> {
+    reduce_dense_pose_sequence_internal(
+        input,
+        snapshot,
+        tolerances,
+        target,
+        worker_count,
+        ValidationMode::Incremental,
+    )
+}
+
+fn reduce_dense_pose_sequence_internal(
+    input: DensePoseSequenceView<'_>,
+    snapshot: SkeletonSnapshot,
+    tolerances: ReductionTolerances,
+    target: ReductionTarget,
+    worker_count: usize,
+    validation_mode: ValidationMode,
+) -> Result<ReducedPoseSequence, PoseReductionError> {
     let tolerances = tolerances.validate()?;
     if input.bone_count != snapshot.bone_count() || input.morph_count != snapshot.morph_count() {
         return Err(PoseReductionError::SnapshotMismatch);
@@ -663,30 +743,54 @@ pub fn reduce_dense_pose_sequence_with_worker_count(
         }
     }
 
+    let mut candidate: Option<ReducedPoseSequence> = None;
+    let mut dirty = DirtyRanges::full(input.frame_count, input.bone_count, input.morph_count);
+    let mut validation_cache =
+        ValidationCache::new(input.frame_count, input.bone_count, input.morph_count);
     loop {
         work_stats.global_validation_passes += 1;
         work_stats.candidate_rebuilds += 1;
+        if candidate.is_some() && matches!(validation_mode, ValidationMode::FullScan) {
+            dirty = DirtyRanges::full(input.frame_count, input.bone_count, input.morph_count);
+        }
         let candidate_started = Instant::now();
-        let candidate = build_sequence(
-            &snapshot,
-            target,
-            input,
-            DenseLocalPose {
-                translations: &local_translations,
-                rotations: &local_rotations,
-                euler_xyz: &local_euler_xyz,
-            },
-            &bone_key_indices,
-            &morph_key_indices,
-            ReductionInstrumentation {
-                work_stats: &mut work_stats,
-                timings: &mut timings,
-            },
-        );
+        let local_pose = DenseLocalPose {
+            translations: &local_translations,
+            rotations: &local_rotations,
+            euler_xyz: &local_euler_xyz,
+        };
+        if let Some(sequence) = candidate.as_mut() {
+            rebuild_dirty_tracks(
+                sequence,
+                target,
+                input,
+                local_pose,
+                &bone_key_indices,
+                &morph_key_indices,
+                &dirty,
+                ReductionInstrumentation {
+                    work_stats: &mut work_stats,
+                    timings: &mut timings,
+                },
+            );
+        } else {
+            candidate = Some(build_sequence(
+                &snapshot,
+                target,
+                input,
+                local_pose,
+                &bone_key_indices,
+                &morph_key_indices,
+                ReductionInstrumentation {
+                    work_stats: &mut work_stats,
+                    timings: &mut timings,
+                },
+            ));
+        }
         timings.candidate_build += candidate_started.elapsed();
         let error_measure_started = Instant::now();
-        let (report, worst_by_track) = measure_error(
-            &candidate,
+        let (report, worst_by_track) = measure_error_cached(
+            candidate.as_ref().expect("candidate initialized"),
             input,
             DenseValidationPose {
                 translations: &local_translations,
@@ -696,6 +800,8 @@ pub fn reduce_dense_pose_sequence_with_worker_count(
             },
             tolerances,
             &mut work_stats,
+            &dirty,
+            &mut validation_cache,
             worker_pool.as_ref(),
             worker_count,
         )?;
@@ -708,7 +814,7 @@ pub fn reduce_dense_pose_sequence_with_worker_count(
         failing.sort_by(compare_worst_errors);
         if failing.is_empty() {
             work_stats.added_keys_per_pass.push(0);
-            let mut result = candidate;
+            let mut result = candidate.expect("candidate initialized");
             result.report = PoseReductionReport {
                 source_bone_key_count: input.frame_count * input.bone_count,
                 reduced_bone_key_count: result
@@ -730,6 +836,7 @@ pub fn reduce_dense_pose_sequence_with_worker_count(
         }
         let mut inserted = false;
         let mut added_this_pass = 0;
+        let mut next_dirty = DirtyRanges::empty(input.bone_count, input.morph_count);
         let first_failure_frame = failing[0].frame;
         for worst in failing {
             match worst.track {
@@ -737,9 +844,13 @@ pub fn reduce_dense_pose_sequence_with_worker_count(
                     let mut cursor = Some(bone);
                     let mut is_origin = true;
                     while let Some(index) = cursor {
-                        if insert_key(&mut bone_key_indices[index], worst.frame) {
+                        if let Some(range) = insert_key_with_affected_range(
+                            &mut bone_key_indices[index],
+                            worst.frame,
+                        ) {
                             inserted = true;
                             added_this_pass += 1;
+                            next_dirty.mark_bone(index, range);
                             if is_origin {
                                 work_stats.normal_key_additions += 1;
                             } else {
@@ -752,9 +863,12 @@ pub fn reduce_dense_pose_sequence_with_worker_count(
                     }
                 }
                 ErrorTrack::Morph(morph) => {
-                    if insert_key(&mut morph_key_indices[morph], worst.frame) {
+                    if let Some(range) =
+                        insert_key_with_affected_range(&mut morph_key_indices[morph], worst.frame)
+                    {
                         inserted = true;
                         added_this_pass += 1;
+                        next_dirty.mark_morph(morph, range);
                         work_stats.normal_key_additions += 1;
                     }
                 }
@@ -766,6 +880,7 @@ pub fn reduce_dense_pose_sequence_with_worker_count(
                 frame: first_failure_frame,
             });
         }
+        dirty = next_dirty;
     }
 }
 
@@ -1093,6 +1208,17 @@ fn insert_key(keys: &mut Vec<usize>, frame: usize) -> bool {
     }
 }
 
+fn insert_key_with_affected_range(
+    keys: &mut Vec<usize>,
+    frame: usize,
+) -> Option<std::ops::RangeInclusive<usize>> {
+    let position = keys.binary_search(&frame).err()?;
+    let start = keys[position.saturating_sub(1)];
+    let end = keys[position.min(keys.len() - 1)];
+    keys.insert(position, frame);
+    Some(start..=end)
+}
+
 #[derive(Clone, Copy)]
 struct DenseLocalPose<'a> {
     translations: &'a [Vec3A],
@@ -1128,52 +1254,13 @@ fn build_sequence(
             .map(|indices| indices.len().saturating_sub(1))
             .sum::<usize>();
     }
+    work_stats.candidate_bone_track_rebuilds += bone_key_indices.len();
+    work_stats.candidate_morph_track_rebuilds += morph_key_indices.len();
     let dcc_bone_started = (target == ReductionTarget::DccCubic).then(Instant::now);
     let bone_tracks = bone_key_indices
         .iter()
         .enumerate()
-        .map(|(bone, indices)| ReducedBoneTrack {
-            keys: indices
-                .iter()
-                .enumerate()
-                .map(|(key_position, &frame)| {
-                    let index = frame * input.bone_count + bone;
-                    let vmd_interpolation =
-                        if target == ReductionTarget::VmdBezier && key_position > 0 {
-                            fit_vmd_bone_interpolation(
-                                input,
-                                bone,
-                                indices[key_position - 1],
-                                frame,
-                                local_pose.translations,
-                                local_pose.rotations,
-                            )
-                        } else {
-                            VmdBoneInterpolation::LINEAR
-                        };
-                    let dcc_segment = if target == ReductionTarget::DccCubic && key_position > 0 {
-                        fit_dcc_bone_segment(
-                            input,
-                            bone,
-                            indices[key_position - 1],
-                            frame,
-                            local_pose.translations,
-                            local_pose.euler_xyz,
-                        )
-                    } else {
-                        DccCubicSegment::default()
-                    };
-                    ReducedBoneKey {
-                        sample_index: frame,
-                        translation: local_pose.translations[index],
-                        rotation: local_pose.rotations[index],
-                        vmd_interpolation,
-                        dcc_segment,
-                    }
-                })
-                .collect::<Vec<_>>()
-                .into_boxed_slice(),
-        })
+        .map(|(bone, indices)| build_bone_track(target, input, local_pose, bone, indices))
         .collect::<Vec<_>>()
         .into_boxed_slice();
     if let Some(started) = dcc_bone_started {
@@ -1183,27 +1270,7 @@ fn build_sequence(
     let morph_tracks = morph_key_indices
         .iter()
         .enumerate()
-        .map(|(morph, indices)| ReducedMorphTrack {
-            keys: indices
-                .iter()
-                .enumerate()
-                .map(|(key_position, &frame)| ReducedMorphKey {
-                    sample_index: frame,
-                    weight: input.morph_weight(frame, morph),
-                    dcc_segment: if target == ReductionTarget::DccCubic && key_position > 0 {
-                        fit_dcc_scalar_segment(
-                            indices[key_position - 1],
-                            frame,
-                            |sample| input.morph_weight(sample, morph),
-                            |sample| input.sample_frame(sample),
-                        )
-                    } else {
-                        DccScalarSegment::default()
-                    },
-                })
-                .collect::<Vec<_>>()
-                .into_boxed_slice(),
-        })
+        .map(|(morph, indices)| build_morph_track(target, input, morph, indices))
         .collect::<Vec<_>>()
         .into_boxed_slice();
     if let Some(started) = dcc_morph_started {
@@ -1227,6 +1294,126 @@ fn build_sequence(
     }
 }
 
+fn build_bone_track(
+    target: ReductionTarget,
+    input: DensePoseSequenceView<'_>,
+    local_pose: DenseLocalPose<'_>,
+    bone: usize,
+    indices: &[usize],
+) -> ReducedBoneTrack {
+    ReducedBoneTrack {
+        keys: indices
+            .iter()
+            .enumerate()
+            .map(|(key_position, &frame)| {
+                let index = frame * input.bone_count + bone;
+                ReducedBoneKey {
+                    sample_index: frame,
+                    translation: local_pose.translations[index],
+                    rotation: local_pose.rotations[index],
+                    vmd_interpolation: if target == ReductionTarget::VmdBezier && key_position > 0 {
+                        fit_vmd_bone_interpolation(
+                            input,
+                            bone,
+                            indices[key_position - 1],
+                            frame,
+                            local_pose.translations,
+                            local_pose.rotations,
+                        )
+                    } else {
+                        VmdBoneInterpolation::LINEAR
+                    },
+                    dcc_segment: if target == ReductionTarget::DccCubic && key_position > 0 {
+                        fit_dcc_bone_segment(
+                            input,
+                            bone,
+                            indices[key_position - 1],
+                            frame,
+                            local_pose.translations,
+                            local_pose.euler_xyz,
+                        )
+                    } else {
+                        DccCubicSegment::default()
+                    },
+                }
+            })
+            .collect::<Vec<_>>()
+            .into_boxed_slice(),
+    }
+}
+
+fn build_morph_track(
+    target: ReductionTarget,
+    input: DensePoseSequenceView<'_>,
+    morph: usize,
+    indices: &[usize],
+) -> ReducedMorphTrack {
+    ReducedMorphTrack {
+        keys: indices
+            .iter()
+            .enumerate()
+            .map(|(key_position, &frame)| ReducedMorphKey {
+                sample_index: frame,
+                weight: input.morph_weight(frame, morph),
+                dcc_segment: if target == ReductionTarget::DccCubic && key_position > 0 {
+                    fit_dcc_scalar_segment(
+                        indices[key_position - 1],
+                        frame,
+                        |sample| input.morph_weight(sample, morph),
+                        |sample| input.sample_frame(sample),
+                    )
+                } else {
+                    DccScalarSegment::default()
+                },
+            })
+            .collect::<Vec<_>>()
+            .into_boxed_slice(),
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn rebuild_dirty_tracks(
+    sequence: &mut ReducedPoseSequence,
+    target: ReductionTarget,
+    input: DensePoseSequenceView<'_>,
+    local_pose: DenseLocalPose<'_>,
+    bone_key_indices: &[Vec<usize>],
+    morph_key_indices: &[Vec<usize>],
+    dirty: &DirtyRanges,
+    instrumentation: ReductionInstrumentation<'_>,
+) {
+    let ReductionInstrumentation {
+        work_stats,
+        timings,
+    } = instrumentation;
+    let dcc_started = (target == ReductionTarget::DccCubic).then(Instant::now);
+    for (bone, range) in dirty.bone_local.iter().enumerate() {
+        if range.is_empty() {
+            continue;
+        }
+        let indices = &bone_key_indices[bone];
+        work_stats.candidate_bone_track_rebuilds += 1;
+        if target == ReductionTarget::DccCubic {
+            work_stats.dcc_bone_segment_fits += indices.len().saturating_sub(1);
+        }
+        sequence.bone_tracks[bone] = build_bone_track(target, input, local_pose, bone, indices);
+    }
+    for (morph, range) in dirty.morph.iter().enumerate() {
+        if range.is_empty() {
+            continue;
+        }
+        let indices = &morph_key_indices[morph];
+        work_stats.candidate_morph_track_rebuilds += 1;
+        if target == ReductionTarget::DccCubic {
+            work_stats.dcc_morph_segment_fits += indices.len().saturating_sub(1);
+        }
+        sequence.morph_tracks[morph] = build_morph_track(target, input, morph, indices);
+    }
+    if let Some(started) = dcc_started {
+        timings.dcc_fit += started.elapsed();
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ErrorTrack {
     Bone(usize),
@@ -1240,26 +1427,6 @@ struct WorstError {
     track: ErrorTrack,
 }
 
-fn measure_error(
-    sequence: &ReducedPoseSequence,
-    input: DensePoseSequenceView<'_>,
-    dense: DenseValidationPose<'_>,
-    tolerances: ReductionTolerances,
-    work_stats: &mut ReductionWorkStats,
-    worker_pool: Option<&ReductionThreadPool>,
-    worker_count: usize,
-) -> Result<(PoseReductionReport, Vec<Option<WorstError>>), PoseReductionError> {
-    measure_error_with_tolerances(
-        sequence,
-        input,
-        dense,
-        tolerances,
-        work_stats,
-        worker_pool,
-        worker_count,
-    )
-}
-
 #[derive(Clone, Copy)]
 struct DenseValidationPose<'a> {
     translations: &'a [Vec3A],
@@ -1268,25 +1435,61 @@ struct DenseValidationPose<'a> {
     world_rotations: &'a [Quat],
 }
 
-struct FrameErrorResult {
-    report: PoseReductionReport,
-    worst: Vec<Option<WorstError>>,
+#[derive(Clone, Copy, Default)]
+struct BoneErrorCell {
+    local_position: f32,
+    local_rotation: f32,
+    world_position: f32,
+    world_rotation: f32,
 }
 
-fn measure_error_with_tolerances(
+struct ValidationCache {
+    local_translations: Vec<Vec3A>,
+    local_rotations: Vec<Quat>,
+    world_matrices: Vec<Mat4>,
+    world_rotations: Vec<Quat>,
+    morph_weights: Vec<f32>,
+    bone_errors: Vec<BoneErrorCell>,
+    morph_errors: Vec<f32>,
+}
+
+#[cfg(not(target_family = "wasm"))]
+struct ValidationCacheChunk {
+    start_frame: usize,
+    local_translations: Vec<Vec3A>,
+    local_rotations: Vec<Quat>,
+    world_matrices: Vec<Mat4>,
+    world_rotations: Vec<Quat>,
+    morph_weights: Vec<f32>,
+    bone_errors: Vec<BoneErrorCell>,
+    morph_errors: Vec<f32>,
+}
+
+impl ValidationCache {
+    fn new(frame_count: usize, bone_count: usize, morph_count: usize) -> Self {
+        Self {
+            local_translations: vec![Vec3A::ZERO; frame_count * bone_count],
+            local_rotations: vec![Quat::IDENTITY; frame_count * bone_count],
+            world_matrices: vec![Mat4::IDENTITY; frame_count * bone_count],
+            world_rotations: vec![Quat::IDENTITY; frame_count * bone_count],
+            morph_weights: vec![0.0; frame_count * morph_count],
+            bone_errors: vec![BoneErrorCell::default(); frame_count * bone_count],
+            morph_errors: vec![0.0; frame_count * morph_count],
+        }
+    }
+}
+
+#[cfg(not(target_family = "wasm"))]
+#[allow(clippy::too_many_arguments)]
+fn refresh_full_validation_cache_parallel(
     sequence: &ReducedPoseSequence,
     input: DensePoseSequenceView<'_>,
     dense: DenseValidationPose<'_>,
-    tolerances: ReductionTolerances,
+    cache: &mut ValidationCache,
     work_stats: &mut ReductionWorkStats,
-    worker_pool: Option<&ReductionThreadPool>,
+    worker_pool: &ReductionThreadPool,
     worker_count: usize,
-) -> Result<(PoseReductionReport, Vec<Option<WorstError>>), PoseReductionError> {
-    work_stats.bone_samples += input.frame_count * input.bone_count;
-    work_stats.morph_samples += input.frame_count * input.morph_count;
-    work_stats.world_rebuilds += input.frame_count;
-    work_stats.world_rotation_decompositions += input.frame_count * input.bone_count;
-
+) -> Result<(), PoseReductionError> {
     let chunk_size = input.frame_count.div_ceil(worker_count);
     let ranges = (0..worker_count)
         .map(|worker| {
@@ -1295,121 +1498,265 @@ fn measure_error_with_tolerances(
         })
         .filter(|range| !range.is_empty())
         .collect::<Vec<_>>();
-    #[cfg(not(target_family = "wasm"))]
-    let results = if let Some(pool) = worker_pool {
-        pool.install(|| {
-            ranges
-                .par_iter()
-                .map(|range| {
-                    measure_error_range(sequence, input, dense, tolerances, range.start, range.end)
-                })
-                .collect::<Result<Vec<_>, _>>()
-        })?
-    } else {
-        vec![measure_error_range(
-            sequence,
-            input,
-            dense,
-            tolerances,
-            0,
-            input.frame_count,
-        )?]
-    };
-    #[cfg(target_family = "wasm")]
-    let results = {
-        let _ = (worker_pool, ranges);
-        vec![measure_error_range(
-            sequence,
-            input,
-            dense,
-            tolerances,
-            0,
-            input.frame_count,
-        )?]
-    };
+    let chunks = worker_pool.install(|| {
+        ranges
+            .par_iter()
+            .map(|range| {
+                let frame_count = range.end - range.start;
+                let mut chunk = ValidationCacheChunk {
+                    start_frame: range.start,
+                    local_translations: Vec::with_capacity(frame_count * input.bone_count),
+                    local_rotations: Vec::with_capacity(frame_count * input.bone_count),
+                    world_matrices: Vec::with_capacity(frame_count * input.bone_count),
+                    world_rotations: Vec::with_capacity(frame_count * input.bone_count),
+                    morph_weights: Vec::with_capacity(frame_count * input.morph_count),
+                    bone_errors: Vec::with_capacity(frame_count * input.bone_count),
+                    morph_errors: Vec::with_capacity(frame_count * input.morph_count),
+                };
+                let mut scratch = ReducedPoseScratch::default();
+                scratch.prepare(input.bone_count, input.morph_count);
+                for frame in range.clone() {
+                    sequence.sample_into(input.sample_frame(frame), &mut scratch)?;
+                    chunk
+                        .local_translations
+                        .extend_from_slice(&scratch.local_translations);
+                    chunk
+                        .local_rotations
+                        .extend_from_slice(&scratch.local_rotations);
+                    chunk
+                        .world_matrices
+                        .extend_from_slice(&scratch.world_matrices);
+                    for bone in 0..input.bone_count {
+                        let index = frame * input.bone_count + bone;
+                        let world_rotation =
+                            decompose_rigid(scratch.world_matrices[bone], frame, bone)?.1;
+                        chunk.world_rotations.push(world_rotation);
+                        chunk.bone_errors.push(BoneErrorCell {
+                            local_position: dense.translations[index]
+                                .distance(scratch.local_translations[bone]),
+                            local_rotation: quat_angle(
+                                dense.rotations[index],
+                                scratch.local_rotations[bone],
+                            ),
+                            world_position: dense.world_positions[index].distance(Vec3A::from(
+                                scratch.world_matrices[bone].w_axis.truncate(),
+                            )),
+                            world_rotation: quat_angle(
+                                dense.world_rotations[index],
+                                world_rotation,
+                            ),
+                        });
+                    }
+                    chunk
+                        .morph_weights
+                        .extend_from_slice(&scratch.morph_weights);
+                    for morph in 0..input.morph_count {
+                        chunk.morph_errors.push(
+                            (input.morph_weight(frame, morph) - scratch.morph_weights[morph]).abs(),
+                        );
+                    }
+                }
+                Ok(chunk)
+            })
+            .collect::<Result<Vec<_>, PoseReductionError>>()
+    })?;
 
-    let mut report = PoseReductionReport::default();
-    let mut worst = vec![None; input.bone_count + input.morph_count];
-    for result in results {
-        merge_reduction_report(&mut report, result.report);
-        for (merged, candidate) in worst.iter_mut().zip(result.worst) {
-            if let Some(candidate) = candidate {
-                update_worst_candidate(merged, candidate);
-            }
-        }
+    for chunk in chunks {
+        let bone_start = chunk.start_frame * input.bone_count;
+        let bone_end = bone_start + chunk.local_translations.len();
+        cache.local_translations[bone_start..bone_end].copy_from_slice(&chunk.local_translations);
+        cache.local_rotations[bone_start..bone_end].copy_from_slice(&chunk.local_rotations);
+        cache.world_matrices[bone_start..bone_end].copy_from_slice(&chunk.world_matrices);
+        cache.world_rotations[bone_start..bone_end].copy_from_slice(&chunk.world_rotations);
+        cache.bone_errors[bone_start..bone_end].copy_from_slice(&chunk.bone_errors);
+        let morph_start = chunk.start_frame * input.morph_count;
+        let morph_end = morph_start + chunk.morph_weights.len();
+        cache.morph_weights[morph_start..morph_end].copy_from_slice(&chunk.morph_weights);
+        cache.morph_errors[morph_start..morph_end].copy_from_slice(&chunk.morph_errors);
     }
-    Ok((report, worst))
+    work_stats.bone_samples += input.frame_count * input.bone_count;
+    work_stats.morph_samples += input.frame_count * input.morph_count;
+    work_stats.world_rebuilds += input.frame_count;
+    work_stats.world_bone_recomputes += input.frame_count * input.bone_count;
+    work_stats.world_rotation_decompositions += input.frame_count * input.bone_count;
+    Ok(())
 }
 
-fn measure_error_range(
+#[allow(clippy::too_many_arguments)]
+fn measure_error_cached(
     sequence: &ReducedPoseSequence,
     input: DensePoseSequenceView<'_>,
     dense: DenseValidationPose<'_>,
     tolerances: ReductionTolerances,
-    start_frame: usize,
-    end_frame: usize,
-) -> Result<FrameErrorResult, PoseReductionError> {
-    let mut report = PoseReductionReport::default();
-    let mut worst = vec![None; input.bone_count + input.morph_count];
-    let mut scratch = ReducedPoseScratch::default();
-    scratch.prepare(input.bone_count, input.morph_count);
-    for frame in start_frame..end_frame {
-        sequence.sample_into(input.sample_frame(frame), &mut scratch)?;
-        for (bone, bone_worst) in worst[..input.bone_count].iter_mut().enumerate() {
-            let index = frame * input.bone_count + bone;
-            let local_position =
-                dense.translations[index].distance(scratch.local_translations[bone]);
-            let local_rotation = quat_angle(dense.rotations[index], scratch.local_rotations[bone]);
-            let world_position = dense.world_positions[index]
-                .distance(Vec3A::from(scratch.world_matrices[bone].w_axis.truncate()));
-            let sampled_world_rotation =
-                decompose_rigid(scratch.world_matrices[bone], frame, bone)?.1;
-            let world_rotation = quat_angle(dense.world_rotations[index], sampled_world_rotation);
-            report.max_local_position_error = report.max_local_position_error.max(local_position);
-            report.max_local_rotation_error_radians =
-                report.max_local_rotation_error_radians.max(local_rotation);
-            report.max_world_position_error = report.max_world_position_error.max(world_position);
-            report.max_world_rotation_error_radians =
-                report.max_world_rotation_error_radians.max(world_rotation);
-            for normalized in [
-                normalized_error(local_position, tolerances.local_position),
-                normalized_error(local_rotation, tolerances.local_rotation_radians),
-                normalized_error(world_position, tolerances.world_position),
-                normalized_error(world_rotation, tolerances.world_rotation_radians),
-            ] {
-                update_worst(bone_worst, normalized, frame, ErrorTrack::Bone(bone));
+    work_stats: &mut ReductionWorkStats,
+    dirty: &DirtyRanges,
+    cache: &mut ValidationCache,
+    worker_pool: Option<&ReductionThreadPool>,
+    worker_count: usize,
+) -> Result<(PoseReductionReport, Vec<Option<WorstError>>), PoseReductionError> {
+    let full_dirty = dirty_ranges_are_full(
+        dirty,
+        input.frame_count,
+        input.bone_count,
+        input.morph_count,
+    );
+    #[cfg(not(target_family = "wasm"))]
+    let refreshed_in_parallel = if full_dirty && worker_count > 1 {
+        refresh_full_validation_cache_parallel(
+            sequence,
+            input,
+            dense,
+            cache,
+            work_stats,
+            worker_pool.expect("multi-worker reduction has a pool"),
+            worker_count,
+        )?;
+        true
+    } else {
+        false
+    };
+    #[cfg(target_family = "wasm")]
+    let refreshed_in_parallel = {
+        let _ = (full_dirty, worker_pool, worker_count);
+        false
+    };
+
+    let mut world_dirty = dirty.bone_local.clone();
+    for &bone in sequence.snapshot.evaluation_order.iter() {
+        let parent = sequence.snapshot.parent_indices[bone];
+        if parent >= 0 {
+            for range in world_dirty[parent as usize].clone() {
+                insert_dirty_range(&mut world_dirty[bone], range);
             }
         }
-        for morph in 0..input.morph_count {
-            let error = (input.morph_weight(frame, morph) - scratch.morph_weights[morph]).abs();
+    }
+
+    if !refreshed_in_parallel {
+        for (bone, ranges) in dirty.bone_local.iter().enumerate() {
+            for range in ranges {
+                for frame in range.clone() {
+                    let index = frame * input.bone_count + bone;
+                    let (translation, rotation) = sample_bone_track(
+                        &sequence.bone_tracks[bone],
+                        &sequence.sample_frames,
+                        input.sample_frame(frame),
+                        sequence.target,
+                    );
+                    cache.local_translations[index] = translation;
+                    cache.local_rotations[index] = rotation;
+                    let cell = &mut cache.bone_errors[index];
+                    cell.local_position = dense.translations[index].distance(translation);
+                    cell.local_rotation = quat_angle(dense.rotations[index], rotation);
+                    work_stats.bone_samples += 1;
+                }
+            }
+        }
+        for (morph, ranges) in dirty.morph.iter().enumerate() {
+            for range in ranges {
+                for frame in range.clone() {
+                    let index = frame * input.morph_count + morph;
+                    let sampled = sample_morph_track(
+                        &sequence.morph_tracks[morph],
+                        &sequence.sample_frames,
+                        input.sample_frame(frame),
+                        sequence.target,
+                    );
+                    cache.morph_weights[index] = sampled;
+                    cache.morph_errors[index] = (input.morph_weight(frame, morph) - sampled).abs();
+                    work_stats.morph_samples += 1;
+                }
+            }
+        }
+
+        let mut rebuilt_frames = vec![false; input.frame_count];
+        for &bone in sequence.snapshot.evaluation_order.iter() {
+            for range in &world_dirty[bone] {
+                for frame in range.clone() {
+                    rebuilt_frames[frame] = true;
+                    let index = frame * input.bone_count + bone;
+                    let local = Mat4::from_rotation_translation(
+                        cache.local_rotations[index],
+                        cache.local_translations[index].into(),
+                    );
+                    let parent = sequence.snapshot.parent_indices[bone];
+                    cache.world_matrices[index] = if parent < 0 {
+                        local
+                    } else {
+                        cache.world_matrices[frame * input.bone_count + parent as usize] * local
+                    };
+                    cache.world_rotations[index] =
+                        decompose_rigid(cache.world_matrices[index], frame, bone)?.1;
+                    let cell = &mut cache.bone_errors[index];
+                    cell.world_position = dense.world_positions[index]
+                        .distance(Vec3A::from(cache.world_matrices[index].w_axis.truncate()));
+                    cell.world_rotation =
+                        quat_angle(dense.world_rotations[index], cache.world_rotations[index]);
+                    work_stats.world_bone_recomputes += 1;
+                    work_stats.world_rotation_decompositions += 1;
+                }
+            }
+        }
+        work_stats.world_rebuilds += rebuilt_frames
+            .into_iter()
+            .filter(|rebuilt| *rebuilt)
+            .count();
+    }
+
+    let mut report = PoseReductionReport::default();
+    let mut worst = vec![None; input.bone_count + input.morph_count];
+    for frame in 0..input.frame_count {
+        let (bone_worst, morph_worst) = worst.split_at_mut(input.bone_count);
+        for (bone, worst) in bone_worst.iter_mut().enumerate() {
+            let index = frame * input.bone_count + bone;
+            let cell = cache.bone_errors[index];
+            report.max_local_position_error =
+                report.max_local_position_error.max(cell.local_position);
+            report.max_local_rotation_error_radians = report
+                .max_local_rotation_error_radians
+                .max(cell.local_rotation);
+            report.max_world_position_error =
+                report.max_world_position_error.max(cell.world_position);
+            report.max_world_rotation_error_radians = report
+                .max_world_rotation_error_radians
+                .max(cell.world_rotation);
+            for normalized in [
+                normalized_error(cell.local_position, tolerances.local_position),
+                normalized_error(cell.local_rotation, tolerances.local_rotation_radians),
+                normalized_error(cell.world_position, tolerances.world_position),
+                normalized_error(cell.world_rotation, tolerances.world_rotation_radians),
+            ] {
+                update_worst(worst, normalized, frame, ErrorTrack::Bone(bone));
+            }
+        }
+        for (morph, morph_worst) in morph_worst.iter_mut().enumerate() {
+            let error = cache.morph_errors[frame * input.morph_count + morph];
             report.max_morph_weight_error = report.max_morph_weight_error.max(error);
             update_worst(
-                &mut worst[input.bone_count + morph],
+                morph_worst,
                 normalized_error(error, tolerances.morph_weight),
                 frame,
                 ErrorTrack::Morph(morph),
             );
         }
     }
-    Ok(FrameErrorResult { report, worst })
+    Ok((report, worst))
 }
 
-fn merge_reduction_report(report: &mut PoseReductionReport, candidate: PoseReductionReport) {
-    report.max_local_position_error = report
-        .max_local_position_error
-        .max(candidate.max_local_position_error);
-    report.max_local_rotation_error_radians = report
-        .max_local_rotation_error_radians
-        .max(candidate.max_local_rotation_error_radians);
-    report.max_world_position_error = report
-        .max_world_position_error
-        .max(candidate.max_world_position_error);
-    report.max_world_rotation_error_radians = report
-        .max_world_rotation_error_radians
-        .max(candidate.max_world_rotation_error_radians);
-    report.max_morph_weight_error = report
-        .max_morph_weight_error
-        .max(candidate.max_morph_weight_error);
+fn dirty_ranges_are_full(
+    dirty: &DirtyRanges,
+    frame_count: usize,
+    bone_count: usize,
+    morph_count: usize,
+) -> bool {
+    let is_full = |ranges: &[std::ops::RangeInclusive<usize>]| {
+        ranges.len() == 1
+            && *ranges[0].start() == 0
+            && *ranges[0].end() == frame_count.saturating_sub(1)
+    };
+    dirty.bone_local.len() == bone_count
+        && dirty.morph.len() == morph_count
+        && dirty.bone_local.iter().all(|ranges| is_full(ranges))
+        && dirty.morph.iter().all(|ranges| is_full(ranges))
 }
 
 fn update_worst(worst: &mut Option<WorstError>, normalized: f32, frame: usize, track: ErrorTrack) {

--- a/crates/mmd-anim-runtime/src/reduce/mod.rs
+++ b/crates/mmd-anim-runtime/src/reduce/mod.rs
@@ -3,7 +3,6 @@ use std::time::{Duration, Instant};
 
 use glam::{EulerRot, Mat3, Mat4, Quat, Vec3, Vec3A};
 #[cfg(not(target_family = "wasm"))]
-#[cfg(not(target_family = "wasm"))]
 use rayon::prelude::*;
 #[cfg(not(target_family = "wasm"))]
 use rayon::{ThreadPool, ThreadPoolBuilder};

--- a/crates/mmd-anim-runtime/src/reduce/mod.rs
+++ b/crates/mmd-anim-runtime/src/reduce/mod.rs
@@ -3,7 +3,7 @@ use std::cmp::Ordering;
 use glam::{Mat3, Mat4, Quat, Vec3, Vec3A};
 use thiserror::Error;
 
-use crate::{BoneIndex, ModelArena};
+use crate::{BoneIndex, InterpolationScalar, ModelArena};
 
 const AFFINE_EPSILON: f32 = 1.0e-4;
 
@@ -196,6 +196,47 @@ impl SkeletonSnapshot {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ReductionTarget {
     LinearSlerp,
+    VmdBezier,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct QuantizedBezier {
+    pub x1: u8,
+    pub y1: u8,
+    pub x2: u8,
+    pub y2: u8,
+}
+
+impl QuantizedBezier {
+    pub const LINEAR: Self = Self {
+        x1: 20,
+        y1: 20,
+        x2: 107,
+        y2: 107,
+    };
+
+    pub fn evaluate(self, time: f32) -> f32 {
+        InterpolationScalar {
+            x1: self.x1.min(127),
+            y1: self.y1.min(127),
+            x2: self.x2.min(127),
+            y2: self.y2.min(127),
+        }
+        .evaluate(time)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct VmdBoneInterpolation {
+    pub translation: [QuantizedBezier; 3],
+    pub rotation: QuantizedBezier,
+}
+
+impl VmdBoneInterpolation {
+    pub const LINEAR: Self = Self {
+        translation: [QuantizedBezier::LINEAR; 3],
+        rotation: QuantizedBezier::LINEAR,
+    };
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -243,6 +284,7 @@ pub struct ReducedBoneKey {
     pub sample_index: usize,
     pub translation: Vec3A,
     pub rotation: Quat,
+    pub vmd_interpolation: VmdBoneInterpolation,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -332,12 +374,12 @@ impl ReducedPoseSequence {
         let local_translations = self
             .bone_tracks
             .iter()
-            .map(|track| sample_bone_track(track, &self.sample_frames, frame).0)
+            .map(|track| sample_bone_track(track, &self.sample_frames, frame, self.target).0)
             .collect::<Vec<_>>();
         let local_rotations = self
             .bone_tracks
             .iter()
-            .map(|track| sample_bone_track(track, &self.sample_frames, frame).1)
+            .map(|track| sample_bone_track(track, &self.sample_frames, frame, self.target).1)
             .collect::<Vec<_>>();
         let morph_weights = self
             .morph_tracks
@@ -437,15 +479,17 @@ pub fn reduce_dense_pose_sequence(
     let mut bone_key_indices = vec![endpoint_indices(input.frame_count); input.bone_count];
     let mut morph_key_indices = vec![endpoint_indices(input.frame_count); input.morph_count];
 
-    for (bone, keys) in bone_key_indices.iter_mut().enumerate() {
-        split_bone_track(
-            keys,
-            input,
-            bone,
-            &local_translations,
-            &local_rotations,
-            tolerances,
-        );
+    if target == ReductionTarget::LinearSlerp {
+        for (bone, keys) in bone_key_indices.iter_mut().enumerate() {
+            split_bone_track(
+                keys,
+                input,
+                bone,
+                &local_translations,
+                &local_rotations,
+                tolerances,
+            );
+        }
     }
     for (morph, keys) in morph_key_indices.iter_mut().enumerate() {
         split_morph_track(keys, input, morph, tolerances.morph_weight);
@@ -703,12 +747,27 @@ fn build_sequence(
         .map(|(bone, indices)| ReducedBoneTrack {
             keys: indices
                 .iter()
-                .map(|&frame| {
+                .enumerate()
+                .map(|(key_position, &frame)| {
                     let index = frame * input.bone_count + bone;
+                    let vmd_interpolation =
+                        if target == ReductionTarget::VmdBezier && key_position > 0 {
+                            fit_vmd_bone_interpolation(
+                                input,
+                                bone,
+                                indices[key_position - 1],
+                                frame,
+                                translations,
+                                rotations,
+                            )
+                        } else {
+                            VmdBoneInterpolation::LINEAR
+                        };
                     ReducedBoneKey {
                         sample_index: frame,
                         translation: translations[index],
                         rotation: rotations[index],
+                        vmd_interpolation,
                     }
                 })
                 .collect::<Vec<_>>()
@@ -833,7 +892,154 @@ fn update_worst(worst: &mut Option<WorstError>, normalized: f32, frame: usize, t
     }
 }
 
-fn sample_bone_track(track: &ReducedBoneTrack, sample_frames: &[f32], frame: f32) -> (Vec3A, Quat) {
+fn fit_vmd_bone_interpolation(
+    input: DensePoseSequenceView<'_>,
+    bone: usize,
+    start: usize,
+    end: usize,
+    translations: &[Vec3A],
+    rotations: &[Quat],
+) -> VmdBoneInterpolation {
+    let bone_count = input.bone_count;
+    let start_index = start * bone_count + bone;
+    let end_index = end * bone_count + bone;
+    let start_translation = translations[start_index];
+    let end_translation = translations[end_index];
+    let translation = std::array::from_fn(|axis| {
+        let start_value = start_translation.to_array()[axis];
+        let end_value = end_translation.to_array()[axis];
+        fit_quantized_bezier(
+            start,
+            end,
+            |sample| {
+                let value = translations[sample * bone_count + bone].to_array()[axis];
+                normalized_channel_value(start_value, end_value, value)
+            },
+            |sample| input.sample_frame(sample),
+        )
+    });
+    let start_rotation = rotations[start_index];
+    let end_rotation = rotations[end_index];
+    let total_angle = quat_angle(start_rotation, end_rotation);
+    let rotation = fit_quantized_bezier(
+        start,
+        end,
+        |sample| {
+            if total_angle <= f32::EPSILON {
+                0.0
+            } else {
+                (quat_angle(start_rotation, rotations[sample * bone_count + bone]) / total_angle)
+                    .clamp(0.0, 1.0)
+            }
+        },
+        |sample| input.sample_frame(sample),
+    );
+    VmdBoneInterpolation {
+        translation,
+        rotation,
+    }
+}
+
+fn fit_quantized_bezier(
+    start: usize,
+    end: usize,
+    value_at: impl Fn(usize) -> f32,
+    frame_at: impl Fn(usize) -> f32,
+) -> QuantizedBezier {
+    if end <= start + 1 {
+        return QuantizedBezier::LINEAR;
+    }
+    let mut best = QuantizedBezier::LINEAR;
+    let score = |curve: QuantizedBezier| -> f32 {
+        (start + 1..end)
+            .map(|sample| {
+                let time = segment_amount(start, end, sample, &frame_at);
+                (curve.evaluate(time) - value_at(sample)).abs()
+            })
+            .fold(0.0f32, f32::max)
+    };
+    let mut best_score = score(best);
+    const COARSE: [u8; 9] = [0, 16, 32, 48, 64, 80, 96, 112, 127];
+    for &x1 in &COARSE {
+        for &x2 in &COARSE {
+            if x1 > x2 {
+                continue;
+            }
+            for &y1 in &COARSE {
+                for &y2 in &COARSE {
+                    let candidate = QuantizedBezier { x1, y1, x2, y2 };
+                    let candidate_score = score(candidate);
+                    if candidate_score.total_cmp(&best_score) == Ordering::Less {
+                        best = candidate;
+                        best_score = candidate_score;
+                    }
+                }
+            }
+        }
+    }
+    for step in [32i16, 16, 8, 4, 2, 1] {
+        loop {
+            let origin = [best.x1, best.y1, best.x2, best.y2];
+            let mut next_best = best;
+            let mut next_score = best_score;
+            for d0 in [-step, 0, step] {
+                for d1 in [-step, 0, step] {
+                    for d2 in [-step, 0, step] {
+                        for d3 in [-step, 0, step] {
+                            let offsets = [d0, d1, d2, d3];
+                            let mut values = [0u8; 4];
+                            let mut valid = true;
+                            for coordinate in 0..4 {
+                                let value = origin[coordinate] as i16 + offsets[coordinate];
+                                if !(0..=127).contains(&value) {
+                                    valid = false;
+                                    break;
+                                }
+                                values[coordinate] = value as u8;
+                            }
+                            if !valid || values[0] > values[2] {
+                                continue;
+                            }
+                            let candidate = QuantizedBezier {
+                                x1: values[0],
+                                y1: values[1],
+                                x2: values[2],
+                                y2: values[3],
+                            };
+                            let candidate_score = score(candidate);
+                            if candidate_score.total_cmp(&next_score) == Ordering::Less {
+                                next_best = candidate;
+                                next_score = candidate_score;
+                            }
+                        }
+                    }
+                }
+            }
+            if next_best == best {
+                break;
+            }
+            best = next_best;
+            best_score = next_score;
+        }
+    }
+    best
+}
+
+fn normalized_channel_value(start: f32, end: f32, value: f32) -> f32 {
+    let range = end - start;
+    if range.abs() <= f32::EPSILON {
+        0.0
+    } else {
+        ((value - start) / range).clamp(0.0, 1.0)
+    }
+}
+
+fn sample_bone_track(
+    track: &ReducedBoneTrack,
+    sample_frames: &[f32],
+    frame: f32,
+    target: ReductionTarget,
+) -> (Vec3A, Quat) {
     let upper = track
         .keys
         .partition_point(|key| sample_frames[key.sample_index] <= frame);
@@ -849,9 +1055,27 @@ fn sample_bone_track(track: &ReducedBoneTrack, sample_frames: &[f32], frame: f32
     let amount = ((frame - sample_frames[left.sample_index])
         / (sample_frames[right.sample_index] - sample_frames[left.sample_index]))
         .clamp(0.0, 1.0);
+    let translation_amount = if target == ReductionTarget::VmdBezier {
+        Vec3A::new(
+            right.vmd_interpolation.translation[0].evaluate(amount),
+            right.vmd_interpolation.translation[1].evaluate(amount),
+            right.vmd_interpolation.translation[2].evaluate(amount),
+        )
+    } else {
+        Vec3A::splat(amount)
+    };
+    let rotation_amount = if target == ReductionTarget::VmdBezier {
+        right.vmd_interpolation.rotation.evaluate(amount)
+    } else {
+        amount
+    };
     (
-        left.translation.lerp(right.translation, amount),
-        normalize_quat(left.rotation.slerp(right.rotation, amount)),
+        Vec3A::new(
+            left.translation.x + (right.translation.x - left.translation.x) * translation_amount.x,
+            left.translation.y + (right.translation.y - left.translation.y) * translation_amount.y,
+            left.translation.z + (right.translation.z - left.translation.z) * translation_amount.z,
+        ),
+        normalize_quat(left.rotation.slerp(right.rotation, rotation_amount)),
     )
 }
 

--- a/crates/mmd-anim-runtime/src/reduce/tests.rs
+++ b/crates/mmd-anim-runtime/src/reduce/tests.rs
@@ -281,3 +281,86 @@ fn custom_tolerance_changes_key_count_and_bounds_report() {
     assert!(strict.report().max_world_rotation_error_radians <= 1.0e-4);
     assert!(strict.report().max_morph_weight_error <= 1.0e-4);
 }
+
+#[test]
+fn vmd_bezier_target_fits_quantized_curve_and_samples_with_it() {
+    let source_curve = QuantizedBezier {
+        x1: 30,
+        y1: 10,
+        x2: 100,
+        y2: 120,
+    };
+    let frame_count = 17;
+    let fitted = fit_quantized_bezier(
+        0,
+        frame_count - 1,
+        |frame| source_curve.evaluate(frame as f32 / (frame_count - 1) as f32),
+        |frame| frame as f32,
+    );
+    let fit_error = (1..frame_count - 1)
+        .map(|frame| {
+            let time = frame as f32 / (frame_count - 1) as f32;
+            (fitted.evaluate(time) - source_curve.evaluate(time)).abs()
+        })
+        .fold(0.0f32, f32::max);
+    assert!(fit_error <= 0.005, "{fitted:?} {fit_error}");
+    let world = (0..frame_count)
+        .map(|frame| {
+            let time = frame as f32 / (frame_count - 1) as f32;
+            Mat4::from_translation(Vec3::new(source_curve.evaluate(time), 0.0, 0.0))
+        })
+        .collect::<Vec<_>>();
+    let input = DensePoseSequenceView::new(&world, &[], frame_count, 1, 0, 0.0, 1.0).unwrap();
+    let one =
+        SkeletonSnapshot::new(vec![-1], vec![Vec3A::ZERO], vec![Quat::IDENTITY], 0, 11).unwrap();
+    let reduced = reduce_dense_pose_sequence(
+        input,
+        one,
+        ReductionTolerances {
+            local_position: 0.005,
+            world_position: 0.005,
+            ..Default::default()
+        },
+        ReductionTarget::VmdBezier,
+    )
+    .unwrap();
+    let interpolation = reduced.bone_tracks()[0].keys()[1]
+        .vmd_interpolation
+        .translation[0];
+    assert_eq!(
+        reduced.bone_tracks()[0].keys().len(),
+        2,
+        "{interpolation:?}"
+    );
+    assert!(interpolation.x1 <= 127 && interpolation.y1 <= 127);
+    assert!(interpolation.x2 <= 127 && interpolation.y2 <= 127);
+    assert!(reduced.report().max_world_position_error <= 0.005);
+}
+
+#[test]
+fn vmd_bezier_world_rotation_gate_handles_near_pi_motion() {
+    let frame_count = 9;
+    let world = (0..frame_count)
+        .map(|frame| {
+            let amount = frame as f32 / (frame_count - 1) as f32;
+            Mat4::from_quat(Quat::from_rotation_y(
+                (std::f32::consts::PI - 0.01) * amount,
+            ))
+        })
+        .collect::<Vec<_>>();
+    let input = DensePoseSequenceView::new(&world, &[], frame_count, 1, 0, 0.0, 1.0).unwrap();
+    let one =
+        SkeletonSnapshot::new(vec![-1], vec![Vec3A::ZERO], vec![Quat::IDENTITY], 0, 12).unwrap();
+    let reduced = reduce_dense_pose_sequence(
+        input,
+        one,
+        ReductionTolerances {
+            local_rotation_radians: 0.002,
+            world_rotation_radians: 0.002,
+            ..Default::default()
+        },
+        ReductionTarget::VmdBezier,
+    )
+    .unwrap();
+    assert!(reduced.report().max_world_rotation_error_radians <= 0.002);
+}

--- a/crates/mmd-anim-runtime/src/reduce/tests.rs
+++ b/crates/mmd-anim-runtime/src/reduce/tests.rs
@@ -687,6 +687,76 @@ fn vmd_bezier_world_rotation_gate_handles_near_pi_motion() {
 }
 
 #[test]
+fn quaternion_angle_is_stable_for_identical_and_small_rotations() {
+    let rotation = normalize_quat(Quat::from_xyzw(
+        0.182_574_18,
+        -0.365_148_37,
+        0.547_722_6,
+        0.730_296_73,
+    ));
+    assert_eq!(quat_angle(rotation, rotation), 0.0);
+    assert_eq!(quat_angle(rotation, -rotation), 0.0);
+
+    let delta = 1.0e-5;
+    let shifted = normalize_quat(rotation * Quat::from_rotation_y(delta));
+    assert!((quat_angle(rotation, shifted) - delta).abs() <= 1.0e-6);
+}
+
+#[test]
+fn tight_rotation_tolerance_handles_rabbit_hole_like_dense_chain() {
+    const FRAME_COUNT: usize = 301;
+    const BONE_COUNT: usize = 12;
+    let parents = (0..BONE_COUNT)
+        .map(|bone| if bone == 0 { -1 } else { bone as i32 - 1 })
+        .collect::<Vec<_>>();
+    let rest_translations = (0..BONE_COUNT)
+        .map(|bone| if bone == 0 { Vec3A::ZERO } else { Vec3A::Y })
+        .collect::<Vec<_>>();
+    let rest_rotations = vec![Quat::IDENTITY; BONE_COUNT];
+    let snapshot = SkeletonSnapshot::new(
+        parents,
+        rest_translations.clone(),
+        rest_rotations,
+        0,
+        0x5241_4242_4954,
+    )
+    .unwrap();
+    let mut world = Vec::with_capacity(FRAME_COUNT * BONE_COUNT);
+    for frame in 0..FRAME_COUNT {
+        let time = frame as f32 / 30.0;
+        let mut frame_world = [Mat4::IDENTITY; BONE_COUNT];
+        for bone in 0..BONE_COUNT {
+            let phase = time * (0.7 + bone as f32 * 0.11) + bone as f32 * 0.37;
+            let rotation = normalize_quat(
+                Quat::from_rotation_x(phase.sin() * 1.2)
+                    * Quat::from_rotation_y((phase * 0.83).cos() * 1.0)
+                    * Quat::from_rotation_z((phase * 1.17).sin() * 0.8),
+            );
+            let local = Mat4::from_rotation_translation(rotation, rest_translations[bone].into());
+            frame_world[bone] = if bone == 0 {
+                local
+            } else {
+                frame_world[bone - 1] * local
+            };
+        }
+        world.extend_from_slice(&frame_world);
+    }
+    let reduced = reduce_dense_pose_sequence(
+        DensePoseSequenceView::new(&world, &[], FRAME_COUNT, BONE_COUNT, 0, 0.0, 1.0).unwrap(),
+        snapshot,
+        ReductionTolerances {
+            local_rotation_radians: 1.0e-4,
+            world_rotation_radians: 1.0e-4,
+            ..Default::default()
+        },
+        ReductionTarget::DccCubic,
+    )
+    .unwrap();
+    assert!(reduced.report().max_local_rotation_error_radians <= 1.0e-4);
+    assert!(reduced.report().max_world_rotation_error_radians <= 1.0e-4);
+}
+
+#[test]
 fn dcc_hermite_matches_independent_reference_equation() {
     let start = -2.0;
     let end = 3.0;

--- a/crates/mmd-anim-runtime/src/reduce/tests.rs
+++ b/crates/mmd-anim-runtime/src/reduce/tests.rs
@@ -230,6 +230,70 @@ fn reduction_work_stats_are_deterministic_and_separate_from_quality_report() {
 }
 
 #[test]
+fn frame_validation_is_deterministic_across_worker_counts() {
+    let world = dense_world(17);
+    let morphs = (0..17)
+        .map(|frame| ((frame as f32 * 0.73).sin() * 0.5 + 0.5).clamp(0.0, 1.0))
+        .collect::<Vec<_>>();
+    let reduce = |workers| {
+        reduce_dense_pose_sequence_with_worker_count(
+            DensePoseSequenceView::new(&world, &morphs, 17, 2, 1, 0.0, 1.0).unwrap(),
+            snapshot(),
+            ReductionTolerances {
+                local_position: 0.01,
+                local_rotation_radians: 0.01,
+                world_position: 0.01,
+                world_rotation_radians: 0.01,
+                morph_weight: 0.01,
+            },
+            ReductionTarget::DccCubic,
+            workers,
+        )
+        .unwrap()
+    };
+
+    let single = reduce(1);
+    let two = reduce(2);
+    let four = reduce(4);
+    assert_eq!(single, two);
+    assert_eq!(single, four);
+    assert_eq!(single.work_stats(), two.work_stats());
+    assert_eq!(single.work_stats(), four.work_stats());
+}
+
+#[test]
+fn worst_error_order_is_normalized_then_frame_then_track() {
+    let mut errors = [
+        WorstError {
+            normalized_error: 2.0,
+            frame: 4,
+            track: ErrorTrack::Morph(0),
+        },
+        WorstError {
+            normalized_error: 3.0,
+            frame: 8,
+            track: ErrorTrack::Bone(2),
+        },
+        WorstError {
+            normalized_error: 2.0,
+            frame: 3,
+            track: ErrorTrack::Bone(5),
+        },
+        WorstError {
+            normalized_error: 2.0,
+            frame: 4,
+            track: ErrorTrack::Bone(1),
+        },
+    ];
+    errors.sort_by(compare_worst_errors);
+
+    assert_eq!(errors[0].normalized_error, 3.0);
+    assert_eq!(errors[1].frame, 3);
+    assert_eq!(errors[2].track, ErrorTrack::Bone(1));
+    assert_eq!(errors[3].track, ErrorTrack::Morph(0));
+}
+
+#[test]
 fn rejects_non_finite_scale_shear_and_invalid_time_base_atomically() {
     let mut non_finite = Mat4::IDENTITY;
     non_finite.x_axis.x = f32::NAN;

--- a/crates/mmd-anim-runtime/src/reduce/tests.rs
+++ b/crates/mmd-anim-runtime/src/reduce/tests.rs
@@ -364,3 +364,213 @@ fn vmd_bezier_world_rotation_gate_handles_near_pi_motion() {
     .unwrap();
     assert!(reduced.report().max_world_rotation_error_radians <= 0.002);
 }
+
+#[test]
+fn dcc_hermite_matches_independent_reference_equation() {
+    let start = -2.0;
+    let end = 3.0;
+    let out_tangent = 1.25;
+    let in_tangent = -0.75;
+    let duration = 4.0;
+    for step in 0..=16 {
+        let t = step as f32 / 16.0;
+        let t2 = t * t;
+        let t3 = t2 * t;
+        let reference = (2.0 * t3 - 3.0 * t2 + 1.0) * start
+            + (t3 - 2.0 * t2 + t) * duration * out_tangent
+            + (-2.0 * t3 + 3.0 * t2) * end
+            + (t3 - t2) * duration * in_tangent;
+        assert!(
+            (sample_hermite(start, end, out_tangent, in_tangent, duration, t) - reference).abs()
+                <= f32::EPSILON
+        );
+    }
+}
+
+#[test]
+fn dcc_cubic_uses_fewer_keys_for_a_single_smooth_peak() {
+    let frame_count = 9;
+    let world = (0..frame_count)
+        .map(|frame| {
+            let t = frame as f32 / (frame_count - 1) as f32;
+            Mat4::from_translation(Vec3::new(4.0 * t * (1.0 - t), 0.0, 0.0))
+        })
+        .collect::<Vec<_>>();
+    let morphs = (0..frame_count)
+        .map(|frame| {
+            let t = frame as f32 / (frame_count - 1) as f32;
+            4.0 * t * (1.0 - t)
+        })
+        .collect::<Vec<_>>();
+    let reduce = |target| {
+        reduce_dense_pose_sequence(
+            DensePoseSequenceView::new(&world, &morphs, frame_count, 1, 1, 0.0, 1.0).unwrap(),
+            SkeletonSnapshot::new(vec![-1], vec![Vec3A::ZERO], vec![Quat::IDENTITY], 1, 13)
+                .unwrap(),
+            ReductionTolerances {
+                local_position: 0.01,
+                world_position: 0.01,
+                morph_weight: 0.01,
+                ..Default::default()
+            },
+            target,
+        )
+        .unwrap()
+    };
+    let linear = reduce(ReductionTarget::LinearSlerp);
+    let cubic = reduce(ReductionTarget::DccCubic);
+    assert_eq!(
+        cubic.bone_tracks()[0].keys().len(),
+        3,
+        "{:?} {:?}",
+        cubic.report(),
+        cubic.bone_tracks()[0].keys()
+    );
+    assert_eq!(cubic.morph_tracks()[0].keys().len(), 3);
+    assert!(
+        cubic.report().reduced_bone_key_count < linear.report().reduced_bone_key_count
+            && cubic.report().reduced_morph_key_count < linear.report().reduced_morph_key_count
+    );
+    assert!(cubic.report().max_world_position_error <= 0.01);
+    assert!(cubic.report().max_morph_weight_error <= 0.01);
+}
+
+#[test]
+fn dcc_constant_tangent_motion_is_finite_and_exact() {
+    let constant = [2.0f32; 4];
+    let constant_segment = fit_dcc_scalar_segment(
+        0,
+        constant.len() - 1,
+        |sample| constant[sample],
+        |sample| sample as f32,
+    );
+    assert_eq!(constant_segment, DccScalarSegment::default());
+    for step in 0..=16 {
+        assert_eq!(
+            sample_hermite(
+                constant[0],
+                constant[constant.len() - 1],
+                constant_segment.out_tangent,
+                constant_segment.in_tangent,
+                (constant.len() - 1) as f32,
+                step as f32 / 16.0,
+            ),
+            2.0
+        );
+    }
+
+    let frame_count = 6;
+    let world = (0..frame_count)
+        .map(|frame| {
+            Mat4::from_rotation_translation(
+                Quat::from_rotation_z(frame as f32 * 0.1),
+                Vec3::new(frame as f32 * 0.25, 0.0, 0.0),
+            )
+        })
+        .collect::<Vec<_>>();
+    let morphs = (0..frame_count)
+        .map(|frame| frame as f32 * 0.2)
+        .collect::<Vec<_>>();
+    let reduced = reduce_dense_pose_sequence(
+        DensePoseSequenceView::new(&world, &morphs, frame_count, 1, 1, 0.0, 1.0).unwrap(),
+        SkeletonSnapshot::new(vec![-1], vec![Vec3A::ZERO], vec![Quat::IDENTITY], 1, 16).unwrap(),
+        ReductionTolerances {
+            local_position: 1.0e-5,
+            local_rotation_radians: 1.0e-4,
+            world_position: 1.0e-5,
+            world_rotation_radians: 1.0e-4,
+            morph_weight: 1.0e-5,
+        },
+        ReductionTarget::DccCubic,
+    )
+    .unwrap();
+    assert_eq!(reduced.bone_tracks()[0].keys().len(), 2);
+    assert_eq!(reduced.morph_tracks()[0].keys().len(), 2);
+    let bone_segment = reduced.bone_tracks()[0].keys()[1].dcc_segment;
+    let morph_segment = reduced.morph_tracks()[0].keys()[1].dcc_segment;
+    assert!((bone_segment.translation_out_tangent.x - 0.25).abs() <= 1.0e-5);
+    assert!((bone_segment.translation_in_tangent.x - 0.25).abs() <= 1.0e-5);
+    assert!((bone_segment.rotation_out_tangent.z - 0.1).abs() <= 1.0e-4);
+    assert!((bone_segment.rotation_in_tangent.z - 0.1).abs() <= 1.0e-4);
+    assert!((morph_segment.out_tangent - 0.2).abs() <= 1.0e-5);
+    assert!((morph_segment.in_tangent - 0.2).abs() <= 1.0e-5);
+}
+
+#[test]
+fn dcc_euler_xyz_unwraps_across_pi_without_flips() {
+    let degrees = [170.0f32, 175.0, 179.0, 181.0, 185.0, 190.0];
+    let world = degrees
+        .iter()
+        .map(|degrees| Mat4::from_quat(Quat::from_rotation_x(degrees.to_radians())))
+        .collect::<Vec<_>>();
+    let reduced = reduce_dense_pose_sequence(
+        DensePoseSequenceView::new(&world, &[], world.len(), 1, 0, 0.0, 1.0).unwrap(),
+        SkeletonSnapshot::new(vec![-1], vec![Vec3A::ZERO], vec![Quat::IDENTITY], 0, 14).unwrap(),
+        ReductionTolerances {
+            local_rotation_radians: 0.002,
+            world_rotation_radians: 0.002,
+            ..Default::default()
+        },
+        ReductionTarget::DccCubic,
+    )
+    .unwrap();
+    assert!(reduced.report().max_world_rotation_error_radians <= 0.002);
+    for (frame, degrees) in degrees.iter().enumerate() {
+        let sample = reduced.sample(frame as f32).unwrap();
+        assert!(sample.local_rotations[0].is_finite());
+        assert!(
+            quat_angle(
+                Quat::from_rotation_x(degrees.to_radians()),
+                sample.local_rotations[0]
+            ) <= 0.002
+        );
+    }
+}
+
+#[test]
+fn dcc_broken_tangents_stay_finite_and_do_not_overshoot_monotonic_segments() {
+    let values = [0.0f32, 0.85, 0.9, 1.0];
+    let segment = fit_dcc_scalar_segment(
+        0,
+        values.len() - 1,
+        |sample| values[sample],
+        |sample| sample as f32,
+    );
+    assert!(segment.out_tangent.is_finite() && segment.in_tangent.is_finite());
+    for step in 0..=128 {
+        let value = sample_hermite(
+            values[0],
+            values[values.len() - 1],
+            segment.out_tangent,
+            segment.in_tangent,
+            (values.len() - 1) as f32,
+            step as f32 / 128.0,
+        );
+        assert!(
+            (-1.0e-6..=1.0 + 1.0e-6).contains(&value),
+            "{segment:?} {value}"
+        );
+    }
+
+    let extrema = [0.0f32, 1.0, -1.0, 1.0, 0.0];
+    let world = extrema
+        .iter()
+        .map(|value| Mat4::from_translation(Vec3::new(*value, 0.0, 0.0)))
+        .collect::<Vec<_>>();
+    let reduced = reduce_dense_pose_sequence(
+        DensePoseSequenceView::new(&world, &[], world.len(), 1, 0, 0.0, 1.0).unwrap(),
+        SkeletonSnapshot::new(vec![-1], vec![Vec3A::ZERO], vec![Quat::IDENTITY], 0, 15).unwrap(),
+        ReductionTolerances {
+            local_position: 0.01,
+            world_position: 0.01,
+            ..Default::default()
+        },
+        ReductionTarget::DccCubic,
+    )
+    .unwrap();
+    assert!(reduced.report().max_world_position_error <= 0.01);
+    assert!(reduced.bone_tracks()[0].keys().iter().all(|key| {
+        key.dcc_segment.translation_out_tangent.is_finite()
+            && key.dcc_segment.translation_in_tangent.is_finite()
+    }));
+}

--- a/crates/mmd-anim-runtime/src/reduce/tests.rs
+++ b/crates/mmd-anim-runtime/src/reduce/tests.rs
@@ -220,15 +220,107 @@ fn reduction_work_stats_are_deterministic_and_separate_from_quality_report() {
     );
     assert_eq!(stats.local_prefit_bone_segment_fits, 0);
     assert_eq!(stats.local_prefit_morph_segment_fits, 0);
-    assert_eq!(stats.bone_samples, stats.global_validation_passes * 7 * 2);
-    assert_eq!(stats.morph_samples, stats.global_validation_passes * 7);
-    assert_eq!(stats.world_rebuilds, stats.global_validation_passes * 7);
+    assert!(stats.bone_samples < stats.global_validation_passes * 7 * 2);
+    assert!(stats.morph_samples < stats.global_validation_passes * 7);
+    assert!(stats.world_rebuilds <= stats.global_validation_passes * 7);
     assert_eq!(
         stats.world_rotation_decompositions,
-        (stats.global_validation_passes + 1) * 7 * 2
+        7 * 2 + stats.world_bone_recomputes
     );
     assert!(stats.dcc_bone_segment_fits > 0);
     assert!(stats.dcc_morph_segment_fits > 0);
+}
+
+#[test]
+fn incremental_validation_matches_full_scan_on_branching_sequence() {
+    let frame_count = 97;
+    let parents = vec![-1, 0, 0, 1, 1];
+    let snapshot = SkeletonSnapshot::new(
+        parents.clone(),
+        vec![Vec3A::ZERO; parents.len()],
+        vec![Quat::IDENTITY; parents.len()],
+        2,
+        314,
+    )
+    .unwrap();
+    let mut world = Vec::with_capacity(frame_count * parents.len());
+    for frame in 0..frame_count {
+        let time = frame as f32;
+        let mut frame_world = vec![Mat4::IDENTITY; parents.len()];
+        for bone in 0..parents.len() {
+            let local = Mat4::from_rotation_translation(
+                Quat::from_rotation_z((time * (0.017 + bone as f32 * 0.009)).sin() * 0.35),
+                Vec3::new(
+                    bone as f32 * 0.3 + (time * (0.031 + bone as f32 * 0.004)).sin(),
+                    (time * (0.023 + bone as f32 * 0.006)).cos() * 0.4,
+                    0.0,
+                ),
+            );
+            frame_world[bone] = if parents[bone] < 0 {
+                local
+            } else {
+                frame_world[parents[bone] as usize] * local
+            };
+        }
+        world.extend(frame_world);
+    }
+    let morphs = (0..frame_count)
+        .flat_map(|frame| {
+            let time = frame as f32;
+            [
+                (time * 0.071).sin() * 0.5 + 0.5,
+                (time * 0.113).cos() * 0.5 + 0.5,
+            ]
+        })
+        .collect::<Vec<_>>();
+    let input =
+        DensePoseSequenceView::new(&world, &morphs, frame_count, parents.len(), 2, 0.0, 1.0)
+            .unwrap();
+    let tolerances = ReductionTolerances {
+        local_position: 0.05,
+        local_rotation_radians: 0.05,
+        world_position: 0.002,
+        world_rotation_radians: 0.002,
+        morph_weight: 0.05,
+    };
+    let incremental_with_workers = |workers| {
+        reduce_dense_pose_sequence_internal(
+            input,
+            snapshot.clone(),
+            tolerances,
+            ReductionTarget::DccCubic,
+            workers,
+            ValidationMode::Incremental,
+        )
+        .unwrap()
+    };
+    let incremental = incremental_with_workers(1);
+    let incremental_two = incremental_with_workers(2);
+    let incremental_four = incremental_with_workers(4);
+    let full = reduce_dense_pose_sequence_internal(
+        input,
+        snapshot,
+        tolerances,
+        ReductionTarget::DccCubic,
+        1,
+        ValidationMode::FullScan,
+    )
+    .unwrap();
+
+    assert_eq!(incremental, incremental_two);
+    assert_eq!(incremental, incremental_four);
+    assert_eq!(incremental.bone_tracks(), full.bone_tracks());
+    assert_eq!(incremental.morph_tracks(), full.morph_tracks());
+    assert_eq!(incremental.report(), full.report());
+    assert_eq!(
+        incremental.work_stats().added_keys_per_pass,
+        full.work_stats().added_keys_per_pass
+    );
+    assert!(incremental.work_stats().bone_samples < full.work_stats().bone_samples);
+    assert!(
+        incremental.work_stats().world_bone_recomputes < full.work_stats().world_bone_recomputes
+    );
+    assert!(incremental.work_stats().morph_samples < full.work_stats().morph_samples);
 }
 
 #[test]

--- a/crates/mmd-anim-runtime/src/reduce/tests.rs
+++ b/crates/mmd-anim-runtime/src/reduce/tests.rs
@@ -218,6 +218,8 @@ fn reduction_work_stats_are_deterministic_and_separate_from_quality_report() {
         stats.normal_key_additions + stats.ancestor_key_additions,
         stats.added_keys_per_pass.iter().sum::<usize>()
     );
+    assert_eq!(stats.local_prefit_bone_segment_fits, 0);
+    assert_eq!(stats.local_prefit_morph_segment_fits, 0);
     assert_eq!(stats.bone_samples, stats.global_validation_passes * 7 * 2);
     assert_eq!(stats.morph_samples, stats.global_validation_passes * 7);
     assert_eq!(stats.world_rebuilds, stats.global_validation_passes * 7);
@@ -230,14 +232,44 @@ fn reduction_work_stats_are_deterministic_and_separate_from_quality_report() {
 }
 
 #[test]
+fn dcc_local_prefit_records_separate_work_for_long_sequences() {
+    let frame_count = 97;
+    let world = dense_world(frame_count);
+    let morphs = (0..frame_count)
+        .map(|frame| ((frame as f32 * 0.37).sin() * 0.5 + 0.5).clamp(0.0, 1.0))
+        .collect::<Vec<_>>();
+    let reduced = reduce_dense_pose_sequence(
+        DensePoseSequenceView::new(&world, &morphs, frame_count, 2, 1, 0.0, 1.0).unwrap(),
+        snapshot(),
+        ReductionTolerances {
+            local_position: 0.01,
+            local_rotation_radians: 0.01,
+            world_position: 0.01,
+            world_rotation_radians: 0.01,
+            morph_weight: 0.01,
+        },
+        ReductionTarget::DccCubic,
+    )
+    .unwrap();
+    let stats = reduced.work_stats();
+
+    assert!(stats.local_prefit_bone_segment_fits > 0);
+    assert!(stats.local_prefit_morph_segment_fits > 0);
+    assert!(stats.local_prefit_morph_key_additions > 0);
+    assert!(stats.local_prefit_bone_samples > 0);
+    assert!(stats.local_prefit_morph_samples > 0);
+}
+
+#[test]
 fn frame_validation_is_deterministic_across_worker_counts() {
-    let world = dense_world(17);
-    let morphs = (0..17)
+    let frame_count = 97;
+    let world = dense_world(frame_count);
+    let morphs = (0..frame_count)
         .map(|frame| ((frame as f32 * 0.73).sin() * 0.5 + 0.5).clamp(0.0, 1.0))
         .collect::<Vec<_>>();
     let reduce = |workers| {
         reduce_dense_pose_sequence_with_worker_count(
-            DensePoseSequenceView::new(&world, &morphs, 17, 2, 1, 0.0, 1.0).unwrap(),
+            DensePoseSequenceView::new(&world, &morphs, frame_count, 2, 1, 0.0, 1.0).unwrap(),
             snapshot(),
             ReductionTolerances {
                 local_position: 0.01,

--- a/crates/mmd-anim-runtime/src/reduce/tests.rs
+++ b/crates/mmd-anim-runtime/src/reduce/tests.rs
@@ -1,6 +1,60 @@
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::cell::Cell;
+use std::hint::black_box;
+use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
+
 use glam::{Mat4, Quat, Vec3, Vec3A};
 
 use super::*;
+
+static TEST_ALLOCATIONS: AtomicUsize = AtomicUsize::new(0);
+
+thread_local! {
+    static COUNT_TEST_ALLOCATIONS: Cell<bool> = const { Cell::new(false) };
+}
+
+struct TestCountingAllocator;
+
+fn record_test_allocation() {
+    if COUNT_TEST_ALLOCATIONS.try_with(Cell::get).unwrap_or(false) {
+        TEST_ALLOCATIONS.fetch_add(1, AtomicOrdering::Relaxed);
+    }
+}
+
+unsafe impl GlobalAlloc for TestCountingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        record_test_allocation();
+        unsafe { System.alloc(layout) }
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        unsafe { System.dealloc(ptr, layout) }
+    }
+
+    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+        record_test_allocation();
+        unsafe { System.alloc_zeroed(layout) }
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        record_test_allocation();
+        unsafe { System.realloc(ptr, layout, new_size) }
+    }
+}
+
+#[global_allocator]
+static TEST_GLOBAL_ALLOCATOR: TestCountingAllocator = TestCountingAllocator;
+
+fn count_test_allocations(f: impl FnOnce()) -> usize {
+    COUNT_TEST_ALLOCATIONS.with(|enabled| {
+        enabled.set(false);
+        TEST_ALLOCATIONS.store(0, AtomicOrdering::Relaxed);
+        enabled.set(true);
+        f();
+        enabled.set(false);
+    });
+    TEST_ALLOCATIONS.load(AtomicOrdering::Relaxed)
+}
 
 fn snapshot() -> SkeletonSnapshot {
     SkeletonSnapshot::new(
@@ -94,6 +148,39 @@ fn sample_reconstructs_world_without_runtime_procedural_layers() {
         }
     }
     assert!((sample.morph_weights[0] - 0.5).abs() < 1.0e-6);
+}
+
+#[test]
+fn sample_into_reuses_scratch_without_allocating_and_matches_sample() {
+    let world = dense_world(7);
+    let morphs = [0.0, 0.2, 0.8, 0.3, 0.7, 0.9, 1.0];
+    let input = DensePoseSequenceView::new(&world, &morphs, 7, 2, 1, 0.0, 1.0).unwrap();
+    let reduced = reduce_dense_pose_sequence(
+        input,
+        snapshot(),
+        ReductionTolerances {
+            local_position: 0.01,
+            local_rotation_radians: 0.01,
+            world_position: 0.01,
+            world_rotation_radians: 0.01,
+            morph_weight: 0.01,
+        },
+        ReductionTarget::DccCubic,
+    )
+    .unwrap();
+    let expected = reduced.sample(2.5).unwrap();
+    let mut scratch = ReducedPoseScratch::default();
+    reduced.sample_into(2.5, &mut scratch).unwrap();
+
+    let allocations = count_test_allocations(|| {
+        reduced.sample_into(black_box(2.5), &mut scratch).unwrap();
+    });
+
+    assert_eq!(allocations, 0);
+    assert_eq!(scratch.local_translations, expected.local_translations);
+    assert_eq!(scratch.local_rotations, expected.local_rotations);
+    assert_eq!(scratch.world_matrices, expected.world_matrices);
+    assert_eq!(scratch.morph_weights, expected.morph_weights);
 }
 
 #[test]

--- a/crates/mmd-anim-runtime/src/reduce/tests.rs
+++ b/crates/mmd-anim-runtime/src/reduce/tests.rs
@@ -184,6 +184,52 @@ fn sample_into_reuses_scratch_without_allocating_and_matches_sample() {
 }
 
 #[test]
+fn reduction_work_stats_are_deterministic_and_separate_from_quality_report() {
+    let world = dense_world(7);
+    let morphs = [0.0, 0.2, 0.8, 0.3, 0.7, 0.9, 1.0];
+    let reduce = || {
+        reduce_dense_pose_sequence(
+            DensePoseSequenceView::new(&world, &morphs, 7, 2, 1, 0.0, 1.0).unwrap(),
+            snapshot(),
+            ReductionTolerances {
+                local_position: 0.01,
+                local_rotation_radians: 0.01,
+                world_position: 0.01,
+                world_rotation_radians: 0.01,
+                morph_weight: 0.01,
+            },
+            ReductionTarget::DccCubic,
+        )
+        .unwrap()
+    };
+
+    let first = reduce();
+    let second = reduce();
+    let stats = first.work_stats();
+    assert_eq!(stats, second.work_stats());
+    assert_eq!(first.report(), second.report());
+    assert_eq!(stats.candidate_rebuilds, stats.global_validation_passes);
+    assert_eq!(
+        stats.added_keys_per_pass.len(),
+        stats.global_validation_passes
+    );
+    assert_eq!(stats.added_keys_per_pass.last(), Some(&0));
+    assert_eq!(
+        stats.normal_key_additions + stats.ancestor_key_additions,
+        stats.added_keys_per_pass.iter().sum::<usize>()
+    );
+    assert_eq!(stats.bone_samples, stats.global_validation_passes * 7 * 2);
+    assert_eq!(stats.morph_samples, stats.global_validation_passes * 7);
+    assert_eq!(stats.world_rebuilds, stats.global_validation_passes * 7);
+    assert_eq!(
+        stats.world_rotation_decompositions,
+        (stats.global_validation_passes + 1) * 7 * 2
+    );
+    assert!(stats.dcc_bone_segment_fits > 0);
+    assert!(stats.dcc_morph_segment_fits > 0);
+}
+
+#[test]
 fn rejects_non_finite_scale_shear_and_invalid_time_base_atomically() {
     let mut non_finite = Mat4::IDENTITY;
     non_finite.x_axis.x = f32::NAN;

--- a/crates/mmd-anim-runtime/src/reduce/tests.rs
+++ b/crates/mmd-anim-runtime/src/reduce/tests.rs
@@ -1,0 +1,283 @@
+use glam::{Mat4, Quat, Vec3, Vec3A};
+
+use super::*;
+
+fn snapshot() -> SkeletonSnapshot {
+    SkeletonSnapshot::new(
+        vec![-1, 0],
+        vec![Vec3A::ZERO, Vec3A::X],
+        vec![Quat::IDENTITY; 2],
+        1,
+        42,
+    )
+    .unwrap()
+}
+
+fn dense_world(frame_count: usize) -> Vec<Mat4> {
+    let mut result = Vec::new();
+    for frame in 0..frame_count {
+        let root = Mat4::from_rotation_translation(
+            Quat::from_rotation_z(frame as f32 * 0.1),
+            Vec3::new(frame as f32, 0.0, 0.0),
+        );
+        result.push(root);
+        result.push(root * Mat4::from_translation(Vec3::X));
+    }
+    result
+}
+
+#[test]
+fn reduces_exact_linear_translation_and_constant_child_to_endpoints() {
+    let world = dense_world(5);
+    let morphs = [0.0, 0.25, 0.5, 0.75, 1.0];
+    let input = DensePoseSequenceView::new(&world, &morphs, 5, 2, 1, 0.0, 1.0).unwrap();
+    let reduced = reduce_dense_pose_sequence(
+        input,
+        snapshot(),
+        ReductionTolerances {
+            local_rotation_radians: 0.001,
+            world_rotation_radians: 0.001,
+            ..Default::default()
+        },
+        ReductionTarget::LinearSlerp,
+    )
+    .unwrap();
+    assert_eq!(reduced.bone_tracks()[0].keys().len(), 2);
+    assert_eq!(reduced.bone_tracks()[1].keys().len(), 2);
+    assert_eq!(reduced.morph_tracks()[0].keys().len(), 2);
+    assert!(reduced.report().max_world_position_error <= 1.0e-4);
+    assert_eq!(reduced.snapshot().model_identity(), 42);
+}
+
+#[test]
+fn deterministic_peak_split_keeps_the_peak() {
+    let world = [
+        Mat4::IDENTITY,
+        Mat4::from_translation(Vec3::Y),
+        Mat4::IDENTITY,
+    ];
+    let input = DensePoseSequenceView::new(&world, &[], 3, 1, 0, 0.0, 1.0).unwrap();
+    let snapshot =
+        SkeletonSnapshot::new(vec![-1], vec![Vec3A::ZERO], vec![Quat::IDENTITY], 0, 1).unwrap();
+    let reduced = reduce_dense_pose_sequence(
+        input,
+        snapshot,
+        Default::default(),
+        ReductionTarget::LinearSlerp,
+    )
+    .unwrap();
+    assert_eq!(
+        reduced.bone_tracks()[0]
+            .keys()
+            .iter()
+            .map(|key| key.sample_index)
+            .collect::<Vec<_>>(),
+        vec![0, 1, 2]
+    );
+}
+
+#[test]
+fn sample_reconstructs_world_without_runtime_procedural_layers() {
+    let world = dense_world(3);
+    let input = DensePoseSequenceView::new(&world, &[0.0, 0.5, 1.0], 3, 2, 1, 10.0, 0.5).unwrap();
+    let reduced = reduce_dense_pose_sequence(
+        input,
+        snapshot(),
+        Default::default(),
+        ReductionTarget::LinearSlerp,
+    )
+    .unwrap();
+    let sample = reduced.sample(10.5).unwrap();
+    for (actual, expected) in sample.world_matrices.iter().zip(&world[2..4]) {
+        for (a, e) in actual.to_cols_array().iter().zip(expected.to_cols_array()) {
+            assert!((a - e).abs() < 1.0e-4);
+        }
+    }
+    assert!((sample.morph_weights[0] - 0.5).abs() < 1.0e-6);
+}
+
+#[test]
+fn rejects_non_finite_scale_shear_and_invalid_time_base_atomically() {
+    let mut non_finite = Mat4::IDENTITY;
+    non_finite.x_axis.x = f32::NAN;
+    let non_finite_world = [non_finite];
+    let view = DensePoseSequenceView::new(&non_finite_world, &[], 1, 1, 0, 0.0, 1.0).unwrap();
+    let one =
+        SkeletonSnapshot::new(vec![-1], vec![Vec3A::ZERO], vec![Quat::IDENTITY], 0, 0).unwrap();
+    assert!(matches!(
+        reduce_dense_pose_sequence(
+            view,
+            one.clone(),
+            Default::default(),
+            ReductionTarget::LinearSlerp
+        ),
+        Err(PoseReductionError::NonFiniteMatrix { .. })
+    ));
+
+    let scaled = Mat4::from_scale(Vec3::new(2.0, 1.0, 1.0));
+    let scaled_world = [scaled];
+    let view = DensePoseSequenceView::new(&scaled_world, &[], 1, 1, 0, 0.0, 1.0).unwrap();
+    assert!(matches!(
+        reduce_dense_pose_sequence(view, one, Default::default(), ReductionTarget::LinearSlerp),
+        Err(PoseReductionError::ScaleOrShear { .. })
+    ));
+    assert_eq!(
+        DensePoseSequenceView::new(&[Mat4::IDENTITY], &[], 1, 1, 0, 0.0, 0.0).unwrap_err(),
+        PoseReductionError::InvalidTimeBase
+    );
+}
+
+#[test]
+fn rejects_snapshot_mismatch_and_hierarchy_cycles() {
+    let world = [Mat4::IDENTITY];
+    let input = DensePoseSequenceView::new(&world, &[], 1, 1, 0, 0.0, 1.0).unwrap();
+    assert!(matches!(
+        reduce_dense_pose_sequence(
+            input,
+            snapshot(),
+            Default::default(),
+            ReductionTarget::LinearSlerp
+        ),
+        Err(PoseReductionError::SnapshotMismatch)
+    ));
+    assert!(matches!(
+        SkeletonSnapshot::new(
+            vec![1, 0],
+            vec![Vec3A::ZERO; 2],
+            vec![Quat::IDENTITY; 2],
+            0,
+            0
+        ),
+        Err(PoseReductionError::SkeletonCycle { .. })
+    ));
+}
+
+#[test]
+fn independent_dense_inputs_produce_identical_results() {
+    let world_a = dense_world(7);
+    let world_b = dense_world(7);
+    let morphs = vec![0.0; 7];
+    let reduce = |world: &[Mat4]| {
+        reduce_dense_pose_sequence(
+            DensePoseSequenceView::new(world, &morphs, 7, 2, 1, 0.0, 1.0).unwrap(),
+            snapshot(),
+            Default::default(),
+            ReductionTarget::LinearSlerp,
+        )
+        .unwrap()
+    };
+    assert_eq!(reduce(&world_a), reduce(&world_b));
+}
+
+#[test]
+fn preserves_physics_seed_sample_as_the_first_endpoint() {
+    let world = [
+        Mat4::from_translation(Vec3::new(3.0, 4.0, 5.0)),
+        Mat4::from_translation(Vec3::new(3.0, 3.5, 5.0)),
+        Mat4::from_translation(Vec3::new(3.0, 3.0, 5.0)),
+    ];
+    let input = DensePoseSequenceView::new(&world, &[], 3, 1, 0, 12.0, 1.0).unwrap();
+    let one =
+        SkeletonSnapshot::new(vec![-1], vec![Vec3A::ZERO], vec![Quat::IDENTITY], 0, 7).unwrap();
+    let reduced =
+        reduce_dense_pose_sequence(input, one, Default::default(), ReductionTarget::LinearSlerp)
+            .unwrap();
+    let seed = reduced.sample(12.0).unwrap();
+    assert_eq!(seed.world_matrices[0], world[0]);
+    assert_eq!(reduced.bone_tracks()[0].keys()[0].sample_index, 0);
+}
+
+#[test]
+fn impossible_zero_tolerance_returns_instead_of_looping() {
+    let world = dense_world(5);
+    let input = DensePoseSequenceView::new(&world, &[], 5, 2, 0, 0.0, 1.0).unwrap();
+    let zero = ReductionTolerances {
+        local_position: 0.0,
+        local_rotation_radians: 0.0,
+        world_position: 0.0,
+        world_rotation_radians: 0.0,
+        morph_weight: 0.0,
+    };
+    let zero_morph_snapshot = SkeletonSnapshot::new(
+        vec![-1, 0],
+        vec![Vec3A::ZERO, Vec3A::X],
+        vec![Quat::IDENTITY; 2],
+        0,
+        42,
+    )
+    .unwrap();
+    assert!(matches!(
+        reduce_dense_pose_sequence(
+            input,
+            zero_morph_snapshot,
+            zero,
+            ReductionTarget::LinearSlerp
+        ),
+        Err(PoseReductionError::ToleranceUnattainable { .. })
+    ));
+}
+
+#[test]
+fn rejects_time_base_whose_adjacent_f32_samples_collapse() {
+    let world = [Mat4::IDENTITY; 2];
+    assert_eq!(
+        DensePoseSequenceView::new(&world, &[], 2, 1, 0, 16_777_216.0, 1.0).unwrap_err(),
+        PoseReductionError::InvalidTimeBase
+    );
+}
+
+#[test]
+fn large_start_frame_samples_by_stored_f32_timestamps() {
+    let world = [
+        Mat4::IDENTITY,
+        Mat4::from_translation(Vec3::Y),
+        Mat4::IDENTITY,
+    ];
+    let start = 1_000_000.0f32;
+    let step = 0.1f32;
+    let input = DensePoseSequenceView::new(&world, &[], 3, 1, 0, start, step).unwrap();
+    let one =
+        SkeletonSnapshot::new(vec![-1], vec![Vec3A::ZERO], vec![Quat::IDENTITY], 0, 9).unwrap();
+    let reduced =
+        reduce_dense_pose_sequence(input, one, Default::default(), ReductionTarget::LinearSlerp)
+            .unwrap();
+    let middle_frame = start + step;
+    let sample = reduced.sample(middle_frame).unwrap();
+    assert_eq!(sample.world_matrices[0], world[1]);
+}
+
+#[test]
+fn custom_tolerance_changes_key_count_and_bounds_report() {
+    let world = [
+        Mat4::IDENTITY,
+        Mat4::from_translation(Vec3::new(0.0, 0.5, 0.0)),
+        Mat4::IDENTITY,
+    ];
+    let make = |position_tolerance| {
+        let input = DensePoseSequenceView::new(&world, &[], 3, 1, 0, 0.0, 1.0).unwrap();
+        let one = SkeletonSnapshot::new(vec![-1], vec![Vec3A::ZERO], vec![Quat::IDENTITY], 0, 10)
+            .unwrap();
+        reduce_dense_pose_sequence(
+            input,
+            one,
+            ReductionTolerances {
+                local_position: position_tolerance,
+                world_position: position_tolerance,
+                ..Default::default()
+            },
+            ReductionTarget::LinearSlerp,
+        )
+        .unwrap()
+    };
+    let loose = make(1.0);
+    let strict = make(0.1);
+    assert_eq!(loose.bone_tracks()[0].keys().len(), 2);
+    assert_eq!(strict.bone_tracks()[0].keys().len(), 3);
+    assert!(loose.report().max_local_position_error <= 1.0);
+    assert!(loose.report().max_world_position_error <= 1.0);
+    assert!(strict.report().max_local_position_error <= 0.1);
+    assert!(strict.report().max_world_position_error <= 0.1);
+    assert!(strict.report().max_local_rotation_error_radians <= 1.0e-4);
+    assert!(strict.report().max_world_rotation_error_radians <= 1.0e-4);
+    assert!(strict.report().max_morph_weight_error <= 1.0e-4);
+}

--- a/crates/mmd-anim-wasm/harness/smoke.mjs
+++ b/crates/mmd-anim-wasm/harness/smoke.mjs
@@ -207,6 +207,36 @@ assert(batch.copyWorldMatrices(new Float32Array(95)) === false, 'batch copyWorld
 runtime.copyWorldMatrices(buf);
 assertClose(buf[12], 2.0, 1e-6, 'batch evaluation does not mutate source runtime frame');
 
+console.log('\n7c. reduced pose handle parity, lifetime, short buffer, and free');
+const reductionArgs = [0, 1e-4, 1e-4, 1e-4, 1e-4, 1e-4];
+const batchReduced = batch.reducePose(...reductionArgs);
+const hostReduced = wasm.reduceDensePose(
+  model,
+  batchWorld,
+  new Float32Array([]),
+  3,
+  0.0,
+  30.0,
+  ...reductionArgs,
+);
+assert(batchReduced.reducedBoneKeyCount() === 4, 'batch reduced pose keeps two keys per bone');
+assert(hostReduced.reducedBoneKeyCount() === 4, 'host dense reduced pose keeps two keys per bone');
+batch.free();
+model.free();
+const reducedWorldA = new Float32Array(32);
+const reducedWorldB = new Float32Array(32);
+assert(batchReduced.sample(30.0, reducedWorldA, new Float32Array([])) === true,
+  'batch reduced result samples after batch/model free');
+assert(hostReduced.sample(30.0, reducedWorldB, new Float32Array([])) === true,
+  'host reduced result samples after model free');
+assert(batchReduced.sample(30.0, new Float32Array(31), new Float32Array([])) === false,
+  'reduced pose sample rejects short buffer');
+assert(reducedWorldA.every((value, index) => value === reducedWorldB[index]),
+  'batch and host dense reduced samplers have parity');
+assertClose(reducedWorldA[12], 2.0, 1e-6, 'reduced pose frame 30 bone 0 world x = 2.0');
+batchReduced.free();
+hostReduced.free();
+
 console.log('\n8. skinningMatricesView()');
 const skinView = runtime.skinningMatricesView();
 assert(skinView instanceof Float32Array, 'skinningMatricesView returns Float32Array');
@@ -241,6 +271,11 @@ assert(vmdJson.kind === 'vmd', 'parseVmdAnimationJson returns VMD DTO kind');
 assert(vmdJson.metadata.format === 'vmd', 'parseVmdAnimationJson metadata.format === vmd');
 assert(vmdJson.boneFrames.length === 0, 'parseVmdAnimationJson bone frame count === 0');
 assert(vmdJson.metadata.counts.bones === 0, 'parseVmdAnimationJson metadata.counts.bones === 0');
+
+clip.free();
+runtime.free();
+runtime2.free();
+model2.free();
 
 console.log(`\n=== Results: ${passed} passed, ${failed} failed ===`);
 if (failed > 0) process.exit(1);

--- a/crates/mmd-anim-wasm/src/lib.rs
+++ b/crates/mmd-anim-wasm/src/lib.rs
@@ -8,9 +8,10 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use mmd_anim_runtime::{
-    AnimationClip, BoneAnimationBinding, BoneIndex, FlatModelInputError, IkSolveOptions,
-    MorphAnimationBinding, MorphIndex, MorphInit, MorphKeyframe, MorphTrack, MovableBoneKeyframe,
-    MovableBoneTrack, PropertyAnimationBinding, PropertyKeyframe, RuntimeInstance,
+    AnimationClip, BoneAnimationBinding, BoneIndex, DensePoseSequenceView, FlatModelInputError,
+    IkSolveOptions, MorphAnimationBinding, MorphIndex, MorphInit, MorphKeyframe, MorphTrack,
+    MovableBoneKeyframe, MovableBoneTrack, PropertyAnimationBinding, PropertyKeyframe,
+    ReducedPoseSequence, ReductionTarget, ReductionTolerances, RuntimeInstance, SkeletonSnapshot,
 };
 use mmd_anim_runtime::{
     FlatAppendTransformInput, FlatBoneInput, FlatBoneMorphInput, FlatGroupMorphInput,
@@ -976,11 +977,210 @@ impl WasmMmdRuntimeInstance {
 
 #[wasm_bindgen]
 pub struct WasmMmdRuntimeBatchEvaluation {
+    model: Arc<ModelArena>,
+    start_frame: f32,
+    frame_step: f32,
     frame_count: usize,
     bone_count: usize,
     morph_count: usize,
     world_matrices: Vec<f32>,
     morph_weights: Vec<f32>,
+}
+
+#[wasm_bindgen]
+pub struct WasmReducedPoseResult {
+    sequence: ReducedPoseSequence,
+}
+
+fn wasm_reduction_target(value: u32) -> Result<ReductionTarget, String> {
+    match value {
+        0 => Ok(ReductionTarget::LinearSlerp),
+        1 => Ok(ReductionTarget::VmdBezier),
+        2 => Ok(ReductionTarget::DccCubic),
+        _ => Err("target must be 0 (LinearSlerp), 1 (VmdBezier), or 2 (DccCubic)".to_owned()),
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn reduce_dense_pose_inner(
+    model: &ModelArena,
+    world_matrices_f32: &[f32],
+    morph_weights: &[f32],
+    frame_count: usize,
+    start_frame: f32,
+    frame_step: f32,
+    target: u32,
+    local_position_tolerance: f32,
+    local_rotation_tolerance: f32,
+    world_position_tolerance: f32,
+    world_rotation_tolerance: f32,
+    morph_weight_tolerance: f32,
+) -> Result<ReducedPoseSequence, String> {
+    let bone_count = model.bone_count();
+    if frame_count == 0 || !morph_weights.len().is_multiple_of(frame_count) {
+        return Err("morph weight length must be divisible by frame count".to_owned());
+    }
+    let morph_count = morph_weights.len() / frame_count;
+    let required_world_len = frame_count
+        .checked_mul(bone_count)
+        .and_then(|len| len.checked_mul(16))
+        .ok_or_else(|| "dense world matrix length overflow".to_owned())?;
+    let required_morph_len = frame_count
+        .checked_mul(morph_count)
+        .ok_or_else(|| "dense morph weight length overflow".to_owned())?;
+    if world_matrices_f32.len() != required_world_len || morph_weights.len() != required_morph_len {
+        return Err("dense pose buffer length does not match model and frame count".to_owned());
+    }
+    let world_matrices = world_matrices_f32
+        .chunks_exact(16)
+        .map(glam::Mat4::from_cols_slice)
+        .collect::<Vec<_>>();
+    let dense = DensePoseSequenceView::new(
+        &world_matrices,
+        morph_weights,
+        frame_count,
+        bone_count,
+        morph_count,
+        start_frame,
+        frame_step,
+    )
+    .map_err(|error| error.to_string())?;
+    let snapshot = SkeletonSnapshot::from_model_with_morph_count(model, 0, morph_count)
+        .map_err(|error| error.to_string())?;
+    mmd_anim_runtime::reduce_dense_pose_sequence(
+        dense,
+        snapshot,
+        ReductionTolerances {
+            local_position: local_position_tolerance,
+            local_rotation_radians: local_rotation_tolerance,
+            world_position: world_position_tolerance,
+            world_rotation_radians: world_rotation_tolerance,
+            morph_weight: morph_weight_tolerance,
+        },
+        wasm_reduction_target(target)?,
+    )
+    .map_err(|error| error.to_string())
+}
+
+/// Reduces host-provided dense pose buffers without assuming a native physics API.
+#[wasm_bindgen(js_name = reduceDensePose)]
+#[allow(clippy::too_many_arguments)]
+pub fn reduce_dense_pose(
+    model: &WasmMmdModel,
+    world_matrices_f32: &[f32],
+    morph_weights: &[f32],
+    frame_count: usize,
+    start_frame: f32,
+    frame_step: f32,
+    target: u32,
+    local_position_tolerance: f32,
+    local_rotation_tolerance: f32,
+    world_position_tolerance: f32,
+    world_rotation_tolerance: f32,
+    morph_weight_tolerance: f32,
+) -> Result<WasmReducedPoseResult, JsValue> {
+    reduce_dense_pose_inner(
+        &model.model,
+        world_matrices_f32,
+        morph_weights,
+        frame_count,
+        start_frame,
+        frame_step,
+        target,
+        local_position_tolerance,
+        local_rotation_tolerance,
+        world_position_tolerance,
+        world_rotation_tolerance,
+        morph_weight_tolerance,
+    )
+    .map(|sequence| WasmReducedPoseResult { sequence })
+    .map_err(|error| JsValue::from_str(&error))
+}
+
+#[wasm_bindgen]
+impl WasmReducedPoseResult {
+    #[wasm_bindgen(js_name = boneCount)]
+    pub fn bone_count(&self) -> usize {
+        self.sequence.snapshot().bone_count()
+    }
+
+    #[wasm_bindgen(js_name = morphCount)]
+    pub fn morph_count(&self) -> usize {
+        self.sequence.snapshot().morph_count()
+    }
+
+    #[wasm_bindgen(js_name = reducedBoneKeyCount)]
+    pub fn reduced_bone_key_count(&self) -> usize {
+        self.sequence.report().reduced_bone_key_count
+    }
+
+    #[wasm_bindgen(js_name = sourceBoneKeyCount)]
+    pub fn source_bone_key_count(&self) -> usize {
+        self.sequence.report().source_bone_key_count
+    }
+
+    #[wasm_bindgen(js_name = reducedMorphKeyCount)]
+    pub fn reduced_morph_key_count(&self) -> usize {
+        self.sequence.report().reduced_morph_key_count
+    }
+
+    #[wasm_bindgen(js_name = sourceMorphKeyCount)]
+    pub fn source_morph_key_count(&self) -> usize {
+        self.sequence.report().source_morph_key_count
+    }
+
+    #[wasm_bindgen(js_name = maxLocalPositionError)]
+    pub fn max_local_position_error(&self) -> f32 {
+        self.sequence.report().max_local_position_error
+    }
+
+    #[wasm_bindgen(js_name = maxLocalRotationErrorRadians)]
+    pub fn max_local_rotation_error_radians(&self) -> f32 {
+        self.sequence.report().max_local_rotation_error_radians
+    }
+
+    #[wasm_bindgen(js_name = maxWorldPositionError)]
+    pub fn max_world_position_error(&self) -> f32 {
+        self.sequence.report().max_world_position_error
+    }
+
+    #[wasm_bindgen(js_name = maxWorldRotationErrorRadians)]
+    pub fn max_world_rotation_error_radians(&self) -> f32 {
+        self.sequence.report().max_world_rotation_error_radians
+    }
+
+    #[wasm_bindgen(js_name = maxMorphWeightError)]
+    pub fn max_morph_weight_error(&self) -> f32 {
+        self.sequence.report().max_morph_weight_error
+    }
+
+    #[wasm_bindgen(js_name = sample)]
+    pub fn sample(
+        &self,
+        frame: f32,
+        out_world_matrices_f32: &mut [f32],
+        out_morph_weights: &mut [f32],
+    ) -> Result<bool, JsValue> {
+        let required_world_len = self.bone_count() * 16;
+        let required_morph_len = self.morph_count();
+        if out_world_matrices_f32.len() < required_world_len
+            || out_morph_weights.len() < required_morph_len
+        {
+            return Ok(false);
+        }
+        let sample = self
+            .sequence
+            .sample(frame)
+            .map_err(|error| JsValue::from_str(&error.to_string()))?;
+        for (out, matrix) in out_world_matrices_f32[..required_world_len]
+            .chunks_exact_mut(16)
+            .zip(&sample.world_matrices)
+        {
+            out.copy_from_slice(&matrix.to_cols_array());
+        }
+        out_morph_weights[..required_morph_len].copy_from_slice(&sample.morph_weights);
+        Ok(true)
+    }
 }
 
 #[wasm_bindgen]
@@ -1046,6 +1246,35 @@ impl WasmMmdRuntimeBatchEvaluation {
         }
         out[..self.morph_weights.len()].copy_from_slice(&self.morph_weights);
         true
+    }
+
+    #[wasm_bindgen(js_name = reducePose)]
+    #[allow(clippy::too_many_arguments)]
+    pub fn reduce_pose(
+        &self,
+        target: u32,
+        local_position_tolerance: f32,
+        local_rotation_tolerance: f32,
+        world_position_tolerance: f32,
+        world_rotation_tolerance: f32,
+        morph_weight_tolerance: f32,
+    ) -> Result<WasmReducedPoseResult, JsValue> {
+        reduce_dense_pose_inner(
+            &self.model,
+            &self.world_matrices,
+            &self.morph_weights,
+            self.frame_count,
+            self.start_frame,
+            self.frame_step,
+            target,
+            local_position_tolerance,
+            local_rotation_tolerance,
+            world_position_tolerance,
+            world_rotation_tolerance,
+            morph_weight_tolerance,
+        )
+        .map(|sequence| WasmReducedPoseResult { sequence })
+        .map_err(|error| JsValue::from_str(&error))
     }
 }
 
@@ -1205,6 +1434,9 @@ impl WasmMmdRuntimeInstance {
         }
 
         Ok(WasmMmdRuntimeBatchEvaluation {
+            model: Arc::clone(&self.model),
+            start_frame,
+            frame_step,
             frame_count,
             bone_count,
             morph_count,
@@ -2542,6 +2774,74 @@ TextureFilename { "tex/main.png"; }
 
         assert_eq!(runtime.world_matrices(), source_world_before);
         assert_eq!(runtime.morph_weights(), source_morph_before);
+    }
+
+    #[test]
+    fn reduced_pose_batch_and_host_dense_samplers_have_parity() {
+        let model = WasmMmdModel::new(&[-1], &[0.0, 0.0, 0.0]).unwrap();
+        let clip = WasmMmdClip::new(
+            &[0, 0, 2],
+            &[0, 60],
+            &[
+                0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 2.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0,
+            ],
+            &[0, 0, 2],
+            &[0, 60],
+            &[0.0, 1.0],
+            &[],
+            &[],
+            0,
+        )
+        .unwrap();
+        let runtime = WasmMmdRuntimeInstance::new(&model, 1);
+        let batch = runtime
+            .evaluate_clip_frame_batch(&clip, 0.0, 30.0, 3, 0)
+            .unwrap();
+        let from_batch = batch
+            .reduce_pose(0, 1.0e-4, 1.0e-4, 1.0e-4, 1.0e-4, 1.0e-4)
+            .unwrap();
+        let from_host = reduce_dense_pose(
+            &model,
+            &batch.world_matrices,
+            &batch.morph_weights,
+            3,
+            0.0,
+            30.0,
+            0,
+            1.0e-4,
+            1.0e-4,
+            1.0e-4,
+            1.0e-4,
+            1.0e-4,
+        )
+        .unwrap();
+        assert_eq!(from_batch.reduced_bone_key_count(), 2);
+        assert_eq!(from_host.reduced_bone_key_count(), 2);
+        assert_eq!(from_batch.reduced_morph_key_count(), 2);
+
+        let mut batch_world = [0.0_f32; 16];
+        let mut host_world = [0.0_f32; 16];
+        let mut batch_morph = [0.0_f32; 1];
+        let mut host_morph = [0.0_f32; 1];
+        assert!(
+            from_batch
+                .sample(30.0, &mut batch_world, &mut batch_morph)
+                .unwrap()
+        );
+        assert!(
+            from_host
+                .sample(30.0, &mut host_world, &mut host_morph)
+                .unwrap()
+        );
+        assert_eq!(batch_world, host_world);
+        assert_eq!(batch_morph, host_morph);
+        assert!((batch_world[12] - 1.0).abs() < 1.0e-5);
+        assert!((batch_morph[0] - 0.5).abs() < 1.0e-5);
+        assert!(
+            !from_batch
+                .sample(30.0, &mut [0.0; 15], &mut [0.0; 1])
+                .unwrap()
+        );
     }
 
     #[test]

--- a/tools/check_ffi_header_symbols.py
+++ b/tools/check_ffi_header_symbols.py
@@ -15,6 +15,10 @@ RUST_NO_MANGLE_RE = re.compile(r"#\[\s*(?:unsafe\s*\(\s*)?no_mangle\s*\)?\s*\]")
 RUST_FN_RE = re.compile(r"fn\s+(mmd_runtime_\w+)\s*\(")
 HEADER_FN_RE = re.compile(r"\b(mmd_runtime_\w+)\s*\(")
 
+FORBIDDEN_DENSE_REDUCED_POSE_SYMBOLS = {
+    "mmd_runtime_reduced_pose_sample",
+}
+
 UNITY_CONSTANTS = {
     "MMD_RUNTIME_UNITY_CURVE_BONE_LOCAL_TRANSLATION": 0,
     "MMD_RUNTIME_UNITY_CURVE_BONE_LOCAL_EULER": 1,
@@ -252,9 +256,11 @@ def main() -> int:
 
     missing_in_header = sorted(rust_symbols - header_symbols)
     missing_in_rust = sorted(header_symbols - rust_symbols)
+    forbidden_in_rust = sorted(FORBIDDEN_DENSE_REDUCED_POSE_SYMBOLS & rust_symbols)
+    forbidden_in_header = sorted(FORBIDDEN_DENSE_REDUCED_POSE_SYMBOLS & header_symbols)
     shape_errors = check_unity_abi_shapes(rust_text, header_text)
 
-    if missing_in_header or missing_in_rust or shape_errors:
+    if missing_in_header or missing_in_rust or forbidden_in_rust or forbidden_in_header or shape_errors:
         print("FFI header symbol mismatch detected.", file=sys.stderr)
         if missing_in_header:
             print("\nExported in Rust but missing from mmd_runtime.h:", file=sys.stderr)
@@ -263,6 +269,10 @@ def main() -> int:
         if missing_in_rust:
             print("\nDeclared in mmd_runtime.h but missing from Rust exports:", file=sys.stderr)
             for symbol in missing_in_rust:
+                print(f"  - {symbol}", file=sys.stderr)
+        if forbidden_in_rust or forbidden_in_header:
+            print("\nDense reduced-pose output must not be public:", file=sys.stderr)
+            for symbol in sorted(set(forbidden_in_rust + forbidden_in_header)):
                 print(f"  - {symbol}", file=sys.stderr)
         if shape_errors:
             print("\nUnity reduced-curve ABI shape drift:", file=sys.stderr)

--- a/tools/check_ffi_header_symbols.py
+++ b/tools/check_ffi_header_symbols.py
@@ -15,6 +15,71 @@ RUST_NO_MANGLE_RE = re.compile(r"#\[\s*(?:unsafe\s*\(\s*)?no_mangle\s*\)?\s*\]")
 RUST_FN_RE = re.compile(r"fn\s+(mmd_runtime_\w+)\s*\(")
 HEADER_FN_RE = re.compile(r"\b(mmd_runtime_\w+)\s*\(")
 
+UNITY_CONSTANTS = {
+    "MMD_RUNTIME_UNITY_CURVE_BONE_LOCAL_TRANSLATION": 0,
+    "MMD_RUNTIME_UNITY_CURVE_BONE_LOCAL_EULER": 1,
+    "MMD_RUNTIME_UNITY_CURVE_MORPH_WEIGHT": 2,
+    "MMD_RUNTIME_UNITY_CURVE_AXIS_X": 0,
+    "MMD_RUNTIME_UNITY_CURVE_AXIS_Y": 1,
+    "MMD_RUNTIME_UNITY_CURVE_AXIS_Z": 2,
+    "MMD_RUNTIME_UNITY_CURVE_AXIS_NONE": 3,
+}
+
+UNITY_STRUCTS = {
+    "MmdRuntimeFfiUnityCurveDescriptor": (
+        "mmd_runtime_ffi_unity_curve_descriptor_t",
+        [
+            ("semantic", "u32"),
+            ("target_index", "u32"),
+            ("axis", "u32"),
+            ("key_count", "usize"),
+        ],
+    ),
+    "MmdRuntimeFfiUnityCurveKey": (
+        "mmd_runtime_ffi_unity_curve_key_t",
+        [
+            ("time_seconds", "f32"),
+            ("value", "f32"),
+            ("in_tangent", "f32"),
+            ("out_tangent", "f32"),
+        ],
+    ),
+}
+
+UNITY_FUNCTIONS = {
+    "mmd_runtime_reduced_pose_unity_curve_count": (
+        "status",
+        [
+            ("pose", "const_reduced_pose_ptr"),
+            ("frames_per_second", "f32"),
+            ("flip_z", "bool"),
+            ("out_curve_count", "usize_ptr"),
+        ],
+    ),
+    "mmd_runtime_reduced_pose_unity_curve_descriptor": (
+        "status",
+        [
+            ("pose", "const_reduced_pose_ptr"),
+            ("frames_per_second", "f32"),
+            ("flip_z", "bool"),
+            ("curve_index", "usize"),
+            ("out_descriptor", "unity_descriptor_ptr"),
+        ],
+    ),
+    "mmd_runtime_reduced_pose_unity_curve_keys": (
+        "status",
+        [
+            ("pose", "const_reduced_pose_ptr"),
+            ("frames_per_second", "f32"),
+            ("flip_z", "bool"),
+            ("curve_index", "usize"),
+            ("out_keys", "unity_key_ptr"),
+            ("out_key_capacity", "usize"),
+            ("out_required_count", "usize_ptr"),
+        ],
+    ),
+}
+
 
 def rust_exported_symbols(text: str) -> set[str]:
     lines = text.splitlines()
@@ -51,6 +116,133 @@ def header_declared_symbols(text: str) -> set[str]:
     return set(HEADER_FN_RE.findall(compact))
 
 
+def strip_c_comments(text: str) -> str:
+    text = re.sub(r"/\*.*?\*/", "", text, flags=re.DOTALL)
+    return re.sub(r"//.*?$", "", text, flags=re.MULTILINE)
+
+
+def canonical_rust_type(type_name: str) -> str:
+    compact = " ".join(type_name.split())
+    return {
+        "u32": "u32",
+        "usize": "usize",
+        "f32": "f32",
+        "bool": "bool",
+        "MmdRuntimeStatus": "status",
+        "*const MmdRuntimeReducedPose": "const_reduced_pose_ptr",
+        "*mut usize": "usize_ptr",
+        "*mut MmdRuntimeFfiUnityCurveDescriptor": "unity_descriptor_ptr",
+        "*mut MmdRuntimeFfiUnityCurveKey": "unity_key_ptr",
+    }.get(compact, compact)
+
+
+def canonical_c_type(type_name: str) -> str:
+    compact = re.sub(r"\s*\*\s*", "*", " ".join(type_name.split()))
+    return {
+        "uint32_t": "u32",
+        "size_t": "usize",
+        "float": "f32",
+        "bool": "bool",
+        "mmd_runtime_status_t": "status",
+        "const mmd_runtime_reduced_pose_t*": "const_reduced_pose_ptr",
+        "size_t*": "usize_ptr",
+        "mmd_runtime_ffi_unity_curve_descriptor_t*": "unity_descriptor_ptr",
+        "mmd_runtime_ffi_unity_curve_key_t*": "unity_key_ptr",
+    }.get(compact, compact)
+
+
+def rust_struct_fields(text: str, name: str) -> list[tuple[str, str]]:
+    match = re.search(rf"pub struct {re.escape(name)}\s*\{{(.*?)\n\}}", text, re.DOTALL)
+    if match is None:
+        raise ValueError(f"missing Rust struct {name}")
+    return [
+        (field, canonical_rust_type(type_name))
+        for field, type_name in re.findall(r"pub\s+(\w+)\s*:\s*([^,]+),", match.group(1))
+    ]
+
+
+def c_struct_fields(text: str, alias: str) -> list[tuple[str, str]]:
+    stripped = strip_c_comments(text)
+    tag = alias.removesuffix("_t")
+    match = re.search(
+        rf"typedef struct\s+{re.escape(tag)}\s*\{{(.*?)\}}\s*{re.escape(alias)}\s*;",
+        stripped,
+        re.DOTALL,
+    )
+    if match is None:
+        raise ValueError(f"missing C struct {alias}")
+    fields: list[tuple[str, str]] = []
+    for declaration in match.group(1).split(";"):
+        declaration = declaration.strip()
+        if not declaration:
+            continue
+        field_match = re.fullmatch(r"(.+?)\s+(\w+)", declaration)
+        if field_match is None:
+            raise ValueError(f"could not parse C field in {alias}: {declaration!r}")
+        fields.append((field_match.group(2), canonical_c_type(field_match.group(1))))
+    return fields
+
+
+def rust_function_shape(text: str, name: str) -> tuple[str, list[tuple[str, str]]]:
+    match = re.search(
+        rf'pub unsafe extern "C" fn {re.escape(name)}\s*\((.*?)\)\s*->\s*(\w+)',
+        text,
+        re.DOTALL,
+    )
+    if match is None:
+        raise ValueError(f"missing Rust function {name}")
+    params = [
+        (param_name, canonical_rust_type(type_name))
+        for param_name, type_name in re.findall(r"(\w+)\s*:\s*([^,]+),?", match.group(1))
+    ]
+    return canonical_rust_type(match.group(2)), params
+
+
+def c_function_shape(text: str, name: str) -> tuple[str, list[tuple[str, str]]]:
+    stripped = strip_c_comments(text)
+    match = re.search(
+        rf"(\w+)\s+{re.escape(name)}\s*\((.*?)\)\s*;", stripped, re.DOTALL
+    )
+    if match is None:
+        raise ValueError(f"missing C function {name}")
+    params: list[tuple[str, str]] = []
+    for declaration in match.group(2).split(","):
+        declaration = declaration.strip()
+        param_match = re.fullmatch(r"(.+?[\s*])(\w+)", declaration)
+        if param_match is None:
+            raise ValueError(f"could not parse C parameter in {name}: {declaration!r}")
+        params.append((param_match.group(2), canonical_c_type(param_match.group(1))))
+    return canonical_c_type(match.group(1)), params
+
+
+def check_unity_abi_shapes(rust_text: str, header_text: str) -> list[str]:
+    errors: list[str] = []
+    for name, expected in UNITY_CONSTANTS.items():
+        rust_match = re.search(rf"pub const {name}: u32 = (\d+);", rust_text)
+        header_match = re.search(rf"\b{name}\s*=\s*(\d+)", header_text)
+        rust_value = int(rust_match.group(1)) if rust_match else None
+        header_value = int(header_match.group(1)) if header_match else None
+        if rust_value != expected or header_value != expected or rust_value != header_value:
+            errors.append(
+                f"constant {name}: Rust={rust_value}, header={header_value}, expected={expected}"
+            )
+    for rust_name, (c_alias, expected) in UNITY_STRUCTS.items():
+        rust_fields = rust_struct_fields(rust_text, rust_name)
+        c_fields = c_struct_fields(header_text, c_alias)
+        if rust_fields != expected or c_fields != expected or rust_fields != c_fields:
+            errors.append(
+                f"struct {rust_name}/{c_alias}: Rust={rust_fields}, header={c_fields}, expected={expected}"
+            )
+    for name, expected in UNITY_FUNCTIONS.items():
+        rust_shape = rust_function_shape(rust_text, name)
+        c_shape = c_function_shape(header_text, name)
+        if rust_shape != expected or c_shape != expected or rust_shape != c_shape:
+            errors.append(
+                f"function {name}: Rust={rust_shape}, header={c_shape}, expected={expected}"
+            )
+    return errors
+
+
 def main() -> int:
     rust_text = LIB_RS.read_text(encoding="utf-8")
     header_text = HEADER.read_text(encoding="utf-8")
@@ -60,8 +252,9 @@ def main() -> int:
 
     missing_in_header = sorted(rust_symbols - header_symbols)
     missing_in_rust = sorted(header_symbols - rust_symbols)
+    shape_errors = check_unity_abi_shapes(rust_text, header_text)
 
-    if missing_in_header or missing_in_rust:
+    if missing_in_header or missing_in_rust or shape_errors:
         print("FFI header symbol mismatch detected.", file=sys.stderr)
         if missing_in_header:
             print("\nExported in Rust but missing from mmd_runtime.h:", file=sys.stderr)
@@ -71,10 +264,15 @@ def main() -> int:
             print("\nDeclared in mmd_runtime.h but missing from Rust exports:", file=sys.stderr)
             for symbol in missing_in_rust:
                 print(f"  - {symbol}", file=sys.stderr)
+        if shape_errors:
+            print("\nUnity reduced-curve ABI shape drift:", file=sys.stderr)
+            for error in shape_errors:
+                print(f"  - {error}", file=sys.stderr)
         return 1
 
     print(
-        f"OK: {len(rust_symbols)} Rust FFI exports match mmd_runtime.h declarations."
+        f"OK: {len(rust_symbols)} Rust FFI exports and Unity curve ABI shapes "
+        "match mmd_runtime.h declarations."
     )
     return 0
 


### PR DESCRIPTION
## Summary
- Add target-aware dense pose reduction for Linear/Slerp, quantized VMD Bezier, and broken per-segment DCC cubic curves.
- Export reduced VMD/FBX curves and expose opaque reduced-pose plus sparse Unity curve enumeration through C ABI and WASM.
- Add `reduce-vmd`, FBX skin diagnostics, and physics-baked reduced FBX CLI paths.
- Stabilize quaternion angular-distance measurement for tight tolerances, including static VMD track detection, and add a 301-frame multi-bone Rabbit Hole-like regression gate.
- Apply `cargo fmt --all` to the full PR diff.

## Validation
- `python tools/check_ffi_header_symbols.py` — PASS (164 Rust FFI exports and Unity curve ABI shapes match).
- `cargo fmt --all -- --check` — PASS.
- `cargo clippy --workspace --all-targets -- -D warnings` — PASS.
- `cargo test --workspace` — PASS (736 passed, 2 ignored).
- Sour式初音ミク White + ラビットホール, native Bullet physics bake, 300 frames, DCC reduced pose, rotation tolerance `0.0001 rad` — PASS in 2.354 s; max local/world rotation error `9.985e-5 / 9.992e-5 rad`.
- Dense VMD smoke across 10 lightweight assets — PASS 10/10; 131,396 → 93,412 bone/morph keys (28.9% reduction), total 1.431 s.

## Notes
- Physics bake remains opt-in because it is intentionally more expensive than non-physics reduction.
- Real MMD assets are local-only; the committed regression gate is a deterministic 301-frame, 12-bone dense-chain equivalent.