### PR TITLE
feat: add experimental low-level Python runtime bridge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,3 +40,28 @@ jobs:
         run: |
           cargo check -p mmd-anim-physics-bullet --no-default-features
           cargo test -p mmd-anim-cli -p mmd-anim-ffi --no-default-features
+
+  python-ffi:
+    name: Python FFI (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
+
+      - name: Check Python ABI drift
+        run: python tools/check_python_abi_drift.py
+
+      - name: Build release C ABI library
+        run: cargo build -p mmd-anim-ffi --release
+
+      - name: Run Python binding tests with native library
+        run: python -m unittest discover -s bindings/python/tests -v

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,38 @@
 # Changelog
 
+## 0.3.1 - 2026-07-16
+
+Python host integration, consistent CLI exit behavior, and named physics
+parameter exchange for the experimental C ABI.
+
+### Added
+
+- Added an in-repository experimental Python binding based on `ctypes`, with a
+  model-create, frame-evaluate, and free smoke path plus explicit ownership,
+  opaque-handle, NULL/error, byte-buffer-free, and UTF-8 JSON policies.
+- Added a header-to-Python ABI drift check and Python smokes for PMX/VMD parser
+  JSON, geometry buffers, runtime frame evaluation, and IK primitives, including
+  CI coverage against a real native library build.
+- Added `mmd_runtime_physics_params_get_json` and
+  `mmd_runtime_physics_params_set_json` for schema-versioned, name-keyed rigid
+  body and joint parameter exchange through the experimental C ABI.
+
+### Changed
+
+- Standardized CLI process outcomes to exit `0` on success, `2` for argument
+  errors, and `1` for execution errors.
+
+### Fixed
+
+- Improved CLI failures to preserve the input path and distinguish an explicit
+  format selection from an automatically detected format.
+
+### Known limitations
+
+- The C ABI and Python binding remain experimental and may change before 1.0.
+- v0.3.1 does not provide Python wheels or a PyPI package; Python consumers use
+  the in-repository bridge and build or provide the native library themselves.
+
 ## 0.3.0 - 2026-07-16
 
 Sparse pose reduction, host-driven physics integration, and expanded FBX

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -403,6 +403,7 @@ dependencies = [
  "mmd-anim-format",
  "mmd-anim-physics-bullet",
  "mmd-anim-runtime",
+ "serde",
  "serde_json",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -372,7 +372,7 @@ checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "mmd-anim"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "mmd-anim-format",
  "mmd-anim-runtime",
@@ -381,7 +381,7 @@ dependencies = [
 
 [[package]]
 name = "mmd-anim-cli"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -397,7 +397,7 @@ dependencies = [
 
 [[package]]
 name = "mmd-anim-ffi"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "glam",
  "mmd-anim-format",
@@ -409,7 +409,7 @@ dependencies = [
 
 [[package]]
 name = "mmd-anim-format"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "encoding_rs",
  "fbxcel",
@@ -422,7 +422,7 @@ dependencies = [
 
 [[package]]
 name = "mmd-anim-physics-bullet"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "cc",
  "glam",
@@ -434,7 +434,7 @@ dependencies = [
 
 [[package]]
 name = "mmd-anim-runtime"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "glam",
  "rayon",
@@ -443,7 +443,7 @@ dependencies = [
 
 [[package]]
 name = "mmd-anim-wasm"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "glam",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 rust-version = "1.87"
 license = "MIT"
@@ -30,6 +30,6 @@ serde_json = "1.0.145"
 wasm-bindgen = "0.2.105"
 js-sys = "0.3"
 encoding_rs = "0.8"
-mmd-anim-runtime = { path = "crates/mmd-anim-runtime", version = "0.3.0" }
-mmd-anim-format = { path = "crates/mmd-anim-format", version = "0.3.0" }
+mmd-anim-runtime = { path = "crates/mmd-anim-runtime", version = "0.3.1" }
+mmd-anim-format = { path = "crates/mmd-anim-format", version = "0.3.1" }
  

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Format support overview. "Loading" means parsing a file into structured data.
 
 ```toml
 [dependencies]
-mmd-anim = "0.3"
+mmd-anim = "0.3.1"
 ```
 
 ## Native Hosts (C ABI)

--- a/bindings/python/.gitignore
+++ b/bindings/python/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.py[cod]
+

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -1,0 +1,17 @@
+# Experimental Python binding
+
+This directory contains the in-repository, dependency-free `ctypes` bridge for
+the experimental mmd-anim C ABI v2.  The implementation deliberately lives in
+the internal module `mmd_anim._runtime`; it is not yet a stable Python API.
+
+Run the tests from the repository root:
+
+```powershell
+python -m unittest discover -s bindings/python/tests -v
+```
+
+The native lifecycle smoke uses `MMD_RUNTIME_LIBRARY` when set, otherwise it
+looks for the platform cdylib under `target/release`.  It creates a one-bone
+model and empty owned clip, evaluates a nonzero clip frame, copies the world
+matrix, and frees clip/instance/model handles.  Without either library, only
+that native test is skipped; pure ABI/ownership tests still run.

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -10,8 +10,14 @@ Run the tests from the repository root:
 python -m unittest discover -s bindings/python/tests -v
 ```
 
-The native lifecycle smoke uses `MMD_RUNTIME_LIBRARY` when set, otherwise it
-looks for the platform cdylib under `target/release`.  It creates a one-bone
-model and empty owned clip, evaluates a nonzero clip frame, copies the world
-matrix, and frees clip/instance/model handles.  Without either library, only
-that native test is skipped; pure ABI/ownership tests still run.
+The native lifecycle and parser/geometry/IK smokes use `MMD_RUNTIME_LIBRARY`
+when set; otherwise they look for the platform cdylib under `target/release`.
+They create a one-bone model and empty owned clip, evaluate a nonzero clip
+frame, copy the world matrix, parse tracked PMX/VMD fixtures, read an owned
+geometry buffer, solve an IK primitive, and free all handles. Without either
+library, native tests are skipped; pure ABI/ownership and header-drift tests
+still run.
+
+The ctypes signature manifest is `mmd_anim/_abi.py`. After changing
+`mmd_runtime.h`, update that manifest for every wrapped declaration, then run
+`python tools/check_python_abi_drift.py`.

--- a/bindings/python/mmd_anim/__init__.py
+++ b/bindings/python/mmd_anim/__init__.py
@@ -1,0 +1,6 @@
+"""Experimental in-repository Python support for mmd-anim.
+
+The native binding intentionally remains in ``mmd_anim._runtime`` while the
+0.3.1 ABI and Python API are being validated.  Nothing is re-exported here yet.
+"""
+

--- a/bindings/python/mmd_anim/_abi.py
+++ b/bindings/python/mmd_anim/_abi.py
@@ -1,0 +1,208 @@
+"""Machine-readable ctypes subset of the experimental C ABI v2.
+
+This module is the single handwritten signature table used both to bind the
+native library and to check the declarations in ``mmd_runtime.h``.
+"""
+
+from __future__ import annotations
+
+import ctypes
+from typing import TypeAlias
+
+
+FieldSpec: TypeAlias = tuple[str, str]
+FunctionSpec: TypeAlias = tuple[str, tuple[str, ...]]
+
+
+STRUCT_SPECS: dict[str, tuple[FieldSpec, ...]] = {
+    "mmd_runtime_ffi_byte_buffer_t": (
+        ("data", "uint8_t*"),
+        ("len", "size_t"),
+    ),
+    "mmd_runtime_ffi_rig_ik_link_t": (
+        ("bone_slot", "uint32_t"),
+        ("has_angle_limit", "bool"),
+        ("angle_limit_min_xyz", "float[3]"),
+        ("angle_limit_max_xyz", "float[3]"),
+    ),
+    "mmd_runtime_ffi_rig_bone_t": (
+        ("parent_slot", "int32_t"),
+        ("rest_position_xyz", "float[3]"),
+        ("flags", "uint32_t"),
+        ("fixed_axis_xyz", "float[3]"),
+    ),
+    "mmd_runtime_ffi_ik_solve_stats_t": (
+        ("executed_iterations", "uint32_t"),
+        ("link_steps", "uint32_t"),
+        ("final_distance", "float"),
+        ("break_reason", "uint32_t"),
+    ),
+}
+
+
+FUNCTION_SPECS: dict[str, FunctionSpec] = {
+    "mmd_runtime_abi_version": ("uint32_t", ()),
+    "mmd_runtime_last_error_message": ("const char*", ()),
+    "mmd_runtime_byte_buffer_free": ("void", ("mmd_runtime_ffi_byte_buffer_t",)),
+    "mmd_runtime_parse_vmd_json": (
+        "mmd_runtime_ffi_byte_buffer_t",
+        ("const uint8_t*", "size_t"),
+    ),
+    "mmd_runtime_parse_pmx_non_geometry_json": (
+        "mmd_runtime_ffi_byte_buffer_t",
+        ("const uint8_t*", "size_t"),
+    ),
+    "mmd_runtime_pmx_geometry_create": (
+        "mmd_runtime_pmx_geometry_t*",
+        ("const uint8_t*", "size_t"),
+    ),
+    "mmd_runtime_pmx_geometry_free": ("void", ("mmd_runtime_pmx_geometry_t*",)),
+    "mmd_runtime_pmx_geometry_positions_buffer": (
+        "mmd_runtime_ffi_byte_buffer_t",
+        ("const mmd_runtime_pmx_geometry_t*",),
+    ),
+    "mmd_runtime_model_create": (
+        "mmd_runtime_model_t*",
+        ("const int32_t*", "const float*", "size_t"),
+    ),
+    "mmd_runtime_model_free": ("void", ("mmd_runtime_model_t*",)),
+    "mmd_runtime_instance_create": (
+        "mmd_runtime_instance_t*",
+        ("const mmd_runtime_model_t*", "size_t"),
+    ),
+    "mmd_runtime_instance_free": ("void", ("mmd_runtime_instance_t*",)),
+    "mmd_runtime_instance_evaluate_rest_pose": (
+        "bool",
+        ("mmd_runtime_instance_t*",),
+    ),
+    "mmd_runtime_instance_evaluate_clip_frame": (
+        "bool",
+        ("mmd_runtime_instance_t*", "const mmd_runtime_clip_t*", "float"),
+    ),
+    "mmd_runtime_instance_world_matrix_f32_len": (
+        "size_t",
+        ("const mmd_runtime_instance_t*",),
+    ),
+    "mmd_runtime_instance_copy_world_matrices": (
+        "bool",
+        ("const mmd_runtime_instance_t*", "float*", "size_t"),
+    ),
+    "mmd_runtime_clip_create": (
+        "mmd_runtime_clip_t*",
+        (
+            "const mmd_runtime_ffi_bone_track_t*",
+            "size_t",
+            "const mmd_runtime_ffi_bone_keyframe_t*",
+            "size_t",
+            "const mmd_runtime_ffi_morph_track_t*",
+            "size_t",
+            "const mmd_runtime_ffi_morph_keyframe_t*",
+            "size_t",
+            "const mmd_runtime_ffi_property_keyframe_t*",
+            "size_t",
+            "const uint8_t*",
+            "size_t",
+        ),
+    ),
+    "mmd_runtime_clip_free": ("void", ("mmd_runtime_clip_t*",)),
+    "mmd_runtime_ik_chain_create": (
+        "mmd_runtime_ik_chain_t*",
+        (
+            "const mmd_runtime_ffi_rig_bone_t*",
+            "size_t",
+            "uint32_t",
+            "const mmd_runtime_ffi_rig_ik_link_t*",
+            "size_t",
+            "uint32_t",
+            "float",
+        ),
+    ),
+    "mmd_runtime_ik_chain_free": ("void", ("mmd_runtime_ik_chain_t*",)),
+    "mmd_runtime_ik_chain_solve": (
+        "bool",
+        (
+            "mmd_runtime_ik_chain_t*",
+            "const float*",
+            "const float*",
+            "const float*",
+            "const float*",
+            "float",
+            "uint32_t",
+            "float*",
+            "size_t",
+            "mmd_runtime_ffi_ik_solve_stats_t*",
+        ),
+    ),
+}
+
+
+class ByteBuffer(ctypes.Structure):
+    pass
+
+
+class RigIkLink(ctypes.Structure):
+    pass
+
+
+class RigBone(ctypes.Structure):
+    pass
+
+
+class IkSolveStats(ctypes.Structure):
+    pass
+
+
+STRUCT_TYPES: dict[str, type[ctypes.Structure]] = {
+    "mmd_runtime_ffi_byte_buffer_t": ByteBuffer,
+    "mmd_runtime_ffi_rig_ik_link_t": RigIkLink,
+    "mmd_runtime_ffi_rig_bone_t": RigBone,
+    "mmd_runtime_ffi_ik_solve_stats_t": IkSolveStats,
+}
+
+
+_SCALARS: dict[str, object] = {
+    "void": None,
+    "bool": ctypes.c_bool,
+    "float": ctypes.c_float,
+    "int32_t": ctypes.c_int32,
+    "uint8_t": ctypes.c_uint8,
+    "uint32_t": ctypes.c_uint32,
+    "size_t": ctypes.c_size_t,
+}
+
+
+def ctypes_type(c_type: str) -> object:
+    """Resolve one normalized C spelling to its ctypes representation."""
+
+    if c_type == "const char*":
+        return ctypes.c_char_p
+    if c_type.endswith("]"):
+        base, count = c_type[:-1].split("[")
+        return ctypes_type(base) * int(count)  # type: ignore[operator]
+    if c_type in STRUCT_TYPES:
+        return STRUCT_TYPES[c_type]
+    if c_type.startswith("const "):
+        c_type = c_type.removeprefix("const ")
+    if c_type.endswith("*"):
+        pointee = c_type[:-1]
+        if pointee in _SCALARS and _SCALARS[pointee] is not None:
+            return ctypes.POINTER(_SCALARS[pointee])
+        if pointee in STRUCT_TYPES:
+            return ctypes.POINTER(STRUCT_TYPES[pointee])
+        return ctypes.c_void_p
+    return _SCALARS[c_type]
+
+
+for _name, _fields in STRUCT_SPECS.items():
+    STRUCT_TYPES[_name]._fields_ = [
+        (field_name, ctypes_type(field_type)) for field_name, field_type in _fields
+    ]
+
+
+def bind_functions(library: ctypes.CDLL) -> None:
+    """Apply all manifest prototypes to a loaded runtime library."""
+
+    for name, (return_type, argument_types) in FUNCTION_SPECS.items():
+        function = getattr(library, name)
+        function.argtypes = [ctypes_type(value) for value in argument_types]
+        function.restype = ctypes_type(return_type)

--- a/bindings/python/mmd_anim/_abi.py
+++ b/bindings/python/mmd_anim/_abi.py
@@ -103,6 +103,22 @@ FUNCTION_SPECS: dict[str, FunctionSpec] = {
         "bool",
         ("const mmd_runtime_instance_t*", "float*", "size_t"),
     ),
+    "mmd_runtime_instance_skinning_matrix_f32_len": (
+        "size_t",
+        ("const mmd_runtime_instance_t*",),
+    ),
+    "mmd_runtime_instance_copy_skinning_matrices": (
+        "bool",
+        ("const mmd_runtime_instance_t*", "float*", "size_t"),
+    ),
+    "mmd_runtime_instance_morph_weight_len": (
+        "size_t",
+        ("const mmd_runtime_instance_t*",),
+    ),
+    "mmd_runtime_instance_copy_morph_weights": (
+        "bool",
+        ("const mmd_runtime_instance_t*", "float*", "size_t"),
+    ),
     "mmd_runtime_clip_create": (
         "mmd_runtime_clip_t*",
         (

--- a/bindings/python/mmd_anim/_abi.py
+++ b/bindings/python/mmd_anim/_abi.py
@@ -65,10 +65,26 @@ FUNCTION_SPECS: dict[str, FunctionSpec] = {
         "mmd_runtime_model_t*",
         ("const int32_t*", "const float*", "size_t"),
     ),
+    "mmd_runtime_model_create_from_pmx_bytes": (
+        "mmd_runtime_model_t*",
+        ("const uint8_t*", "size_t"),
+    ),
+    "mmd_runtime_model_bone_count": (
+        "size_t",
+        ("const mmd_runtime_model_t*",),
+    ),
+    "mmd_runtime_model_morph_count": (
+        "size_t",
+        ("const mmd_runtime_model_t*",),
+    ),
     "mmd_runtime_model_free": ("void", ("mmd_runtime_model_t*",)),
     "mmd_runtime_instance_create": (
         "mmd_runtime_instance_t*",
         ("const mmd_runtime_model_t*", "size_t"),
+    ),
+    "mmd_runtime_instance_create_for_model": (
+        "mmd_runtime_instance_t*",
+        ("const mmd_runtime_model_t*",),
     ),
     "mmd_runtime_instance_free": ("void", ("mmd_runtime_instance_t*",)),
     "mmd_runtime_instance_evaluate_rest_pose": (
@@ -105,6 +121,14 @@ FUNCTION_SPECS: dict[str, FunctionSpec] = {
         ),
     ),
     "mmd_runtime_clip_free": ("void", ("mmd_runtime_clip_t*",)),
+    "mmd_runtime_clip_create_from_vmd_bytes_for_model": (
+        "mmd_runtime_clip_t*",
+        ("const mmd_runtime_model_t*", "const uint8_t*", "size_t"),
+    ),
+    "mmd_runtime_clip_frame_range": (
+        "bool",
+        ("const mmd_runtime_clip_t*", "uint32_t*", "uint32_t*"),
+    ),
     "mmd_runtime_ik_chain_create": (
         "mmd_runtime_ik_chain_t*",
         (

--- a/bindings/python/mmd_anim/_abi.py
+++ b/bindings/python/mmd_anim/_abi.py
@@ -42,6 +42,7 @@ STRUCT_SPECS: dict[str, tuple[FieldSpec, ...]] = {
 
 FUNCTION_SPECS: dict[str, FunctionSpec] = {
     "mmd_runtime_abi_version": ("uint32_t", ()),
+    "mmd_runtime_feature_flags": ("uint32_t", ()),
     "mmd_runtime_last_error_message": ("const char*", ()),
     "mmd_runtime_byte_buffer_free": ("void", ("mmd_runtime_ffi_byte_buffer_t",)),
     "mmd_runtime_parse_vmd_json": (
@@ -145,6 +146,22 @@ FUNCTION_SPECS: dict[str, FunctionSpec] = {
         "bool",
         ("const mmd_runtime_clip_t*", "uint32_t*", "uint32_t*"),
     ),
+    "mmd_runtime_physics_world_create_from_pmx_bytes": (
+        "mmd_runtime_status_t",
+        ("const uint8_t*", "size_t", "mmd_runtime_physics_world_t**"),
+    ),
+    "mmd_runtime_physics_world_free": (
+        "void",
+        ("mmd_runtime_physics_world_t*",),
+    ),
+    "mmd_runtime_physics_params_get_json": (
+        "mmd_runtime_ffi_byte_buffer_t",
+        ("const mmd_runtime_physics_world_t*",),
+    ),
+    "mmd_runtime_physics_params_set_json": (
+        "mmd_runtime_status_t",
+        ("mmd_runtime_physics_world_t*", "const uint8_t*", "size_t"),
+    ),
     "mmd_runtime_ik_chain_create": (
         "mmd_runtime_ik_chain_t*",
         (
@@ -205,6 +222,7 @@ _SCALARS: dict[str, object] = {
     "bool": ctypes.c_bool,
     "float": ctypes.c_float,
     "int32_t": ctypes.c_int32,
+    "mmd_runtime_status_t": ctypes.c_int,
     "uint8_t": ctypes.c_uint8,
     "uint32_t": ctypes.c_uint32,
     "size_t": ctypes.c_size_t,
@@ -223,6 +241,8 @@ def ctypes_type(c_type: str) -> object:
         return STRUCT_TYPES[c_type]
     if c_type.startswith("const "):
         c_type = c_type.removeprefix("const ")
+    if c_type.endswith("**"):
+        return ctypes.POINTER(ctypes.c_void_p)
     if c_type.endswith("*"):
         pointee = c_type[:-1]
         if pointee in _SCALARS and _SCALARS[pointee] is not None:

--- a/bindings/python/mmd_anim/_runtime.py
+++ b/bindings/python/mmd_anim/_runtime.py
@@ -6,6 +6,7 @@ import ctypes
 import json
 import os
 import sys
+from array import array
 from pathlib import Path
 from typing import Callable, Sequence
 
@@ -338,23 +339,48 @@ class Instance:
                 "mmd_runtime_instance_evaluate_clip_frame"
             )
 
-    def world_matrices(self) -> list[float]:
+    def _copy_f32_array(
+        self,
+        length_function: str,
+        copy_function: str,
+        *,
+        allow_empty: bool,
+    ) -> array:
         handle = self._require_open()
-        length = self._model._runtime._lib.mmd_runtime_instance_world_matrix_f32_len(
-            handle
-        )
+        library = self._model._runtime._lib
+        length = int(getattr(library, length_function)(handle))
         if length == 0:
+            if allow_empty:
+                return array("f")
             raise self._model._runtime._failure(
-                "mmd_runtime_instance_world_matrix_f32_len"
+                length_function
             )
-        output = (ctypes.c_float * length)()
-        if not self._model._runtime._lib.mmd_runtime_instance_copy_world_matrices(
-            handle, output, length
-        ):
-            raise self._model._runtime._failure(
-                "mmd_runtime_instance_copy_world_matrices"
-            )
-        return list(output)
+        output = array("f", (0.0,)) * length
+        native_output = (ctypes.c_float * length).from_buffer(output)
+        if not getattr(library, copy_function)(handle, native_output, length):
+            raise self._model._runtime._failure(copy_function)
+        return output
+
+    def world_matrices_f32(self) -> array:
+        return self._copy_f32_array(
+            "mmd_runtime_instance_world_matrix_f32_len",
+            "mmd_runtime_instance_copy_world_matrices",
+            allow_empty=False,
+        )
+
+    def skinning_matrices_f32(self) -> array:
+        return self._copy_f32_array(
+            "mmd_runtime_instance_skinning_matrix_f32_len",
+            "mmd_runtime_instance_copy_skinning_matrices",
+            allow_empty=False,
+        )
+
+    def morph_weights_f32(self) -> array:
+        return self._copy_f32_array(
+            "mmd_runtime_instance_morph_weight_len",
+            "mmd_runtime_instance_copy_morph_weights",
+            allow_empty=True,
+        )
 
     def close(self) -> None:
         if self._handle is None:

--- a/bindings/python/mmd_anim/_runtime.py
+++ b/bindings/python/mmd_anim/_runtime.py
@@ -7,6 +7,7 @@ import json
 import os
 import sys
 from array import array
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Callable, Sequence
 
@@ -14,11 +15,35 @@ from ._abi import ByteBuffer, IkSolveStats, RigBone, RigIkLink, bind_functions
 
 
 EXPECTED_ABI_VERSION = 2
+FEATURE_PHYSICS_BULLET_NATIVE = 1 << 1
 LIBRARY_ENV = "MMD_RUNTIME_LIBRARY"
 
 
 class NativeRuntimeError(RuntimeError):
     """Raised when loading or calling the native runtime fails."""
+
+
+_STATUS_NAMES = {
+    0: "OK",
+    1: "INVALID_INPUT",
+    2: "UNSUPPORTED",
+    3: "BUFFER_TOO_SMALL",
+    4: "ERROR",
+}
+
+
+class NativeStatusError(NativeRuntimeError):
+    """Raised when a status-returning native function does not return OK."""
+
+    def __init__(self, operation: str, status: int, detail: str | None) -> None:
+        self.operation = operation
+        self.status = int(status)
+        self.status_name = _STATUS_NAMES.get(self.status, "UNKNOWN_STATUS")
+        self.detail = detail
+        message = f"{operation} failed with {self.status_name} ({self.status})"
+        if detail:
+            message += f": {detail}"
+        super().__init__(message)
 
 
 class AbiVersionError(NativeRuntimeError):
@@ -100,6 +125,12 @@ class RuntimeLibrary:
         bind_functions(lib)
         _require_abi_version(lib.mmd_runtime_abi_version())
 
+    def feature_flags(self) -> int:
+        return int(self._lib.mmd_runtime_feature_flags())
+
+    def supports_native_physics(self) -> bool:
+        return bool(self.feature_flags() & FEATURE_PHYSICS_BULLET_NATIVE)
+
     def _last_error(self) -> str | None:
         value = self._lib.mmd_runtime_last_error_message()
         if not value:
@@ -112,6 +143,11 @@ class RuntimeLibrary:
     def _failure(self, operation: str) -> NativeRuntimeError:
         detail = self._last_error()
         return NativeRuntimeError(f"{operation} failed" + (f": {detail}" if detail else ""))
+
+    def _require_ok(self, status: int, operation: str) -> None:
+        numeric_status = int(status)
+        if numeric_status != 0:
+            raise NativeStatusError(operation, numeric_status, self._last_error())
 
     def create_model(
         self, parent_indices: Sequence[int], rest_positions_xyz: Sequence[float]
@@ -137,6 +173,23 @@ class RuntimeLibrary:
         if not handle:
             raise self._failure("mmd_runtime_model_create_from_pmx_bytes")
         return Model(self, handle)
+
+    def create_physics_world_from_pmx_bytes(self, data: bytes) -> PhysicsWorld:
+        storage, length = self._input_bytes(data)
+        out_world = ctypes.c_void_p()
+        operation = "mmd_runtime_physics_world_create_from_pmx_bytes"
+        status = self._lib.mmd_runtime_physics_world_create_from_pmx_bytes(
+            storage, length, ctypes.byref(out_world)
+        )
+        try:
+            self._require_ok(status, operation)
+        except NativeStatusError:
+            if out_world.value:
+                self._lib.mmd_runtime_physics_world_free(out_world.value)
+            raise
+        if not out_world.value:
+            raise NativeRuntimeError(f"{operation} returned OK with a NULL world")
+        return PhysicsWorld(self, out_world.value)
 
     def create_clip_from_vmd_bytes(self, model: Model, data: bytes) -> Clip:
         if model._runtime is not self:
@@ -422,6 +475,61 @@ class Clip:
         if self._handle is None:
             return
         self._runtime._lib.mmd_runtime_clip_free(self._handle)
+        self._handle = None
+
+
+class PhysicsWorld:
+    """Owned opaque PMX-derived physics world for parameter inspection."""
+
+    def __init__(self, runtime: RuntimeLibrary, handle: int) -> None:
+        self._runtime = runtime
+        self._handle: int | None = handle
+
+    def __enter__(self) -> PhysicsWorld:
+        self._require_open()
+        return self
+
+    def __exit__(self, exc_type: object, exc: object, traceback: object) -> None:
+        self.close()
+
+    def _require_open(self) -> int:
+        if self._handle is None:
+            raise NativeRuntimeError("physics world handle is closed")
+        return self._handle
+
+    def params_json(self) -> dict[str, object]:
+        operation = "mmd_runtime_physics_params_get_json"
+        decoded = self._runtime.decode_owned_json(
+            self._runtime._lib.mmd_runtime_physics_params_get_json(
+                self._require_open()
+            ),
+            operation,
+        )
+        if not isinstance(decoded, dict):
+            raise NativeRuntimeError(f"{operation} did not return a JSON object")
+        return decoded
+
+    def set_params_json(self, params: Mapping[str, object]) -> None:
+        if not isinstance(params, Mapping):
+            raise TypeError("params must be a mapping")
+        payload = json.dumps(
+            dict(params),
+            ensure_ascii=False,
+            allow_nan=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("utf-8")
+        storage, length = self._runtime._input_bytes(payload)
+        operation = "mmd_runtime_physics_params_set_json"
+        status = self._runtime._lib.mmd_runtime_physics_params_set_json(
+            self._require_open(), storage, length
+        )
+        self._runtime._require_ok(status, operation)
+
+    def close(self) -> None:
+        if self._handle is None:
+            return
+        self._runtime._lib.mmd_runtime_physics_world_free(self._handle)
         self._handle = None
 
 

--- a/bindings/python/mmd_anim/_runtime.py
+++ b/bindings/python/mmd_anim/_runtime.py
@@ -9,6 +9,8 @@ import sys
 from pathlib import Path
 from typing import Callable, Sequence
 
+from ._abi import ByteBuffer, IkSolveStats, RigBone, RigIkLink, bind_functions
+
 
 EXPECTED_ABI_VERSION = 2
 LIBRARY_ENV = "MMD_RUNTIME_LIBRARY"
@@ -20,15 +22,6 @@ class NativeRuntimeError(RuntimeError):
 
 class AbiVersionError(NativeRuntimeError):
     """Raised when the loaded native library does not implement ABI v2."""
-
-
-class ByteBuffer(ctypes.Structure):
-    """Value representation of ``mmd_runtime_ffi_byte_buffer_t``."""
-
-    _fields_ = [
-        ("data", ctypes.POINTER(ctypes.c_uint8)),
-        ("len", ctypes.c_size_t),
-    ]
 
 
 def _require_abi_version(actual: int) -> None:
@@ -103,71 +96,17 @@ class RuntimeLibrary:
 
     def _bind(self) -> None:
         lib = self._lib
-
-        lib.mmd_runtime_abi_version.argtypes = []
-        lib.mmd_runtime_abi_version.restype = ctypes.c_uint32
+        bind_functions(lib)
         _require_abi_version(lib.mmd_runtime_abi_version())
 
-        lib.mmd_runtime_last_error_message.argtypes = []
-        lib.mmd_runtime_last_error_message.restype = ctypes.c_void_p
-
-        lib.mmd_runtime_byte_buffer_free.argtypes = [ByteBuffer]
-        lib.mmd_runtime_byte_buffer_free.restype = None
-
-        lib.mmd_runtime_model_create.argtypes = [
-            ctypes.POINTER(ctypes.c_int32),
-            ctypes.POINTER(ctypes.c_float),
-            ctypes.c_size_t,
-        ]
-        lib.mmd_runtime_model_create.restype = ctypes.c_void_p
-        lib.mmd_runtime_model_free.argtypes = [ctypes.c_void_p]
-        lib.mmd_runtime_model_free.restype = None
-
-        lib.mmd_runtime_instance_create.argtypes = [ctypes.c_void_p, ctypes.c_size_t]
-        lib.mmd_runtime_instance_create.restype = ctypes.c_void_p
-        lib.mmd_runtime_instance_free.argtypes = [ctypes.c_void_p]
-        lib.mmd_runtime_instance_free.restype = None
-        lib.mmd_runtime_instance_evaluate_rest_pose.argtypes = [ctypes.c_void_p]
-        lib.mmd_runtime_instance_evaluate_rest_pose.restype = ctypes.c_bool
-        lib.mmd_runtime_instance_world_matrix_f32_len.argtypes = [ctypes.c_void_p]
-        lib.mmd_runtime_instance_world_matrix_f32_len.restype = ctypes.c_size_t
-        lib.mmd_runtime_instance_copy_world_matrices.argtypes = [
-            ctypes.c_void_p,
-            ctypes.POINTER(ctypes.c_float),
-            ctypes.c_size_t,
-        ]
-        lib.mmd_runtime_instance_copy_world_matrices.restype = ctypes.c_bool
-
-        lib.mmd_runtime_clip_create.argtypes = [
-            ctypes.c_void_p,
-            ctypes.c_size_t,
-            ctypes.c_void_p,
-            ctypes.c_size_t,
-            ctypes.c_void_p,
-            ctypes.c_size_t,
-            ctypes.c_void_p,
-            ctypes.c_size_t,
-            ctypes.c_void_p,
-            ctypes.c_size_t,
-            ctypes.c_void_p,
-            ctypes.c_size_t,
-        ]
-        lib.mmd_runtime_clip_create.restype = ctypes.c_void_p
-        lib.mmd_runtime_clip_free.argtypes = [ctypes.c_void_p]
-        lib.mmd_runtime_clip_free.restype = None
-        lib.mmd_runtime_instance_evaluate_clip_frame.argtypes = [
-            ctypes.c_void_p,
-            ctypes.c_void_p,
-            ctypes.c_float,
-        ]
-        lib.mmd_runtime_instance_evaluate_clip_frame.restype = ctypes.c_bool
-
     def _last_error(self) -> str | None:
-        pointer = self._lib.mmd_runtime_last_error_message()
-        if not pointer:
+        value = self._lib.mmd_runtime_last_error_message()
+        if not value:
             return None
-        # Copy immediately: this thread-local pointer expires on the next FFI call.
-        return ctypes.string_at(pointer).decode("utf-8", errors="replace")
+        # c_char_p copies the borrowed C string to bytes before returning. Keep
+        # integer-pointer handling for lightweight fake libraries in pure tests.
+        copied = value if isinstance(value, bytes) else ctypes.string_at(value)
+        return copied.decode("utf-8", errors="replace")
 
     def _failure(self, operation: str) -> NativeRuntimeError:
         detail = self._last_error()
@@ -209,6 +148,59 @@ class RuntimeLibrary:
         if not handle:
             raise self._failure("mmd_runtime_clip_create")
         return Clip(self, handle)
+
+    @staticmethod
+    def _input_bytes(data: bytes) -> tuple[object, int]:
+        if not data:
+            raise ValueError("native parser input must not be empty")
+        storage = (ctypes.c_uint8 * len(data)).from_buffer_copy(data)
+        return storage, len(data)
+
+    def parse_vmd_json(self, data: bytes) -> object:
+        storage, length = self._input_bytes(data)
+        return self.decode_owned_json(
+            self._lib.mmd_runtime_parse_vmd_json(storage, length),
+            "mmd_runtime_parse_vmd_json",
+        )
+
+    def parse_pmx_non_geometry_json(self, data: bytes) -> object:
+        storage, length = self._input_bytes(data)
+        return self.decode_owned_json(
+            self._lib.mmd_runtime_parse_pmx_non_geometry_json(storage, length),
+            "mmd_runtime_parse_pmx_non_geometry_json",
+        )
+
+    def create_pmx_geometry(self, data: bytes) -> PmxGeometry:
+        storage, length = self._input_bytes(data)
+        handle = self._lib.mmd_runtime_pmx_geometry_create(storage, length)
+        if not handle:
+            raise self._failure("mmd_runtime_pmx_geometry_create")
+        return PmxGeometry(self, handle)
+
+    def create_ik_chain(
+        self,
+        bones: Sequence[RigBone],
+        target_bone_slot: int,
+        links: Sequence[RigIkLink],
+        iteration_count: int,
+        limit_angle: float,
+    ) -> IkChain:
+        if not bones or not links:
+            raise ValueError("bones and links must not be empty")
+        native_bones = (RigBone * len(bones))(*bones)
+        native_links = (RigIkLink * len(links))(*links)
+        handle = self._lib.mmd_runtime_ik_chain_create(
+            native_bones,
+            len(bones),
+            target_bone_slot,
+            native_links,
+            len(links),
+            iteration_count,
+            limit_angle,
+        )
+        if not handle:
+            raise self._failure("mmd_runtime_ik_chain_create")
+        return IkChain(self, handle, len(bones), len(links))
 
     def copy_owned_bytes(self, buffer: ByteBuffer, operation: str) -> bytes:
         if buffer.len == 0 or not buffer.data:
@@ -354,4 +346,101 @@ class Clip:
         if self._handle is None:
             return
         self._runtime._lib.mmd_runtime_clip_free(self._handle)
+        self._handle = None
+
+
+class PmxGeometry:
+    """Owned parsed-PMX geometry handle."""
+
+    def __init__(self, runtime: RuntimeLibrary, handle: int) -> None:
+        self._runtime = runtime
+        self._handle: int | None = handle
+
+    def __enter__(self) -> PmxGeometry:
+        self._require_open()
+        return self
+
+    def __exit__(self, exc_type: object, exc: object, traceback: object) -> None:
+        self.close()
+
+    def _require_open(self) -> int:
+        if self._handle is None:
+            raise NativeRuntimeError("PMX geometry handle is closed")
+        return self._handle
+
+    def positions_bytes(self) -> bytes:
+        return self._runtime.copy_owned_bytes(
+            self._runtime._lib.mmd_runtime_pmx_geometry_positions_buffer(
+                self._require_open()
+            ),
+            "mmd_runtime_pmx_geometry_positions_buffer",
+        )
+
+    def close(self) -> None:
+        if self._handle is None:
+            return
+        self._runtime._lib.mmd_runtime_pmx_geometry_free(self._handle)
+        self._handle = None
+
+
+class IkChain:
+    """Owned IK-chain primitive with caller-owned solve output."""
+
+    def __init__(
+        self, runtime: RuntimeLibrary, handle: int, bone_count: int, link_count: int
+    ) -> None:
+        self._runtime = runtime
+        self._handle: int | None = handle
+        self._bone_count = bone_count
+        self._link_count = link_count
+
+    def __enter__(self) -> IkChain:
+        self._require_open()
+        return self
+
+    def __exit__(self, exc_type: object, exc: object, traceback: object) -> None:
+        self.close()
+
+    def _require_open(self) -> int:
+        if self._handle is None:
+            raise NativeRuntimeError("IK chain handle is closed")
+        return self._handle
+
+    def solve(
+        self,
+        local_rotations_xyzw: Sequence[float],
+        goal_position_xyz: Sequence[float],
+        *,
+        tolerance: float = 1.0e-3,
+        max_iterations_cap: int = 0,
+    ) -> tuple[list[float], IkSolveStats]:
+        if len(local_rotations_xyzw) != self._bone_count * 4:
+            raise ValueError("local rotations must contain four floats per bone")
+        if len(goal_position_xyz) != 3:
+            raise ValueError("goal position must contain three floats")
+        rotations = (ctypes.c_float * len(local_rotations_xyzw))(
+            *local_rotations_xyzw
+        )
+        goal = (ctypes.c_float * 3)(*goal_position_xyz)
+        output = (ctypes.c_float * (self._link_count * 4))()
+        stats = IkSolveStats()
+        if not self._runtime._lib.mmd_runtime_ik_chain_solve(
+            self._require_open(),
+            None,
+            None,
+            rotations,
+            goal,
+            tolerance,
+            max_iterations_cap,
+            output,
+            len(output),
+            ctypes.byref(stats),
+        ):
+            raise self._runtime._failure("mmd_runtime_ik_chain_solve")
+        return list(output), stats
+
+    def close(self) -> None:
+        if self._handle is None:
+            return
+        self._runtime._lib.mmd_runtime_ik_chain_free(self._handle)
         self._handle = None

--- a/bindings/python/mmd_anim/_runtime.py
+++ b/bindings/python/mmd_anim/_runtime.py
@@ -130,6 +130,27 @@ class RuntimeLibrary:
             raise self._failure("mmd_runtime_model_create")
         return Model(self, handle)
 
+    def create_model_from_pmx_bytes(self, data: bytes) -> Model:
+        storage, length = self._input_bytes(data)
+        handle = self._lib.mmd_runtime_model_create_from_pmx_bytes(storage, length)
+        if not handle:
+            raise self._failure("mmd_runtime_model_create_from_pmx_bytes")
+        return Model(self, handle)
+
+    def create_clip_from_vmd_bytes(self, model: Model, data: bytes) -> Clip:
+        if model._runtime is not self:
+            raise ValueError("model and clip must belong to the same RuntimeLibrary")
+        model_handle = model._require_open()
+        storage, length = self._input_bytes(data)
+        handle = self._lib.mmd_runtime_clip_create_from_vmd_bytes_for_model(
+            model_handle, storage, length
+        )
+        if not handle:
+            raise self._failure(
+                "mmd_runtime_clip_create_from_vmd_bytes_for_model"
+            )
+        return Clip(self, handle)
+
     def create_empty_clip(self) -> Clip:
         handle = self._lib.mmd_runtime_clip_create(
             None,
@@ -251,6 +272,26 @@ class Model:
         self._instances.add(instance)
         return instance
 
+    def bone_count(self) -> int:
+        return int(
+            self._runtime._lib.mmd_runtime_model_bone_count(self._require_open())
+        )
+
+    def morph_count(self) -> int:
+        return int(
+            self._runtime._lib.mmd_runtime_model_morph_count(self._require_open())
+        )
+
+    def create_instance_for_model(self) -> Instance:
+        handle = self._runtime._lib.mmd_runtime_instance_create_for_model(
+            self._require_open()
+        )
+        if not handle:
+            raise self._runtime._failure("mmd_runtime_instance_create_for_model")
+        instance = Instance(self, handle)
+        self._instances.add(instance)
+        return instance
+
     def close(self) -> None:
         if self._handle is None:
             return
@@ -341,6 +382,15 @@ class Clip:
         if self._handle is None:
             raise NativeRuntimeError("clip handle is closed")
         return self._handle
+
+    def frame_range(self) -> tuple[int, int]:
+        first = ctypes.c_uint32()
+        last = ctypes.c_uint32()
+        if not self._runtime._lib.mmd_runtime_clip_frame_range(
+            self._require_open(), ctypes.byref(first), ctypes.byref(last)
+        ):
+            raise self._runtime._failure("mmd_runtime_clip_frame_range")
+        return first.value, last.value
 
     def close(self) -> None:
         if self._handle is None:

--- a/bindings/python/mmd_anim/_runtime.py
+++ b/bindings/python/mmd_anim/_runtime.py
@@ -1,0 +1,357 @@
+"""Minimal, internal ctypes binding for the mmd-anim runtime C ABI v2."""
+
+from __future__ import annotations
+
+import ctypes
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Callable, Sequence
+
+
+EXPECTED_ABI_VERSION = 2
+LIBRARY_ENV = "MMD_RUNTIME_LIBRARY"
+
+
+class NativeRuntimeError(RuntimeError):
+    """Raised when loading or calling the native runtime fails."""
+
+
+class AbiVersionError(NativeRuntimeError):
+    """Raised when the loaded native library does not implement ABI v2."""
+
+
+class ByteBuffer(ctypes.Structure):
+    """Value representation of ``mmd_runtime_ffi_byte_buffer_t``."""
+
+    _fields_ = [
+        ("data", ctypes.POINTER(ctypes.c_uint8)),
+        ("len", ctypes.c_size_t),
+    ]
+
+
+def _require_abi_version(actual: int) -> None:
+    if actual != EXPECTED_ABI_VERSION:
+        raise AbiVersionError(
+            f"mmd-anim runtime ABI mismatch: expected {EXPECTED_ABI_VERSION}, got {actual}"
+        )
+
+
+def _library_filename() -> str:
+    if sys.platform == "win32":
+        return "mmd_runtime_ffi.dll"
+    if sys.platform == "darwin":
+        return "libmmd_runtime_ffi.dylib"
+    return "libmmd_runtime_ffi.so"
+
+
+def local_release_library_path() -> Path:
+    repository_root = Path(__file__).resolve().parents[3]
+    return repository_root / "target" / "release" / _library_filename()
+
+
+def resolve_library_path(path: os.PathLike[str] | str | None = None) -> Path:
+    """Resolve an explicit path, the environment override, or local release output."""
+
+    configured = path if path is not None else os.environ.get(LIBRARY_ENV)
+    candidate = (
+        Path(configured).expanduser()
+        if configured is not None
+        else local_release_library_path()
+    )
+    if not candidate.is_file():
+        source = "configured" if configured is not None else "local release"
+        raise NativeRuntimeError(
+            f"{source} mmd-anim runtime library was not found: {candidate}"
+        )
+    return candidate.resolve()
+
+
+def _copy_and_free_byte_buffer(
+    buffer: ByteBuffer, free_buffer: Callable[[ByteBuffer], None]
+) -> bytes:
+    """Copy an owned ABI buffer, then free it exactly once even on failure."""
+
+    try:
+        if buffer.len == 0:
+            return b""
+        if not buffer.data:
+            raise NativeRuntimeError("native byte buffer has non-zero length and NULL data")
+        return ctypes.string_at(buffer.data, buffer.len)
+    finally:
+        free_buffer(buffer)
+
+
+class RuntimeLibrary:
+    """Loaded ABI v2 function table; internal and experimental."""
+
+    def __init__(self, path: os.PathLike[str] | str | None = None) -> None:
+        self.path = resolve_library_path(path)
+        try:
+            self._lib = ctypes.CDLL(str(self.path))
+        except OSError as error:
+            raise NativeRuntimeError(
+                f"failed to load mmd-anim runtime library {self.path}: {error}"
+            ) from error
+        try:
+            self._bind()
+        except AttributeError as error:
+            raise NativeRuntimeError(
+                f"mmd-anim runtime library is missing a required ABI v2 symbol: {error}"
+            ) from error
+
+    def _bind(self) -> None:
+        lib = self._lib
+
+        lib.mmd_runtime_abi_version.argtypes = []
+        lib.mmd_runtime_abi_version.restype = ctypes.c_uint32
+        _require_abi_version(lib.mmd_runtime_abi_version())
+
+        lib.mmd_runtime_last_error_message.argtypes = []
+        lib.mmd_runtime_last_error_message.restype = ctypes.c_void_p
+
+        lib.mmd_runtime_byte_buffer_free.argtypes = [ByteBuffer]
+        lib.mmd_runtime_byte_buffer_free.restype = None
+
+        lib.mmd_runtime_model_create.argtypes = [
+            ctypes.POINTER(ctypes.c_int32),
+            ctypes.POINTER(ctypes.c_float),
+            ctypes.c_size_t,
+        ]
+        lib.mmd_runtime_model_create.restype = ctypes.c_void_p
+        lib.mmd_runtime_model_free.argtypes = [ctypes.c_void_p]
+        lib.mmd_runtime_model_free.restype = None
+
+        lib.mmd_runtime_instance_create.argtypes = [ctypes.c_void_p, ctypes.c_size_t]
+        lib.mmd_runtime_instance_create.restype = ctypes.c_void_p
+        lib.mmd_runtime_instance_free.argtypes = [ctypes.c_void_p]
+        lib.mmd_runtime_instance_free.restype = None
+        lib.mmd_runtime_instance_evaluate_rest_pose.argtypes = [ctypes.c_void_p]
+        lib.mmd_runtime_instance_evaluate_rest_pose.restype = ctypes.c_bool
+        lib.mmd_runtime_instance_world_matrix_f32_len.argtypes = [ctypes.c_void_p]
+        lib.mmd_runtime_instance_world_matrix_f32_len.restype = ctypes.c_size_t
+        lib.mmd_runtime_instance_copy_world_matrices.argtypes = [
+            ctypes.c_void_p,
+            ctypes.POINTER(ctypes.c_float),
+            ctypes.c_size_t,
+        ]
+        lib.mmd_runtime_instance_copy_world_matrices.restype = ctypes.c_bool
+
+        lib.mmd_runtime_clip_create.argtypes = [
+            ctypes.c_void_p,
+            ctypes.c_size_t,
+            ctypes.c_void_p,
+            ctypes.c_size_t,
+            ctypes.c_void_p,
+            ctypes.c_size_t,
+            ctypes.c_void_p,
+            ctypes.c_size_t,
+            ctypes.c_void_p,
+            ctypes.c_size_t,
+            ctypes.c_void_p,
+            ctypes.c_size_t,
+        ]
+        lib.mmd_runtime_clip_create.restype = ctypes.c_void_p
+        lib.mmd_runtime_clip_free.argtypes = [ctypes.c_void_p]
+        lib.mmd_runtime_clip_free.restype = None
+        lib.mmd_runtime_instance_evaluate_clip_frame.argtypes = [
+            ctypes.c_void_p,
+            ctypes.c_void_p,
+            ctypes.c_float,
+        ]
+        lib.mmd_runtime_instance_evaluate_clip_frame.restype = ctypes.c_bool
+
+    def _last_error(self) -> str | None:
+        pointer = self._lib.mmd_runtime_last_error_message()
+        if not pointer:
+            return None
+        # Copy immediately: this thread-local pointer expires on the next FFI call.
+        return ctypes.string_at(pointer).decode("utf-8", errors="replace")
+
+    def _failure(self, operation: str) -> NativeRuntimeError:
+        detail = self._last_error()
+        return NativeRuntimeError(f"{operation} failed" + (f": {detail}" if detail else ""))
+
+    def create_model(
+        self, parent_indices: Sequence[int], rest_positions_xyz: Sequence[float]
+    ) -> Model:
+        bone_count = len(parent_indices)
+        if bone_count == 0:
+            raise ValueError("parent_indices must contain at least one bone")
+        if len(rest_positions_xyz) != bone_count * 3:
+            raise ValueError(
+                "rest_positions_xyz must contain exactly three floats per bone"
+            )
+
+        parents = (ctypes.c_int32 * bone_count)(*parent_indices)
+        rest = (ctypes.c_float * (bone_count * 3))(*rest_positions_xyz)
+        handle = self._lib.mmd_runtime_model_create(parents, rest, bone_count)
+        if not handle:
+            raise self._failure("mmd_runtime_model_create")
+        return Model(self, handle)
+
+    def create_empty_clip(self) -> Clip:
+        handle = self._lib.mmd_runtime_clip_create(
+            None,
+            0,
+            None,
+            0,
+            None,
+            0,
+            None,
+            0,
+            None,
+            0,
+            None,
+            0,
+        )
+        if not handle:
+            raise self._failure("mmd_runtime_clip_create")
+        return Clip(self, handle)
+
+    def copy_owned_bytes(self, buffer: ByteBuffer, operation: str) -> bytes:
+        if buffer.len == 0 or not buffer.data:
+            detail = self._last_error()
+            self._lib.mmd_runtime_byte_buffer_free(buffer)
+            raise NativeRuntimeError(
+                f"{operation} returned an empty byte buffer"
+                + (f": {detail}" if detail else "")
+            )
+        return _copy_and_free_byte_buffer(
+            buffer, self._lib.mmd_runtime_byte_buffer_free
+        )
+
+    def decode_owned_json(self, buffer: ByteBuffer, operation: str) -> object:
+        copied = self.copy_owned_bytes(buffer, operation)
+        return json.loads(copied.decode("utf-8", errors="strict"))
+
+
+class Model:
+    """Owned opaque model handle."""
+
+    def __init__(self, runtime: RuntimeLibrary, handle: int) -> None:
+        self._runtime = runtime
+        self._handle: int | None = handle
+        self._instances: set[Instance] = set()
+
+    def __enter__(self) -> Model:
+        self._require_open()
+        return self
+
+    def __exit__(self, exc_type: object, exc: object, traceback: object) -> None:
+        self.close()
+
+    def _require_open(self) -> int:
+        if self._handle is None:
+            raise NativeRuntimeError("model handle is closed")
+        return self._handle
+
+    def create_instance(self, morph_count: int = 0) -> Instance:
+        if morph_count < 0:
+            raise ValueError("morph_count must be non-negative")
+        handle = self._runtime._lib.mmd_runtime_instance_create(
+            self._require_open(), morph_count
+        )
+        if not handle:
+            raise self._runtime._failure("mmd_runtime_instance_create")
+        instance = Instance(self, handle)
+        self._instances.add(instance)
+        return instance
+
+    def close(self) -> None:
+        if self._handle is None:
+            return
+        for instance in tuple(self._instances):
+            instance.close()
+        self._runtime._lib.mmd_runtime_model_free(self._handle)
+        self._handle = None
+
+
+class Instance:
+    """Owned opaque runtime-instance handle."""
+
+    def __init__(self, model: Model, handle: int) -> None:
+        self._model = model
+        self._handle: int | None = handle
+
+    def __enter__(self) -> Instance:
+        self._require_open()
+        return self
+
+    def __exit__(self, exc_type: object, exc: object, traceback: object) -> None:
+        self.close()
+
+    def _require_open(self) -> int:
+        if self._handle is None:
+            raise NativeRuntimeError("instance handle is closed")
+        return self._handle
+
+    def evaluate_rest_pose(self) -> None:
+        if not self._model._runtime._lib.mmd_runtime_instance_evaluate_rest_pose(
+            self._require_open()
+        ):
+            raise self._model._runtime._failure(
+                "mmd_runtime_instance_evaluate_rest_pose"
+            )
+
+    def evaluate_clip_frame(self, clip: Clip, frame: float) -> None:
+        if clip._runtime is not self._model._runtime:
+            raise ValueError("clip and instance must belong to the same RuntimeLibrary")
+        if not self._model._runtime._lib.mmd_runtime_instance_evaluate_clip_frame(
+            self._require_open(), clip._require_open(), frame
+        ):
+            raise self._model._runtime._failure(
+                "mmd_runtime_instance_evaluate_clip_frame"
+            )
+
+    def world_matrices(self) -> list[float]:
+        handle = self._require_open()
+        length = self._model._runtime._lib.mmd_runtime_instance_world_matrix_f32_len(
+            handle
+        )
+        if length == 0:
+            raise self._model._runtime._failure(
+                "mmd_runtime_instance_world_matrix_f32_len"
+            )
+        output = (ctypes.c_float * length)()
+        if not self._model._runtime._lib.mmd_runtime_instance_copy_world_matrices(
+            handle, output, length
+        ):
+            raise self._model._runtime._failure(
+                "mmd_runtime_instance_copy_world_matrices"
+            )
+        return list(output)
+
+    def close(self) -> None:
+        if self._handle is None:
+            return
+        self._model._runtime._lib.mmd_runtime_instance_free(self._handle)
+        self._handle = None
+        self._model._instances.discard(self)
+
+
+class Clip:
+    """Owned opaque clip handle used by the minimal frame-evaluation smoke."""
+
+    def __init__(self, runtime: RuntimeLibrary, handle: int) -> None:
+        self._runtime = runtime
+        self._handle: int | None = handle
+
+    def __enter__(self) -> Clip:
+        self._require_open()
+        return self
+
+    def __exit__(self, exc_type: object, exc: object, traceback: object) -> None:
+        self.close()
+
+    def _require_open(self) -> int:
+        if self._handle is None:
+            raise NativeRuntimeError("clip handle is closed")
+        return self._handle
+
+    def close(self) -> None:
+        if self._handle is None:
+            return
+        self._runtime._lib.mmd_runtime_clip_free(self._handle)
+        self._handle = None

--- a/bindings/python/tests/test_abi_drift.py
+++ b/bindings/python/tests/test_abi_drift.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(ROOT / "tools"))
+
+from check_python_abi_drift import HEADER, check_header  # noqa: E402
+
+
+class AbiDriftCheckerTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.header = HEADER.read_text(encoding="utf-8")
+
+    def test_current_header_matches_manifest(self) -> None:
+        errors, unwrapped = check_header(self.header)
+        self.assertEqual(errors, [])
+        self.assertGreater(len(unwrapped), 0)
+
+    def test_function_signature_mutation_is_detected(self) -> None:
+        mutated = self.header.replace(
+            "size_t         len);",
+            "uint32_t       len);",
+            1,
+        )
+        errors, _ = check_header(mutated)
+        self.assertTrue(
+            any("mmd_runtime_parse_vmd_json" in error for error in errors), errors
+        )
+
+    def test_struct_shape_mutation_is_detected(self) -> None:
+        mutated = self.header.replace(
+            "typedef struct mmd_runtime_ffi_rig_ik_link {\n"
+            "    uint32_t bone_slot;\n"
+            "    bool     has_angle_limit;\n"
+            "    float    angle_limit_min_xyz[3];\n"
+            "    float    angle_limit_max_xyz[3];",
+            "typedef struct mmd_runtime_ffi_rig_ik_link {\n"
+            "    uint32_t bone_slot;\n"
+            "    bool     has_angle_limit;\n"
+            "    float    angle_limit_min_xyz[3];\n"
+            "    float    angle_limit_max_xyz[4];",
+            1,
+        )
+        errors, _ = check_header(mutated)
+        self.assertTrue(
+            any("mmd_runtime_ffi_rig_ik_link_t" in error for error in errors), errors
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/bindings/python/tests/test_runtime.py
+++ b/bindings/python/tests/test_runtime.py
@@ -6,6 +6,7 @@ import math
 import os
 import sys
 import unittest
+from array import array
 from pathlib import Path
 
 
@@ -32,6 +33,59 @@ from mmd_anim._abi import ctypes_type  # noqa: E402
 
 
 class PureBindingTests(unittest.TestCase):
+    def test_f32_arrays_use_stdlib_storage_and_zero_length_policy(self) -> None:
+        class FakeLibrary:
+            def mmd_runtime_instance_morph_weight_len(self, instance: int) -> int:
+                return 0
+
+            def mmd_runtime_instance_world_matrix_f32_len(
+                self, instance: int
+            ) -> int:
+                return 0
+
+            def mmd_runtime_instance_skinning_matrix_f32_len(
+                self, instance: int
+            ) -> int:
+                return 0
+
+            def mmd_runtime_instance_copy_morph_weights(
+                self, instance: int, output: object, length: int
+            ) -> bool:
+                raise AssertionError("zero-length morph output must not be constructed")
+
+            def mmd_runtime_instance_copy_world_matrices(
+                self, instance: int, output: object, length: int
+            ) -> bool:
+                raise AssertionError("zero-length world output must not be constructed")
+
+            def mmd_runtime_instance_copy_skinning_matrices(
+                self, instance: int, output: object, length: int
+            ) -> bool:
+                raise AssertionError(
+                    "zero-length skinning output must not be constructed"
+                )
+
+            def mmd_runtime_last_error_message(self) -> None:
+                return None
+
+        runtime = object.__new__(RuntimeLibrary)
+        runtime._lib = FakeLibrary()
+        instance = Instance(Model(runtime, 1), 2)
+
+        morphs = instance.morph_weights_f32()
+        self.assertIsInstance(morphs, array)
+        self.assertEqual(morphs.typecode, "f")
+        self.assertEqual(morphs.itemsize, ctypes.sizeof(ctypes.c_float))
+        self.assertEqual(len(morphs), 0)
+        with self.assertRaisesRegex(
+            NativeRuntimeError, "world_matrix_f32_len failed"
+        ):
+            instance.world_matrices_f32()
+        with self.assertRaisesRegex(
+            NativeRuntimeError, "skinning_matrix_f32_len failed"
+        ):
+            instance.skinning_matrices_f32()
+
     def test_empty_import_bytes_are_rejected_before_native_calls(self) -> None:
         class FakeLibrary:
             def __init__(self) -> None:
@@ -192,7 +246,7 @@ class NativeLifecycleSmoke(unittest.TestCase):
                 clip = runtime.create_empty_clip()
                 with clip:
                     instance.evaluate_clip_frame(clip, 12.5)
-                    matrices = instance.world_matrices()
+                    matrices = instance.world_matrices_f32()
                 clip.close()  # Idempotent after context-manager cleanup.
 
         self.assertEqual(len(matrices), 16)
@@ -247,9 +301,18 @@ class NativeRepresentativeSmoke(unittest.TestCase):
         self.assertEqual(clip.frame_range(), (0, 30))
 
         instance.evaluate_clip_frame(clip, 15.0)
-        matrices = instance.world_matrices()
-        self.assertEqual(len(matrices), model.bone_count() * 16)
-        self.assertTrue(all(math.isfinite(value) for value in matrices))
+        world = instance.world_matrices_f32()
+        skinning = instance.skinning_matrices_f32()
+        morphs = instance.morph_weights_f32()
+        self.assertEqual(len(world), model.bone_count() * 16)
+        self.assertEqual(len(skinning), model.bone_count() * 16)
+        self.assertEqual(len(morphs), model.morph_count())
+        for output in (world, skinning, morphs):
+            self.assertIsInstance(output, array)
+            self.assertEqual(output.typecode, "f")
+        self.assertTrue(all(math.isfinite(value) for value in world))
+        self.assertTrue(all(math.isfinite(value) for value in skinning))
+        self.assertTrue(all(math.isfinite(value) for value in morphs))
 
         model.close()  # Cascades the still-live instance.
         model.close()

--- a/bindings/python/tests/test_runtime.py
+++ b/bindings/python/tests/test_runtime.py
@@ -15,6 +15,7 @@ sys.path.insert(0, str(PYTHON_BINDING_ROOT))
 
 from mmd_anim._runtime import (  # noqa: E402
     EXPECTED_ABI_VERSION,
+    FEATURE_PHYSICS_BULLET_NATIVE,
     LIBRARY_ENV,
     AbiVersionError,
     ByteBuffer,
@@ -22,6 +23,8 @@ from mmd_anim._runtime import (  # noqa: E402
     Instance,
     Model,
     NativeRuntimeError,
+    NativeStatusError,
+    PhysicsWorld,
     RigBone,
     RigIkLink,
     RuntimeLibrary,
@@ -33,6 +36,122 @@ from mmd_anim._abi import ctypes_type  # noqa: E402
 
 
 class PureBindingTests(unittest.TestCase):
+    def test_native_physics_capability_bit(self) -> None:
+        class FakeLibrary:
+            def __init__(self, flags: int) -> None:
+                self.flags = flags
+
+            def mmd_runtime_feature_flags(self) -> int:
+                return self.flags
+
+        runtime = object.__new__(RuntimeLibrary)
+        runtime._lib = FakeLibrary(0)
+        self.assertEqual(runtime.feature_flags(), 0)
+        self.assertFalse(runtime.supports_native_physics())
+
+        runtime._lib = FakeLibrary(FEATURE_PHYSICS_BULLET_NATIVE)
+        self.assertEqual(runtime.feature_flags(), FEATURE_PHYSICS_BULLET_NATIVE)
+        self.assertTrue(runtime.supports_native_physics())
+
+    def test_native_status_error_names_and_detail(self) -> None:
+        self.assertIs(ctypes_type("mmd_runtime_status_t"), ctypes.c_int)
+        self.assertIs(
+            ctypes_type("mmd_runtime_physics_world_t**"),
+            ctypes.POINTER(ctypes.c_void_p),
+        )
+        expected = {
+            0: "OK",
+            1: "INVALID_INPUT",
+            2: "UNSUPPORTED",
+            3: "BUFFER_TOO_SMALL",
+            4: "ERROR",
+        }
+        for status, name in expected.items():
+            with self.subTest(status=status):
+                error = NativeStatusError("test_operation", status, "native detail")
+                self.assertEqual(error.status, status)
+                self.assertEqual(error.status_name, name)
+                self.assertIn("native detail", str(error))
+
+    def test_physics_world_create_validates_and_cleans_failed_output(self) -> None:
+        class FakeLibrary:
+            def __init__(self, status: int, write_handle: bool) -> None:
+                self.status = status
+                self.write_handle = write_handle
+                self.create_calls = 0
+                self.freed: list[int] = []
+
+            def mmd_runtime_physics_world_create_from_pmx_bytes(
+                self, data: object, length: int, out_world: object
+            ) -> int:
+                self.create_calls += 1
+                if self.write_handle:
+                    ctypes.cast(out_world, ctypes.POINTER(ctypes.c_void_p))[0] = 77
+                return self.status
+
+            def mmd_runtime_physics_world_free(self, world: int) -> None:
+                self.freed.append(world)
+
+            def mmd_runtime_last_error_message(self) -> bytes:
+                return b"physics unavailable"
+
+        empty_runtime = object.__new__(RuntimeLibrary)
+        empty_runtime._lib = FakeLibrary(0, False)
+        with self.assertRaisesRegex(ValueError, "must not be empty"):
+            empty_runtime.create_physics_world_from_pmx_bytes(b"")
+        self.assertEqual(empty_runtime._lib.create_calls, 0)
+
+        failed_runtime = object.__new__(RuntimeLibrary)
+        failed_runtime._lib = FakeLibrary(2, True)
+        with self.assertRaises(NativeStatusError) as caught:
+            failed_runtime.create_physics_world_from_pmx_bytes(b"pmx")
+        self.assertEqual(caught.exception.status_name, "UNSUPPORTED")
+        self.assertIn("physics unavailable", str(caught.exception))
+        self.assertEqual(failed_runtime._lib.freed, [77])
+
+        null_runtime = object.__new__(RuntimeLibrary)
+        null_runtime._lib = FakeLibrary(0, False)
+        with self.assertRaisesRegex(NativeRuntimeError, "NULL world"):
+            null_runtime.create_physics_world_from_pmx_bytes(b"pmx")
+
+    def test_physics_set_status_json_and_idempotent_close(self) -> None:
+        class FakeLibrary:
+            def __init__(self) -> None:
+                self.payload = b""
+                self.free_calls = 0
+
+            def mmd_runtime_physics_params_set_json(
+                self, world: int, data: object, length: int
+            ) -> int:
+                self.payload = bytes(data[:length])
+                return 1
+
+            def mmd_runtime_last_error_message(self) -> bytes:
+                return "無効な設定".encode()
+
+            def mmd_runtime_physics_world_free(self, world: int) -> None:
+                self.free_calls += 1
+
+        runtime = object.__new__(RuntimeLibrary)
+        runtime._lib = FakeLibrary()
+        world = PhysicsWorld(runtime, 9)
+
+        with self.assertRaises(TypeError):
+            world.set_params_json([("schema_version", 1)])  # type: ignore[arg-type]
+        with self.assertRaises(NativeStatusError) as caught:
+            world.set_params_json({"名前": "剛体", "schema_version": 1})
+        self.assertEqual(caught.exception.status, 1)
+        self.assertEqual(caught.exception.status_name, "INVALID_INPUT")
+        self.assertIn("無効な設定", str(caught.exception))
+        self.assertEqual(
+            runtime._lib.payload,
+            '{"schema_version":1,"名前":"剛体"}'.encode(),
+        )
+
+        world.close()
+        world.close()
+        self.assertEqual(runtime._lib.free_calls, 1)
+
     def test_f32_arrays_use_stdlib_storage_and_zero_length_policy(self) -> None:
         class FakeLibrary:
             def mmd_runtime_instance_morph_weight_len(self, instance: int) -> int:
@@ -287,6 +406,33 @@ class NativeRepresentativeSmoke(unittest.TestCase):
         self.assertEqual(vmd["metadata"]["counts"]["bones"], 5)
         self.assertEqual(vmd["metadata"]["maxFrame"], 30)
         self.assertEqual(vmd["boneFrames"][3]["frame"], 15)
+
+    def test_physics_parameter_json_roundtrip_is_fail_atomic(self) -> None:
+        if not self.runtime.supports_native_physics():
+            self.skipTest(
+                "release DLL does not advertise native Bullet physics capability"
+            )
+        world = self.runtime.create_physics_world_from_pmx_bytes(self.pmx)
+        self.addCleanup(world.close)
+
+        before = world.params_json()
+        self.assertEqual(
+            before,
+            {"schema_version": 1, "rigid_bodies": {}, "joints": {}},
+        )
+        world.set_params_json(before)
+        self.assertEqual(world.params_json(), before)
+
+        invalid = dict(before)
+        invalid["schema_version"] = 2
+        with self.assertRaises(NativeStatusError) as caught:
+            world.set_params_json(invalid)
+        self.assertEqual(caught.exception.status, 1)
+        self.assertEqual(caught.exception.status_name, "INVALID_INPUT")
+        self.assertEqual(world.params_json(), before)
+
+        world.close()
+        world.close()
 
     def test_repository_fixture_import_evaluate_and_idempotent_free(self) -> None:
         model = self.runtime.create_model_from_pmx_bytes(self.pmx)

--- a/bindings/python/tests/test_runtime.py
+++ b/bindings/python/tests/test_runtime.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import ctypes
+import json
+import os
+import sys
+import unittest
+from pathlib import Path
+
+
+PYTHON_BINDING_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(PYTHON_BINDING_ROOT))
+
+from mmd_anim._runtime import (  # noqa: E402
+    EXPECTED_ABI_VERSION,
+    LIBRARY_ENV,
+    AbiVersionError,
+    ByteBuffer,
+    Clip,
+    Instance,
+    Model,
+    NativeRuntimeError,
+    RuntimeLibrary,
+    _copy_and_free_byte_buffer,
+    _require_abi_version,
+    local_release_library_path,
+)
+
+
+class PureBindingTests(unittest.TestCase):
+    def test_abi_version_guard_accepts_only_v2(self) -> None:
+        _require_abi_version(EXPECTED_ABI_VERSION)
+        with self.assertRaisesRegex(AbiVersionError, "expected 2, got 1"):
+            _require_abi_version(1)
+
+    def test_owned_buffer_is_copied_and_freed_once(self) -> None:
+        storage = (ctypes.c_uint8 * 3)(1, 2, 3)
+        buffer = ByteBuffer(ctypes.cast(storage, ctypes.POINTER(ctypes.c_uint8)), 3)
+        freed: list[int] = []
+
+        copied = _copy_and_free_byte_buffer(buffer, lambda value: freed.append(value.len))
+
+        self.assertEqual(copied, b"\x01\x02\x03")
+        self.assertEqual(freed, [3])
+
+    def test_owned_json_is_freed_before_decode_errors_escape(self) -> None:
+        class FakeLibrary:
+            def __init__(self) -> None:
+                self.freed: list[int] = []
+
+            def mmd_runtime_byte_buffer_free(self, value: ByteBuffer) -> None:
+                self.freed.append(value.len)
+
+        cases = ((b"\xff", UnicodeDecodeError), (b"not json", json.JSONDecodeError))
+        for payload, error_type in cases:
+            with self.subTest(payload=payload):
+                native = FakeLibrary()
+                runtime = object.__new__(RuntimeLibrary)
+                runtime._lib = native
+                storage = (ctypes.c_uint8 * len(payload))(*payload)
+                buffer = ByteBuffer(
+                    ctypes.cast(storage, ctypes.POINTER(ctypes.c_uint8)), len(payload)
+                )
+
+                with self.assertRaises(error_type):
+                    runtime.decode_owned_json(buffer, "test_json")
+
+                self.assertEqual(native.freed, [len(payload)])
+
+    def test_cross_runtime_clip_is_rejected_before_native_call(self) -> None:
+        class FakeLibrary:
+            def __init__(self) -> None:
+                self.evaluate_calls = 0
+
+            def mmd_runtime_instance_evaluate_clip_frame(
+                self, instance: int, clip: int, frame: float
+            ) -> bool:
+                self.evaluate_calls += 1
+                return True
+
+        instance_runtime = object.__new__(RuntimeLibrary)
+        instance_runtime._lib = FakeLibrary()
+        clip_runtime = object.__new__(RuntimeLibrary)
+        clip_runtime._lib = FakeLibrary()
+        instance = Instance(Model(instance_runtime, 1), 2)
+        foreign_clip = Clip(clip_runtime, 3)
+
+        with self.assertRaisesRegex(ValueError, "same RuntimeLibrary"):
+            instance.evaluate_clip_frame(foreign_clip, 12.5)
+
+        self.assertEqual(instance_runtime._lib.evaluate_calls, 0)
+
+    def test_local_release_fallback_names_platform_library(self) -> None:
+        path = local_release_library_path()
+        self.assertEqual(path.parent.name, "release")
+        self.assertIn(path.suffix, {".dll", ".so", ".dylib"})
+
+
+class NativeLifecycleSmoke(unittest.TestCase):
+    def test_one_bone_clip_frame_matrix_readback_and_free(self) -> None:
+        explicit = os.environ.get(LIBRARY_ENV)
+        fallback = local_release_library_path()
+        if explicit is None and not fallback.is_file():
+            self.skipTest(
+                f"native library absent; build release or set {LIBRARY_ENV}"
+            )
+
+        runtime = RuntimeLibrary()
+        with runtime.create_model([-1], [1.0, 2.0, 3.0]) as model:
+            with model.create_instance() as instance:
+                clip = runtime.create_empty_clip()
+                with clip:
+                    instance.evaluate_clip_frame(clip, 12.5)
+                    matrices = instance.world_matrices()
+                clip.close()  # Idempotent after context-manager cleanup.
+
+        self.assertEqual(len(matrices), 16)
+        self.assertAlmostEqual(matrices[12], 1.0)
+        self.assertAlmostEqual(matrices[13], 2.0)
+        self.assertAlmostEqual(matrices[14], 3.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/bindings/python/tests/test_runtime.py
+++ b/bindings/python/tests/test_runtime.py
@@ -20,14 +20,43 @@ from mmd_anim._runtime import (  # noqa: E402
     Instance,
     Model,
     NativeRuntimeError,
+    RigBone,
+    RigIkLink,
     RuntimeLibrary,
     _copy_and_free_byte_buffer,
     _require_abi_version,
     local_release_library_path,
 )
+from mmd_anim._abi import ctypes_type  # noqa: E402
 
 
 class PureBindingTests(unittest.TestCase):
+    def test_const_char_pointer_and_borrowed_last_error_copy(self) -> None:
+        self.assertIs(ctypes_type("const char*"), ctypes.c_char_p)
+
+        class FakeLibrary:
+            def __init__(self) -> None:
+                self.free_calls = 0
+                self.storage = ctypes.create_string_buffer(b"integer pointer failure")
+                self.values: list[bytes | int] = [
+                    "native failure".encode("utf-8"),
+                    ctypes.addressof(self.storage),
+                ]
+
+            def mmd_runtime_last_error_message(self) -> bytes | int:
+                return self.values.pop(0)
+
+            def mmd_runtime_byte_buffer_free(self, value: ByteBuffer) -> None:
+                self.free_calls += 1
+
+        native = FakeLibrary()
+        runtime = object.__new__(RuntimeLibrary)
+        runtime._lib = native
+
+        self.assertEqual(runtime._last_error(), "native failure")
+        self.assertEqual(runtime._last_error(), "integer pointer failure")
+        self.assertEqual(native.free_calls, 0)
+
     def test_abi_version_guard_accepts_only_v2(self) -> None:
         _require_abi_version(EXPECTED_ABI_VERSION)
         with self.assertRaisesRegex(AbiVersionError, "expected 2, got 1"):
@@ -118,6 +147,71 @@ class NativeLifecycleSmoke(unittest.TestCase):
         self.assertAlmostEqual(matrices[12], 1.0)
         self.assertAlmostEqual(matrices[13], 2.0)
         self.assertAlmostEqual(matrices[14], 3.0)
+
+
+class NativeRepresentativeSmoke(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        explicit = os.environ.get(LIBRARY_ENV)
+        fallback = local_release_library_path()
+        if explicit is None and not fallback.is_file():
+            raise unittest.SkipTest(
+                f"native library absent; build release or set {LIBRARY_ENV}"
+            )
+        cls.runtime = RuntimeLibrary()
+        fixtures = (
+            Path(__file__).resolve().parents[3]
+            / "crates"
+            / "mmd-anim-format"
+            / "fixtures"
+        )
+        cls.pmx = (fixtures / "pmx" / "ik_multi_axis_limit.pmx").read_bytes()
+        cls.vmd = (fixtures / "vmd" / "ik_multi_bone_nondefault.vmd").read_bytes()
+
+    def test_repository_fixture_parser_json_semantics(self) -> None:
+        pmx = self.runtime.parse_pmx_non_geometry_json(self.pmx)
+        self.assertIsInstance(pmx, dict)
+        self.assertEqual(pmx["metadata"]["format"], "pmx")
+        self.assertEqual(pmx["metadata"]["counts"]["bones"], 3)
+        self.assertEqual(pmx["skeleton"]["bones"][2]["ik"]["targetIndex"], 1)
+
+        vmd = self.runtime.parse_vmd_json(self.vmd)
+        self.assertIsInstance(vmd, dict)
+        self.assertEqual(vmd["kind"], "vmd")
+        self.assertEqual(vmd["metadata"]["counts"]["bones"], 5)
+        self.assertEqual(vmd["metadata"]["maxFrame"], 30)
+        self.assertEqual(vmd["boneFrames"][3]["frame"], 15)
+
+    def test_pmx_geometry_positions_buffer_and_idempotent_free(self) -> None:
+        geometry = self.runtime.create_pmx_geometry(self.pmx)
+        payload = geometry.positions_bytes()
+        geometry.close()
+        geometry.close()
+
+        self.assertGreater(len(payload), 0)
+        self.assertEqual(len(payload) % ctypes.sizeof(ctypes.c_float), 0)
+        self.assertEqual(len(payload) // ctypes.sizeof(ctypes.c_float), 9)
+
+    def test_ik_chain_create_solve_and_idempotent_free(self) -> None:
+        zero3 = (ctypes.c_float * 3)(0.0, 0.0, 0.0)
+        bones = [
+            RigBone(-1, zero3, 0, zero3),
+            RigBone(0, (ctypes.c_float * 3)(1.0, 0.0, 0.0), 0, zero3),
+        ]
+        links = [RigIkLink(0, False, zero3, zero3)]
+        chain = self.runtime.create_ik_chain(bones, 1, links, 4, 0.0)
+        output, stats = chain.solve(
+            [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0],
+            [0.0, 1.0, 0.0],
+        )
+        chain.close()
+        chain.close()
+
+        self.assertEqual(len(output), 4)
+        self.assertLessEqual(stats.final_distance, 1.0e-3)
+        self.assertEqual(stats.break_reason, 0)
+        self.assertAlmostEqual(output[2], 2.0**-0.5, places=4)
+        self.assertAlmostEqual(output[3], 2.0**-0.5, places=4)
 
 
 if __name__ == "__main__":

--- a/bindings/python/tests/test_runtime.py
+++ b/bindings/python/tests/test_runtime.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import ctypes
 import json
+import math
 import os
 import sys
 import unittest
@@ -31,6 +32,57 @@ from mmd_anim._abi import ctypes_type  # noqa: E402
 
 
 class PureBindingTests(unittest.TestCase):
+    def test_empty_import_bytes_are_rejected_before_native_calls(self) -> None:
+        class FakeLibrary:
+            def __init__(self) -> None:
+                self.model_import_calls = 0
+                self.clip_import_calls = 0
+
+            def mmd_runtime_model_create_from_pmx_bytes(
+                self, data: object, length: int
+            ) -> int:
+                self.model_import_calls += 1
+                return 1
+
+            def mmd_runtime_clip_create_from_vmd_bytes_for_model(
+                self, model: int, data: object, length: int
+            ) -> int:
+                self.clip_import_calls += 1
+                return 1
+
+        runtime = object.__new__(RuntimeLibrary)
+        runtime._lib = FakeLibrary()
+        model = Model(runtime, 1)
+
+        with self.assertRaisesRegex(ValueError, "must not be empty"):
+            runtime.create_model_from_pmx_bytes(b"")
+        with self.assertRaisesRegex(ValueError, "must not be empty"):
+            runtime.create_clip_from_vmd_bytes(model, b"")
+
+        self.assertEqual(runtime._lib.model_import_calls, 0)
+        self.assertEqual(runtime._lib.clip_import_calls, 0)
+
+    def test_cross_runtime_model_import_is_rejected_before_native_call(self) -> None:
+        class FakeLibrary:
+            def __init__(self) -> None:
+                self.clip_import_calls = 0
+
+            def mmd_runtime_clip_create_from_vmd_bytes_for_model(
+                self, model: int, data: object, length: int
+            ) -> int:
+                self.clip_import_calls += 1
+                return 1
+
+        runtime = object.__new__(RuntimeLibrary)
+        runtime._lib = FakeLibrary()
+        foreign_runtime = object.__new__(RuntimeLibrary)
+        foreign_runtime._lib = FakeLibrary()
+
+        with self.assertRaisesRegex(ValueError, "same RuntimeLibrary"):
+            runtime.create_clip_from_vmd_bytes(Model(foreign_runtime, 1), b"vmd")
+
+        self.assertEqual(runtime._lib.clip_import_calls, 0)
+
     def test_const_char_pointer_and_borrowed_last_error_copy(self) -> None:
         self.assertIs(ctypes_type("const char*"), ctypes.c_char_p)
 
@@ -181,6 +233,29 @@ class NativeRepresentativeSmoke(unittest.TestCase):
         self.assertEqual(vmd["metadata"]["counts"]["bones"], 5)
         self.assertEqual(vmd["metadata"]["maxFrame"], 30)
         self.assertEqual(vmd["boneFrames"][3]["frame"], 15)
+
+    def test_repository_fixture_import_evaluate_and_idempotent_free(self) -> None:
+        model = self.runtime.create_model_from_pmx_bytes(self.pmx)
+        self.addCleanup(model.close)
+        clip = self.runtime.create_clip_from_vmd_bytes(model, self.vmd)
+        self.addCleanup(clip.close)
+        instance = model.create_instance_for_model()
+        self.addCleanup(instance.close)
+
+        self.assertEqual(model.bone_count(), 3)
+        self.assertEqual(model.morph_count(), 0)
+        self.assertEqual(clip.frame_range(), (0, 30))
+
+        instance.evaluate_clip_frame(clip, 15.0)
+        matrices = instance.world_matrices()
+        self.assertEqual(len(matrices), model.bone_count() * 16)
+        self.assertTrue(all(math.isfinite(value) for value in matrices))
+
+        model.close()  # Cascades the still-live instance.
+        model.close()
+        instance.close()
+        clip.close()
+        clip.close()
 
     def test_pmx_geometry_positions_buffer_and_idempotent_free(self) -> None:
         geometry = self.runtime.create_pmx_geometry(self.pmx)

--- a/crates/mmd-anim-cli/Cargo.toml
+++ b/crates/mmd-anim-cli/Cargo.toml
@@ -26,8 +26,8 @@ clap = { version = "4", features = ["derive"] }
 clap_complete = "4"
 glam.workspace = true
 mmd-anim-runtime.workspace = true
-mmd-anim-format = { path = "../mmd-anim-format", version = "0.3.0", features = ["fbx"] }
-mmd-anim-physics-bullet = { path = "../mmd-anim-physics-bullet", version = "0.3.0", features = ["native", "pmx-format", "runtime"], optional = true }
+mmd-anim-format = { path = "../mmd-anim-format", version = "0.3.1", features = ["fbx"] }
+mmd-anim-physics-bullet = { path = "../mmd-anim-physics-bullet", version = "0.3.1", features = ["native", "pmx-format", "runtime"], optional = true }
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true

--- a/crates/mmd-anim-cli/src/main/tests.rs
+++ b/crates/mmd-anim-cli/src/main/tests.rs
@@ -2734,7 +2734,11 @@ fn import_pmx_summary_reports_import_failure_context() {
     let error = import::import_pmx_summary(&path).unwrap_err();
     let message = error.to_string();
     assert!(message.contains("import:"), "{message}");
-    assert!(message.contains("failed to import PMX file"), "{message}");
+    assert!(
+        message.contains("failed to import file (format=PMX)"),
+        "{message}"
+    );
+    assert!(!message.contains("detected="), "{message}");
     assert!(message.contains("broken.pmx"), "{message}");
 }
 

--- a/crates/mmd-anim-cli/src/support.rs
+++ b/crates/mmd-anim-cli/src/support.rs
@@ -91,7 +91,7 @@ pub(crate) fn unsupported_format_operation_error(
     operation: &str,
 ) -> Box<dyn std::error::Error> {
     anyhow!(
-        "{command}: {operation} is not supported for {} file: {}",
+        "{command}: {operation} is not supported for file (detected={}): {}",
         format_kind_label(kind),
         path.display()
     )
@@ -105,7 +105,7 @@ pub(crate) fn parse_failure_error(
     error: impl std::fmt::Display,
 ) -> Box<dyn std::error::Error> {
     anyhow!(
-        "{command}: failed to parse {} file {}: {error}",
+        "{command}: failed to parse file (format={}): {}: {error}",
         format_kind_label(kind),
         path.display()
     )
@@ -119,7 +119,7 @@ pub(crate) fn import_failure_error(
     error: impl std::fmt::Display,
 ) -> Box<dyn std::error::Error> {
     anyhow!(
-        "{command}: failed to import {} file {}: {error}",
+        "{command}: failed to import file (format={}): {}: {error}",
         format_kind_label(kind),
         path.display()
     )
@@ -207,7 +207,8 @@ mod tests {
         let error = parse_failure_error("inspect", path, MmdFormatKind::Pmx, "bad header");
         let message = error.to_string();
         assert!(message.contains("inspect:"));
-        assert!(message.contains("failed to parse PMX file model.pmx"));
+        assert!(message.contains("failed to parse file (format=PMX): model.pmx"));
+        assert!(!message.contains("detected="));
         assert!(message.contains("bad header"));
     }
 
@@ -217,7 +218,8 @@ mod tests {
         let error = import_failure_error("import", path, MmdFormatKind::Vmd, "truncated frame");
         let message = error.to_string();
         assert!(message.contains("import:"));
-        assert!(message.contains("failed to import VMD file motion.vmd"));
+        assert!(message.contains("failed to import file (format=VMD): motion.vmd"));
+        assert!(!message.contains("detected="));
         assert!(message.contains("truncated frame"));
     }
 }

--- a/crates/mmd-anim-cli/tests/exit_codes.rs
+++ b/crates/mmd-anim-cli/tests/exit_codes.rs
@@ -1,0 +1,71 @@
+use std::{
+    env, fs,
+    path::{Path, PathBuf},
+    process::{Command, Output},
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+fn run_cli(args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_mmd-anim"))
+        .args(args)
+        .output()
+        .expect("mmd-anim CLI should run")
+}
+
+fn unique_temp_path(name: &str) -> PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock should be after the Unix epoch")
+        .as_nanos();
+    env::temp_dir().join(format!(
+        "mmd-anim-cli-exit-{}-{nanos}-{name}",
+        std::process::id()
+    ))
+}
+
+fn stderr_text(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stderr).into_owned()
+}
+
+#[test]
+fn success_exits_with_zero() {
+    let output = run_cli(&["--version"]);
+
+    assert_eq!(output.status.code(), Some(0), "{}", stderr_text(&output));
+}
+
+#[test]
+fn clap_argument_error_exits_with_two() {
+    let output = run_cli(&["inspect"]);
+
+    assert_eq!(output.status.code(), Some(2), "{}", stderr_text(&output));
+}
+
+#[test]
+fn execution_error_exits_with_one_and_reports_input_path() {
+    let missing = unique_temp_path("missing.pmx");
+    let output = run_cli(&["inspect", path_text(&missing)]);
+    let stderr = stderr_text(&output);
+
+    assert_eq!(output.status.code(), Some(1), "{stderr}");
+    assert!(stderr.contains(path_text(&missing)), "{stderr}");
+}
+
+#[test]
+fn detected_format_parse_error_reports_path_and_format() {
+    let malformed = unique_temp_path("malformed.pmx");
+    fs::write(&malformed, b"PMX ").expect("malformed PMX fixture should be written");
+
+    let output = run_cli(&["inspect", path_text(&malformed)]);
+    let stderr = stderr_text(&output);
+    let _ = fs::remove_file(&malformed);
+
+    assert_eq!(output.status.code(), Some(1), "{stderr}");
+    assert!(stderr.contains(path_text(&malformed)), "{stderr}");
+    assert!(stderr.contains("format=PMX"), "{stderr}");
+    assert!(!stderr.contains("detected="), "{stderr}");
+}
+
+fn path_text(path: &Path) -> &str {
+    path.to_str().expect("temporary path should be valid UTF-8")
+}

--- a/crates/mmd-anim-ffi/Cargo.toml
+++ b/crates/mmd-anim-ffi/Cargo.toml
@@ -20,6 +20,7 @@ glam.workspace = true
 mmd-anim-runtime.workspace = true
 mmd-anim-format = { path = "../mmd-anim-format", version = "0.3.0", features = ["fbx"] }
 mmd-anim-physics-bullet = { path = "../mmd-anim-physics-bullet", version = "0.3.0", optional = true, features = ["native", "runtime", "pmx-format"] }
+serde.workspace = true
 serde_json.workspace = true
 
 [features]

--- a/crates/mmd-anim-ffi/Cargo.toml
+++ b/crates/mmd-anim-ffi/Cargo.toml
@@ -18,8 +18,8 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 glam.workspace = true
 mmd-anim-runtime.workspace = true
-mmd-anim-format = { path = "../mmd-anim-format", version = "0.3.0", features = ["fbx"] }
-mmd-anim-physics-bullet = { path = "../mmd-anim-physics-bullet", version = "0.3.0", optional = true, features = ["native", "runtime", "pmx-format"] }
+mmd-anim-format = { path = "../mmd-anim-format", version = "0.3.1", features = ["fbx"] }
+mmd-anim-physics-bullet = { path = "../mmd-anim-physics-bullet", version = "0.3.1", optional = true, features = ["native", "runtime", "pmx-format"] }
 serde.workspace = true
 serde_json.workspace = true
 

--- a/crates/mmd-anim-ffi/include/mmd_runtime.h
+++ b/crates/mmd-anim-ffi/include/mmd_runtime.h
@@ -1053,6 +1053,24 @@ mmd_runtime_status_t mmd_runtime_physics_world_create_from_pmx_bytes(
 void mmd_runtime_physics_world_free(
     mmd_runtime_physics_world_t* world);
 
+/* Returns a deterministic UTF-8 JSON snapshot of the editable physics
+   parameters for a PMX-created world. The top-level schema_version is 1;
+   rigid_bodies and joints are objects keyed by the original PMX names.
+   Descriptor-created worlds return an empty buffer and UNSUPPORTED details in
+   the thread-local last error. The returned Rust-owned buffer must be freed
+   with mmd_runtime_byte_buffer_free. */
+mmd_runtime_ffi_byte_buffer_t mmd_runtime_physics_params_get_json(
+    const mmd_runtime_physics_world_t* world);
+
+/* Applies a partial schema-version-1 named parameter update. A successful
+   update rebuilds the physics world, preserves gravity, resets simulation
+   state, and takes effect on the next seed/step. Validation or rebuild failure
+   leaves the existing world unchanged. */
+mmd_runtime_status_t mmd_runtime_physics_params_set_json(
+    mmd_runtime_physics_world_t* world,
+    const uint8_t*               data,
+    size_t                       len);
+
 /* Successful reset reseeds every bound body from the runtime pose, performs
    one fixed 1/60 solver settle, re-pins static bodies, cleans transient state,
    writes the settled dynamic bodies back to the runtime pose, and arms

--- a/crates/mmd-anim-ffi/src/lib.rs
+++ b/crates/mmd-anim-ffi/src/lib.rs
@@ -2,10 +2,15 @@
 
 use std::cell::RefCell;
 use std::collections::HashMap;
+#[cfg(feature = "physics-bullet-native")]
+use std::collections::{BTreeMap, HashSet};
 use std::ffi::CString;
 use std::os::raw::c_char;
 use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::{ptr, slice, str, sync::Arc};
+
+#[cfg(feature = "physics-bullet-native")]
+use serde::{Deserialize, Deserializer, Serialize};
 
 use mmd_anim_format::fbx::{
     UnityAnimationClipDto, UnityMorphBinding, UnityReducedPoseBindings,
@@ -128,6 +133,10 @@ pub struct MmdRuntimeAppendSolver {
 pub struct MmdRuntimePhysicsWorld {
     #[cfg(feature = "physics-bullet-native")]
     world: mmd_anim_physics_bullet::PmxBulletWorld,
+    /// The name-bearing rebuild source is available only for PMX-created
+    /// worlds. Descriptor-created worlds intentionally remain unnamed.
+    #[cfg(feature = "physics-bullet-native")]
+    pmx_model: Option<mmd_anim_format::PmxParsedModel>,
     /// When true, the next bake sample reseeds the Bullet world from the
     /// evaluated pose and copies outputs without advancing either the solver or
     /// the normal forward physics clock.
@@ -138,6 +147,92 @@ pub struct MmdRuntimePhysicsWorld {
     /// `mmd_runtime_physics_world_step_runtime`.
     #[cfg(feature = "physics-bullet-native")]
     next_bake_sample_is_seed_only: bool,
+}
+
+#[cfg(feature = "physics-bullet-native")]
+const PHYSICS_PARAMS_SCHEMA_VERSION: u32 = 1;
+
+#[cfg(feature = "physics-bullet-native")]
+#[derive(Debug, Serialize)]
+struct PhysicsParamsSnapshot {
+    schema_version: u32,
+    rigid_bodies: BTreeMap<String, PhysicsRigidBodyParams>,
+    joints: BTreeMap<String, PhysicsJointParams>,
+}
+
+#[cfg(feature = "physics-bullet-native")]
+#[derive(Debug, Serialize)]
+struct PhysicsRigidBodyParams {
+    mass: f32,
+    linear_damping: f32,
+    angular_damping: f32,
+    friction: f32,
+    restitution: f32,
+}
+
+#[cfg(feature = "physics-bullet-native")]
+#[derive(Debug, Serialize)]
+struct PhysicsJointParams {
+    translation_lower_limit: [f32; 3],
+    translation_upper_limit: [f32; 3],
+    rotation_lower_limit: [f32; 3],
+    rotation_upper_limit: [f32; 3],
+    spring_translation_factor: [f32; 3],
+    spring_rotation_factor: [f32; 3],
+}
+
+#[cfg(feature = "physics-bullet-native")]
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct PhysicsParamsUpdate {
+    schema_version: u32,
+    #[serde(default)]
+    rigid_bodies: BTreeMap<String, PhysicsRigidBodyParamsUpdate>,
+    #[serde(default)]
+    joints: BTreeMap<String, PhysicsJointParamsUpdate>,
+}
+
+#[cfg(feature = "physics-bullet-native")]
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct PhysicsRigidBodyParamsUpdate {
+    #[serde(default, deserialize_with = "deserialize_present_option")]
+    mass: Option<f32>,
+    #[serde(default, deserialize_with = "deserialize_present_option")]
+    linear_damping: Option<f32>,
+    #[serde(default, deserialize_with = "deserialize_present_option")]
+    angular_damping: Option<f32>,
+    #[serde(default, deserialize_with = "deserialize_present_option")]
+    friction: Option<f32>,
+    #[serde(default, deserialize_with = "deserialize_present_option")]
+    restitution: Option<f32>,
+}
+
+#[cfg(feature = "physics-bullet-native")]
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct PhysicsJointParamsUpdate {
+    #[serde(default, deserialize_with = "deserialize_present_option")]
+    translation_lower_limit: Option<[f32; 3]>,
+    #[serde(default, deserialize_with = "deserialize_present_option")]
+    translation_upper_limit: Option<[f32; 3]>,
+    #[serde(default, deserialize_with = "deserialize_present_option")]
+    rotation_lower_limit: Option<[f32; 3]>,
+    #[serde(default, deserialize_with = "deserialize_present_option")]
+    rotation_upper_limit: Option<[f32; 3]>,
+    #[serde(default, deserialize_with = "deserialize_present_option")]
+    spring_translation_factor: Option<[f32; 3]>,
+    #[serde(default, deserialize_with = "deserialize_present_option")]
+    spring_rotation_factor: Option<[f32; 3]>,
+}
+
+#[cfg(feature = "physics-bullet-native")]
+fn deserialize_present_option<'de, D, T>(deserializer: D) -> Result<Option<T>, D::Error>
+where
+    D: Deserializer<'de>,
+    T: Deserialize<'de>,
+{
+    T::deserialize(deserializer).map(Some)
 }
 
 #[repr(C)]
@@ -4094,6 +4189,58 @@ pub unsafe extern "C" fn mmd_runtime_physics_world_free(world: *mut MmdRuntimePh
     })
 }
 
+/// Returns a deterministic schema-v1 snapshot of editable PMX physics parameters.
+///
+/// The returned UTF-8 JSON buffer is Rust-owned and must be freed with
+/// `mmd_runtime_byte_buffer_free`. Only worlds created from PMX bytes have the
+/// original names required by this API; descriptor-created worlds are unsupported.
+///
+/// # Safety
+///
+/// `world` must be a valid physics-world handle.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn mmd_runtime_physics_params_get_json(
+    world: *const MmdRuntimePhysicsWorld,
+) -> MmdRuntimeFfiByteBuffer {
+    ffi_guard(empty_byte_buffer(), || {
+        let Some(world) = (unsafe { world.as_ref() }) else {
+            return empty_byte_buffer_failure(FFI_ERR_INVALID_INPUT);
+        };
+        physics_params_get_json_impl(world)
+    })
+}
+
+/// Applies a partial schema-v1 named PMX physics-parameter update.
+///
+/// A successful update rebuilds the whole Bullet world, preserves gravity,
+/// resets simulation state, and re-arms seed-only behavior for the next
+/// seed/bake sample. Any parse, validation, or rebuild failure leaves the
+/// original world untouched.
+///
+/// # Safety
+///
+/// `world` must be a valid physics-world handle. `data` must point to `len`
+/// readable UTF-8 JSON bytes, and `len` must be non-zero.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn mmd_runtime_physics_params_set_json(
+    world: *mut MmdRuntimePhysicsWorld,
+    data: *const u8,
+    len: usize,
+) -> MmdRuntimeStatus {
+    ffi_guard(MmdRuntimeStatus::Error, || {
+        let Some(world) = (unsafe { world.as_mut() }) else {
+            return status_failure(MmdRuntimeStatus::InvalidInput, FFI_ERR_INVALID_INPUT);
+        };
+        let Some(data) = (unsafe { checked_slice(data, len) }) else {
+            return status_failure(MmdRuntimeStatus::InvalidInput, FFI_ERR_INVALID_INPUT);
+        };
+        if data.is_empty() {
+            return status_failure(MmdRuntimeStatus::InvalidInput, FFI_ERR_INVALID_INPUT);
+        }
+        physics_params_set_json_impl(world, data)
+    })
+}
+
 /// Resets the physics world and reseeds it from the runtime pose.
 ///
 /// Reset includes one fixed 1/60 second solver settle, static-body re-pinning,
@@ -4387,6 +4534,19 @@ fn physics_world_create_from_pmx_bytes_impl(
 }
 
 #[cfg(not(feature = "physics-bullet-native"))]
+fn physics_params_get_json_impl(_world: &MmdRuntimePhysicsWorld) -> MmdRuntimeFfiByteBuffer {
+    empty_byte_buffer_failure("physics backend unsupported")
+}
+
+#[cfg(not(feature = "physics-bullet-native"))]
+fn physics_params_set_json_impl(
+    _world: &mut MmdRuntimePhysicsWorld,
+    _data: &[u8],
+) -> MmdRuntimeStatus {
+    status_failure(MmdRuntimeStatus::Unsupported, "physics backend unsupported")
+}
+
+#[cfg(not(feature = "physics-bullet-native"))]
 fn physics_world_reset_impl(
     _world: *mut MmdRuntimePhysicsWorld,
     _instance: *mut MmdRuntimeInstance,
@@ -4538,6 +4698,7 @@ fn physics_world_create_impl(
             unsafe {
                 *out_world = Box::into_raw(Box::new(MmdRuntimePhysicsWorld {
                     world,
+                    pmx_model: None,
                     next_bake_sample_is_seed_only: true,
                 }));
             }
@@ -4564,6 +4725,7 @@ fn physics_world_create_from_pmx_bytes_impl(
             unsafe {
                 *out_world = Box::into_raw(Box::new(MmdRuntimePhysicsWorld {
                     world,
+                    pmx_model: Some(model),
                     next_bake_sample_is_seed_only: true,
                 }));
             }
@@ -4571,6 +4733,246 @@ fn physics_world_create_from_pmx_bytes_impl(
         }
         Err(err) => status_failure(MmdRuntimeStatus::Error, err.to_string().as_str()),
     }
+}
+
+#[cfg(feature = "physics-bullet-native")]
+fn validate_physics_param_names(model: &mmd_anim_format::PmxParsedModel) -> Result<(), String> {
+    fn validate<'a>(kind: &str, names: impl Iterator<Item = &'a str>) -> Result<(), String> {
+        let mut seen = HashSet::new();
+        for name in names {
+            if name.is_empty() {
+                return Err(format!("PMX {kind} has an empty name"));
+            }
+            if !seen.insert(name) {
+                return Err(format!("PMX {kind} name is duplicated: {name}"));
+            }
+        }
+        Ok(())
+    }
+
+    validate(
+        "rigid body",
+        model.rigid_bodies.iter().map(|body| body.name.as_str()),
+    )?;
+    validate(
+        "joint",
+        model.joints.iter().map(|joint| joint.name.as_str()),
+    )
+}
+
+#[cfg(feature = "physics-bullet-native")]
+fn physics_params_get_json_impl(world: &MmdRuntimePhysicsWorld) -> MmdRuntimeFfiByteBuffer {
+    let Some(model) = world.pmx_model.as_ref() else {
+        return empty_byte_buffer_failure("physics parameters require a PMX-created world");
+    };
+    if let Err(message) = validate_physics_param_names(model) {
+        set_last_error(message);
+        return empty_byte_buffer();
+    }
+
+    let rigid_bodies = model
+        .rigid_bodies
+        .iter()
+        .map(|body| {
+            (
+                body.name.clone(),
+                PhysicsRigidBodyParams {
+                    mass: body.mass,
+                    linear_damping: body.linear_damping,
+                    angular_damping: body.angular_damping,
+                    friction: body.friction,
+                    restitution: body.restitution,
+                },
+            )
+        })
+        .collect();
+    let joints = model
+        .joints
+        .iter()
+        .map(|joint| {
+            (
+                joint.name.clone(),
+                PhysicsJointParams {
+                    translation_lower_limit: joint.translation_lower_limit,
+                    translation_upper_limit: joint.translation_upper_limit,
+                    rotation_lower_limit: joint.rotation_lower_limit,
+                    rotation_upper_limit: joint.rotation_upper_limit,
+                    spring_translation_factor: joint.spring_translation_factor,
+                    spring_rotation_factor: joint.spring_rotation_factor,
+                },
+            )
+        })
+        .collect();
+    let snapshot = PhysicsParamsSnapshot {
+        schema_version: PHYSICS_PARAMS_SCHEMA_VERSION,
+        rigid_bodies,
+        joints,
+    };
+    match serde_json::to_vec(&snapshot) {
+        Ok(bytes) => byte_buffer_from_vec(bytes),
+        Err(error) => {
+            set_last_error(format!("physics parameter JSON encode failed: {error}"));
+            empty_byte_buffer()
+        }
+    }
+}
+
+#[cfg(feature = "physics-bullet-native")]
+fn physics_params_set_json_impl(
+    world: &mut MmdRuntimePhysicsWorld,
+    data: &[u8],
+) -> MmdRuntimeStatus {
+    let Some(source_model) = world.pmx_model.as_ref() else {
+        return status_failure(
+            MmdRuntimeStatus::Unsupported,
+            "physics parameters require a PMX-created world",
+        );
+    };
+    if let Err(message) = validate_physics_param_names(source_model) {
+        set_last_error(message);
+        return MmdRuntimeStatus::InvalidInput;
+    }
+    let update: PhysicsParamsUpdate = match serde_json::from_slice(data) {
+        Ok(update) => update,
+        Err(error) => {
+            set_last_error(format!("invalid physics parameter JSON: {error}"));
+            return MmdRuntimeStatus::InvalidInput;
+        }
+    };
+    if update.schema_version != PHYSICS_PARAMS_SCHEMA_VERSION {
+        return status_failure(
+            MmdRuntimeStatus::InvalidInput,
+            "unsupported physics parameter schema_version",
+        );
+    }
+
+    let mut replacement_model = source_model.clone();
+    for (name, values) in update.rigid_bodies {
+        let Some(body) = replacement_model
+            .rigid_bodies
+            .iter_mut()
+            .find(|body| body.name == name)
+        else {
+            set_last_error(format!("unknown PMX rigid body name: {name}"));
+            return MmdRuntimeStatus::InvalidInput;
+        };
+        if let Some(value) = values.mass {
+            if !value.is_finite() || value < 0.0 {
+                return invalid_physics_param("mass must be finite and >= 0");
+            }
+            body.mass = value;
+        }
+        if let Some(value) = values.linear_damping {
+            if !value.is_finite() || !(0.0..=1.0).contains(&value) {
+                return invalid_physics_param("linear_damping must be finite and in [0, 1]");
+            }
+            body.linear_damping = value;
+        }
+        if let Some(value) = values.angular_damping {
+            if !value.is_finite() || !(0.0..=1.0).contains(&value) {
+                return invalid_physics_param("angular_damping must be finite and in [0, 1]");
+            }
+            body.angular_damping = value;
+        }
+        if let Some(value) = values.friction {
+            if !value.is_finite() || value < 0.0 {
+                return invalid_physics_param("friction must be finite and >= 0");
+            }
+            body.friction = value;
+        }
+        if let Some(value) = values.restitution {
+            if !value.is_finite() || !(0.0..=1.0).contains(&value) {
+                return invalid_physics_param("restitution must be finite and in [0, 1]");
+            }
+            body.restitution = value;
+        }
+    }
+
+    for (name, values) in update.joints {
+        let Some(joint) = replacement_model
+            .joints
+            .iter_mut()
+            .find(|joint| joint.name == name)
+        else {
+            set_last_error(format!("unknown PMX joint name: {name}"));
+            return MmdRuntimeStatus::InvalidInput;
+        };
+        if let Some(value) = values.translation_lower_limit {
+            joint.translation_lower_limit = value;
+        }
+        if let Some(value) = values.translation_upper_limit {
+            joint.translation_upper_limit = value;
+        }
+        if let Some(value) = values.rotation_lower_limit {
+            joint.rotation_lower_limit = value;
+        }
+        if let Some(value) = values.rotation_upper_limit {
+            joint.rotation_upper_limit = value;
+        }
+        if let Some(value) = values.spring_translation_factor {
+            joint.spring_translation_factor = value;
+        }
+        if let Some(value) = values.spring_rotation_factor {
+            joint.spring_rotation_factor = value;
+        }
+        for (field, value) in [
+            ("translation_lower_limit", joint.translation_lower_limit),
+            ("translation_upper_limit", joint.translation_upper_limit),
+            ("rotation_lower_limit", joint.rotation_lower_limit),
+            ("rotation_upper_limit", joint.rotation_upper_limit),
+        ] {
+            if !all_finite(&value) {
+                return invalid_physics_param(&format!("{field} must contain finite values"));
+            }
+        }
+        for (field, value) in [
+            ("spring_translation_factor", joint.spring_translation_factor),
+            ("spring_rotation_factor", joint.spring_rotation_factor),
+        ] {
+            if !all_finite(&value) || value.iter().any(|component| *component < 0.0) {
+                return invalid_physics_param(&format!("{field} must contain finite values >= 0"));
+            }
+        }
+        if joint
+            .translation_lower_limit
+            .iter()
+            .zip(joint.translation_upper_limit)
+            .any(|(lower, upper)| *lower > upper)
+        {
+            return invalid_physics_param("translation lower limits must be <= upper limits");
+        }
+        if joint
+            .rotation_lower_limit
+            .iter()
+            .zip(joint.rotation_upper_limit)
+            .any(|(lower, upper)| *lower > upper)
+        {
+            return invalid_physics_param("rotation lower limits must be <= upper limits");
+        }
+    }
+
+    let gravity = match world.world.world.gravity() {
+        Ok(gravity) => gravity,
+        Err(error) => return status_failure(MmdRuntimeStatus::Error, &error.to_string()),
+    };
+    let mut replacement_world =
+        match mmd_anim_physics_bullet::build_bullet_world_from_pmx(&replacement_model) {
+            Ok(world) => world,
+            Err(error) => return status_failure(MmdRuntimeStatus::Error, &error.to_string()),
+        };
+    if let Err(error) = replacement_world.world.set_gravity(gravity) {
+        return status_failure(MmdRuntimeStatus::Error, &error.to_string());
+    }
+
+    world.world = replacement_world;
+    world.pmx_model = Some(replacement_model);
+    world.next_bake_sample_is_seed_only = true;
+    MmdRuntimeStatus::Ok
+}
+
+#[cfg(feature = "physics-bullet-native")]
+fn invalid_physics_param(message: &str) -> MmdRuntimeStatus {
+    status_failure(MmdRuntimeStatus::InvalidInput, message)
 }
 
 #[cfg(feature = "physics-bullet-native")]

--- a/crates/mmd-anim-ffi/src/tests.rs
+++ b/crates/mmd-anim-ffi/src/tests.rs
@@ -1460,6 +1460,24 @@ fn physics_world_abi_exports_unsupported_stubs_when_feature_is_off() {
         },
         MmdRuntimeStatus::Unsupported
     );
+
+    let get = unsafe { mmd_runtime_physics_params_get_json(ptr::null()) };
+    assert!(get.data.is_null());
+    assert_eq!(get.len, 0);
+    assert_eq!(
+        unsafe { mmd_runtime_physics_params_set_json(ptr::null_mut(), b"{}".as_ptr(), 2) },
+        MmdRuntimeStatus::InvalidInput
+    );
+
+    let world = Box::into_raw(Box::new(MmdRuntimePhysicsWorld {}));
+    let get = unsafe { mmd_runtime_physics_params_get_json(world) };
+    assert!(get.data.is_null());
+    assert_eq!(get.len, 0);
+    assert_eq!(
+        unsafe { mmd_runtime_physics_params_set_json(world, b"{}".as_ptr(), 2) },
+        MmdRuntimeStatus::Unsupported
+    );
+    unsafe { mmd_runtime_physics_world_free(world) };
 }
 
 #[cfg(feature = "physics-bullet-native")]
@@ -1892,6 +1910,43 @@ fn create_physics_bake_clip() -> *mut MmdRuntimeClip {
             morph_tracks.len(),
             morph_keyframes.as_ptr(),
             morph_keyframes.len(),
+            ptr::null(),
+            0,
+            ptr::null(),
+            0,
+        )
+    }
+}
+
+#[cfg(feature = "physics-bullet-native")]
+fn create_bone_only_physics_bake_clip() -> *mut MmdRuntimeClip {
+    let bone_tracks = [MmdRuntimeFfiBoneTrack {
+        bone_index: 0,
+        keyframe_offset: 0,
+        keyframe_count: 2,
+    }];
+    let bone_keyframes = [
+        MmdRuntimeFfiBoneKeyframe {
+            frame: 0,
+            position_xyz: [0.0, 0.0, 0.0],
+            rotation_xyzw: [0.0, 0.0, 0.0, 1.0],
+        },
+        MmdRuntimeFfiBoneKeyframe {
+            frame: 30,
+            position_xyz: [0.0, 1.0, 0.0],
+            rotation_xyzw: [0.0, 0.0, 0.0, 1.0],
+        },
+    ];
+    unsafe {
+        mmd_runtime_clip_create(
+            bone_tracks.as_ptr(),
+            bone_tracks.len(),
+            bone_keyframes.as_ptr(),
+            bone_keyframes.len(),
+            ptr::null(),
+            0,
+            ptr::null(),
+            0,
             ptr::null(),
             0,
             ptr::null(),
@@ -5188,30 +5243,41 @@ fn host_frame_pmx_bytes() -> Vec<u8> {
             ],
             "rigidBodies": [
                 {
-                    "name": "anchorBody",
+                    "name": "アンカー剛体",
                     "boneIndex": 1,
                     "shape": "sphere",
                     "size": [0.5, 0.0, 0.0],
                     "position": [0.0, 10.0, 0.0],
+                    "friction": 0.25,
                     "mode": "static"
                 },
                 {
-                    "name": "physicsBody",
+                    "name": "物理剛体",
                     "boneIndex": 2,
                     "shape": "sphere",
                     "size": [0.5, 0.0, 0.0],
                     "position": [0.0, 8.0, 0.0],
                     "mass": 1.0,
+                    "linearDamping": 0.2,
+                    "angularDamping": 0.3,
+                    "friction": 0.4,
+                    "restitution": 0.1,
                     "mode": "dynamic"
                 }
             ],
             "joints": [
                 {
-                    "name": "joint",
+                    "name": "接続ジョイント",
                     "type": "generic6dofSpring",
                     "rigidBodyIndexA": 0,
                     "rigidBodyIndexB": 1,
-                    "position": [0.0, 9.0, 0.0]
+                    "position": [0.0, 9.0, 0.0],
+                    "translationLowerLimit": [-1.0, -2.0, -3.0],
+                    "translationUpperLimit": [1.0, 2.0, 3.0],
+                    "rotationLowerLimit": [-0.1, -0.2, -0.3],
+                    "rotationUpperLimit": [0.1, 0.2, 0.3],
+                    "springTranslationFactor": [1.0, 2.0, 3.0],
+                    "springRotationFactor": [4.0, 5.0, 6.0]
                 }
             ]
         }))
@@ -5235,6 +5301,336 @@ fn host_frame_pmx_bytes() -> Vec<u8> {
     .unwrap();
 
     mmd_anim_format::export_pmx_model(&model)
+}
+
+#[cfg(feature = "physics-bullet-native")]
+fn physics_params_json_bytes(world: *const MmdRuntimePhysicsWorld) -> Vec<u8> {
+    let buffer = unsafe { mmd_runtime_physics_params_get_json(world) };
+    assert!(!buffer.data.is_null(), "{:?}", last_error_cstr());
+    assert!(buffer.len > 0);
+    let bytes = unsafe { slice::from_raw_parts(buffer.data, buffer.len).to_vec() };
+    unsafe { mmd_runtime_byte_buffer_free(buffer) };
+    bytes
+}
+
+#[cfg(feature = "physics-bullet-native")]
+fn physics_gravity(world: *const MmdRuntimePhysicsWorld) -> [f32; 3] {
+    let mut gravity = [0.0; 3];
+    assert_eq!(
+        unsafe { mmd_runtime_physics_world_get_gravity(world, gravity.as_mut_ptr()) },
+        MmdRuntimeStatus::Ok
+    );
+    gravity
+}
+
+#[cfg(feature = "physics-bullet-native")]
+fn physics_world_from_bytes(bytes: &[u8]) -> *mut MmdRuntimePhysicsWorld {
+    let mut world = ptr::null_mut();
+    assert_eq!(
+        unsafe {
+            mmd_runtime_physics_world_create_from_pmx_bytes(bytes.as_ptr(), bytes.len(), &mut world)
+        },
+        MmdRuntimeStatus::Ok
+    );
+    assert!(!world.is_null());
+    world
+}
+
+#[cfg(feature = "physics-bullet-native")]
+#[test]
+fn physics_params_get_emits_complete_deterministic_utf8_schema_v1_snapshot() {
+    let bytes = host_frame_pmx_bytes();
+    let world = physics_world_from_bytes(&bytes);
+
+    let first = physics_params_json_bytes(world);
+    let second = physics_params_json_bytes(world);
+    assert_eq!(first, second);
+    let value: serde_json::Value = serde_json::from_slice(&first).unwrap();
+    assert_eq!(
+        value.as_object().unwrap().keys().collect::<Vec<_>>(),
+        ["joints", "rigid_bodies", "schema_version"]
+    );
+    assert_eq!(value["schema_version"], 1);
+    assert_eq!(
+        value["rigid_bodies"]
+            .as_object()
+            .unwrap()
+            .keys()
+            .collect::<Vec<_>>(),
+        ["アンカー剛体", "物理剛体"]
+    );
+    assert_eq!(value["rigid_bodies"]["物理剛体"]["mass"], 1.0);
+    assert_eq!(value["rigid_bodies"]["物理剛体"]["linear_damping"], 0.2);
+    assert_eq!(value["rigid_bodies"]["物理剛体"]["angular_damping"], 0.3);
+    assert_eq!(value["rigid_bodies"]["物理剛体"]["friction"], 0.4);
+    assert_eq!(value["rigid_bodies"]["物理剛体"]["restitution"], 0.1);
+    assert_eq!(
+        value["joints"]["接続ジョイント"]["translation_lower_limit"],
+        serde_json::json!([-1.0, -2.0, -3.0])
+    );
+    assert_eq!(
+        value["joints"]["接続ジョイント"]["spring_rotation_factor"],
+        serde_json::json!([4.0, 5.0, 6.0])
+    );
+
+    unsafe { mmd_runtime_physics_world_free(world) };
+}
+
+#[cfg(feature = "physics-bullet-native")]
+#[test]
+fn physics_params_unchanged_roundtrip_is_stable() {
+    let bytes = host_frame_pmx_bytes();
+    let world = physics_world_from_bytes(&bytes);
+    let snapshot = physics_params_json_bytes(world);
+
+    assert_eq!(
+        unsafe { mmd_runtime_physics_params_set_json(world, snapshot.as_ptr(), snapshot.len()) },
+        MmdRuntimeStatus::Ok
+    );
+    assert_eq!(physics_params_json_bytes(world), snapshot);
+
+    unsafe { mmd_runtime_physics_world_free(world) };
+}
+
+#[cfg(feature = "physics-bullet-native")]
+#[test]
+fn physics_params_set_rearms_next_bake_sample_as_seed_only_via_abi() {
+    let (model, instance, world) = host_frame_fixture();
+    let clip = create_bone_only_physics_bake_clip();
+    assert!(!clip.is_null());
+
+    assert_eq!(
+        unsafe { mmd_runtime_physics_world_reset(world, instance, ptr::null_mut()) },
+        MmdRuntimeStatus::Ok
+    );
+    let mut report = zero_physics_step_report();
+    assert_eq!(
+        unsafe { mmd_runtime_physics_world_step_runtime(world, instance, 1.0 / 60.0, &mut report) },
+        MmdRuntimeStatus::Ok
+    );
+    assert!(report.tick.substeps > 0 || report.bones_written_back > 0);
+
+    let snapshot = physics_params_json_bytes(world);
+    assert_eq!(
+        unsafe { mmd_runtime_physics_params_set_json(world, snapshot.as_ptr(), snapshot.len()) },
+        MmdRuntimeStatus::Ok
+    );
+
+    let mut world_out = [0.0f32; 48];
+    let morph_count = unsafe { mmd_runtime_model_morph_count(model) };
+    let mut morphs = vec![0.0f32; morph_count];
+    report = zero_physics_step_report();
+    assert_eq!(
+        unsafe {
+            mmd_runtime_physics_world_bake_clip_frames(
+                world,
+                instance,
+                clip,
+                0.0,
+                15.0,
+                1.0 / 60.0,
+                1,
+                world_out.as_mut_ptr(),
+                world_out.len(),
+                morphs.as_mut_ptr(),
+                morphs.len(),
+                &mut report,
+            )
+        },
+        MmdRuntimeStatus::Ok
+    );
+    assert_zero_physics_step_report(&report);
+
+    unsafe {
+        mmd_runtime_clip_free(clip);
+        mmd_runtime_physics_world_free(world);
+        mmd_runtime_instance_free(instance);
+        mmd_runtime_model_free(model);
+    }
+}
+
+#[cfg(feature = "physics-bullet-native")]
+#[test]
+fn physics_params_partial_set_rebuilds_and_preserves_gravity() {
+    let bytes = host_frame_pmx_bytes();
+    let world = physics_world_from_bytes(&bytes);
+    let gravity = [1.0f32, -42.0, 3.0];
+    assert_eq!(
+        unsafe { mmd_runtime_physics_world_set_gravity(world, gravity.as_ptr()) },
+        MmdRuntimeStatus::Ok
+    );
+    unsafe {
+        (*world).next_bake_sample_is_seed_only = false;
+    }
+    let update = serde_json::to_vec(&serde_json::json!({
+        "schema_version": 1,
+        "rigid_bodies": {
+            "物理剛体": {
+                "mass": 2.5,
+                "linear_damping": 0.6,
+                "angular_damping": 0.7,
+                "friction": 0.8,
+                "restitution": 0.9
+            }
+        },
+        "joints": {
+            "接続ジョイント": {
+                "translation_lower_limit": [-4.0, -5.0, -6.0],
+                "translation_upper_limit": [4.0, 5.0, 6.0],
+                "rotation_lower_limit": [-0.4, -0.5, -0.6],
+                "rotation_upper_limit": [0.4, 0.5, 0.6],
+                "spring_translation_factor": [7.0, 8.0, 9.0],
+                "spring_rotation_factor": [10.0, 11.0, 12.0]
+            }
+        }
+    }))
+    .unwrap();
+
+    assert_eq!(
+        unsafe { mmd_runtime_physics_params_set_json(world, update.as_ptr(), update.len()) },
+        MmdRuntimeStatus::Ok
+    );
+    assert_eq!(physics_gravity(world), gravity);
+    assert!(unsafe { (*world).next_bake_sample_is_seed_only });
+    let value: serde_json::Value =
+        serde_json::from_slice(&physics_params_json_bytes(world)).unwrap();
+    assert_eq!(value["rigid_bodies"]["物理剛体"]["mass"], 2.5);
+    assert_eq!(
+        value["joints"]["接続ジョイント"]["translation_lower_limit"],
+        serde_json::json!([-4.0, -5.0, -6.0])
+    );
+    assert_eq!(
+        value["joints"]["接続ジョイント"]["spring_rotation_factor"],
+        serde_json::json!([10.0, 11.0, 12.0])
+    );
+
+    unsafe { mmd_runtime_physics_world_free(world) };
+}
+
+#[cfg(feature = "physics-bullet-native")]
+#[test]
+fn physics_params_invalid_updates_are_fail_atomic() {
+    let bytes = host_frame_pmx_bytes();
+    let world = physics_world_from_bytes(&bytes);
+    let gravity = [2.0f32, -50.0, 4.0];
+    assert_eq!(
+        unsafe { mmd_runtime_physics_world_set_gravity(world, gravity.as_ptr()) },
+        MmdRuntimeStatus::Ok
+    );
+    let snapshot = physics_params_json_bytes(world);
+    unsafe {
+        (*world).next_bake_sample_is_seed_only = false;
+    }
+    let invalid_updates = [
+        r#"{"schema_version":2}"#.as_bytes().to_vec(),
+        r#"{"schema_version":1,"unknown":{}}"#.as_bytes().to_vec(),
+        r#"{"schema_version":1,"rigid_bodies":{"missing":{"mass":1}}}"#
+            .as_bytes()
+            .to_vec(),
+        r#"{"schema_version":1,"rigid_bodies":{"物理剛体":{"unknown":1}}}"#
+            .as_bytes()
+            .to_vec(),
+        r#"{"schema_version":1,"rigid_bodies":{"物理剛体":{"mass":-1}}}"#
+            .as_bytes()
+            .to_vec(),
+        r#"{"schema_version":1,"rigid_bodies":{"物理剛体":{"mass":null}}}"#
+            .as_bytes()
+            .to_vec(),
+        r#"{"schema_version":1,"rigid_bodies":{"物理剛体":{"linear_damping":1.1}}}"#
+            .as_bytes()
+            .to_vec(),
+        r#"{"schema_version":1,"rigid_bodies":{"物理剛体":{"mass":1e999}}}"#
+            .as_bytes()
+            .to_vec(),
+        r#"{"schema_version":1,"joints":{"missing":{"spring_translation_factor":[0,0,0]}}}"#
+            .as_bytes()
+            .to_vec(),
+        r#"{"schema_version":1,"joints":{"接続ジョイント":{"spring_rotation_factor":[0,-1,0]}}}"#
+            .as_bytes()
+            .to_vec(),
+        r#"{"schema_version":1,"joints":{"接続ジョイント":{"spring_rotation_factor":null}}}"#
+            .as_bytes()
+            .to_vec(),
+        r#"{"schema_version":1,"joints":{"接続ジョイント":{"translation_lower_limit":[2,0,0]}}}"#
+            .as_bytes()
+            .to_vec(),
+        r#"{"schema_version":1"#.as_bytes().to_vec(),
+        vec![0xff, 0xfe],
+    ];
+
+    for update in &invalid_updates {
+        assert_eq!(
+            unsafe { mmd_runtime_physics_params_set_json(world, update.as_ptr(), update.len()) },
+            MmdRuntimeStatus::InvalidInput,
+            "update={:?}",
+            String::from_utf8_lossy(update)
+        );
+        assert!(last_error_cstr().is_some());
+        assert_eq!(physics_params_json_bytes(world), snapshot);
+        assert_eq!(physics_gravity(world), gravity);
+        assert!(!unsafe { (*world).next_bake_sample_is_seed_only });
+    }
+
+    unsafe { mmd_runtime_physics_world_free(world) };
+}
+
+#[cfg(feature = "physics-bullet-native")]
+#[test]
+fn physics_params_reject_unnamed_and_ambiguous_worlds() {
+    let valid_update = br#"{"schema_version":1}"#;
+
+    let mut typed_world = ptr::null_mut();
+    assert_eq!(
+        unsafe {
+            mmd_runtime_physics_world_create(ptr::null(), 0, ptr::null(), 0, &mut typed_world)
+        },
+        MmdRuntimeStatus::Ok
+    );
+    let get = unsafe { mmd_runtime_physics_params_get_json(typed_world) };
+    assert!(get.data.is_null());
+    assert_eq!(get.len, 0);
+    assert_eq!(
+        unsafe {
+            mmd_runtime_physics_params_set_json(
+                typed_world,
+                valid_update.as_ptr(),
+                valid_update.len(),
+            )
+        },
+        MmdRuntimeStatus::Unsupported
+    );
+    unsafe { mmd_runtime_physics_world_free(typed_world) };
+
+    let mutations: [fn(&mut mmd_anim_format::PmxParsedModel); 2] = [
+        |model: &mut mmd_anim_format::PmxParsedModel| {
+            model.rigid_bodies[1].name = model.rigid_bodies[0].name.clone();
+        },
+        |model: &mut mmd_anim_format::PmxParsedModel| {
+            model.joints[0].name.clear();
+        },
+    ];
+    for mutate in mutations {
+        let bytes = host_frame_pmx_bytes();
+        let mut model = mmd_anim_format::parse_pmx_model(&bytes).unwrap();
+        mutate(&mut model);
+        let bytes = mmd_anim_format::export_pmx_model(&model);
+        let world = physics_world_from_bytes(&bytes);
+        let get = unsafe { mmd_runtime_physics_params_get_json(world) };
+        assert!(get.data.is_null());
+        assert_eq!(get.len, 0);
+        assert!(last_error_cstr().is_some());
+        assert_eq!(
+            unsafe {
+                mmd_runtime_physics_params_set_json(
+                    world,
+                    valid_update.as_ptr(),
+                    valid_update.len(),
+                )
+            },
+            MmdRuntimeStatus::InvalidInput
+        );
+        unsafe { mmd_runtime_physics_world_free(world) };
+    }
 }
 
 /// Builds a model + instance + physics world all derived from the same PMX

--- a/crates/mmd-anim-wasm/Cargo.toml
+++ b/crates/mmd-anim-wasm/Cargo.toml
@@ -17,7 +17,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 glam.workspace = true
 mmd-anim-runtime.workspace = true
-mmd-anim-format = { path = "../mmd-anim-format", version = "0.3.0" }
+mmd-anim-format = { path = "../mmd-anim-format", version = "0.3.1" }
 wasm-bindgen.workspace = true
 js-sys.workspace = true
 serde_json.workspace = true

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -74,7 +74,7 @@ Rust API、C ABI、WASM wrapper を通じて、他のホストや製品にも同
 
 ```toml
 [dependencies]
-mmd-anim = "0.3"
+mmd-anim = "0.3.1"
 ```
 
 ## ネイティブ (C ABI) から使う

--- a/tools/check_ffi_header_symbols.py
+++ b/tools/check_ffi_header_symbols.py
@@ -84,6 +84,21 @@ UNITY_FUNCTIONS = {
     ),
 }
 
+PHYSICS_PARAM_FUNCTIONS = {
+    "mmd_runtime_physics_params_get_json": (
+        "ffi_byte_buffer",
+        [("world", "const_physics_world_ptr")],
+    ),
+    "mmd_runtime_physics_params_set_json": (
+        "status",
+        [
+            ("world", "physics_world_ptr"),
+            ("data", "const_u8_ptr"),
+            ("len", "usize"),
+        ],
+    ),
+}
+
 
 def rust_exported_symbols(text: str) -> set[str]:
     lines = text.splitlines()
@@ -133,7 +148,11 @@ def canonical_rust_type(type_name: str) -> str:
         "f32": "f32",
         "bool": "bool",
         "MmdRuntimeStatus": "status",
+        "MmdRuntimeFfiByteBuffer": "ffi_byte_buffer",
         "*const MmdRuntimeReducedPose": "const_reduced_pose_ptr",
+        "*const MmdRuntimePhysicsWorld": "const_physics_world_ptr",
+        "*mut MmdRuntimePhysicsWorld": "physics_world_ptr",
+        "*const u8": "const_u8_ptr",
         "*mut usize": "usize_ptr",
         "*mut MmdRuntimeFfiUnityCurveDescriptor": "unity_descriptor_ptr",
         "*mut MmdRuntimeFfiUnityCurveKey": "unity_key_ptr",
@@ -148,7 +167,11 @@ def canonical_c_type(type_name: str) -> str:
         "float": "f32",
         "bool": "bool",
         "mmd_runtime_status_t": "status",
+        "mmd_runtime_ffi_byte_buffer_t": "ffi_byte_buffer",
         "const mmd_runtime_reduced_pose_t*": "const_reduced_pose_ptr",
+        "const mmd_runtime_physics_world_t*": "const_physics_world_ptr",
+        "mmd_runtime_physics_world_t*": "physics_world_ptr",
+        "const uint8_t*": "const_u8_ptr",
         "size_t*": "usize_ptr",
         "mmd_runtime_ffi_unity_curve_descriptor_t*": "unity_descriptor_ptr",
         "mmd_runtime_ffi_unity_curve_key_t*": "unity_key_ptr",
@@ -244,6 +267,13 @@ def check_unity_abi_shapes(rust_text: str, header_text: str) -> list[str]:
             errors.append(
                 f"function {name}: Rust={rust_shape}, header={c_shape}, expected={expected}"
             )
+    for name, expected in PHYSICS_PARAM_FUNCTIONS.items():
+        rust_shape = rust_function_shape(rust_text, name)
+        c_shape = c_function_shape(header_text, name)
+        if rust_shape != expected or c_shape != expected or rust_shape != c_shape:
+            errors.append(
+                f"function {name}: Rust={rust_shape}, header={c_shape}, expected={expected}"
+            )
     return errors
 
 
@@ -281,7 +311,7 @@ def main() -> int:
         return 1
 
     print(
-        f"OK: {len(rust_symbols)} Rust FFI exports and Unity curve ABI shapes "
+        f"OK: {len(rust_symbols)} Rust FFI exports and tracked ABI shapes "
         "match mmd_runtime.h declarations."
     )
     return 0

--- a/tools/check_python_abi_drift.py
+++ b/tools/check_python_abi_drift.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Check the Python ctypes ABI subset against mmd_runtime.h."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PYTHON_ROOT = ROOT / "bindings" / "python"
+HEADER = ROOT / "crates" / "mmd-anim-ffi" / "include" / "mmd_runtime.h"
+sys.path.insert(0, str(PYTHON_ROOT))
+
+from mmd_anim._abi import FUNCTION_SPECS, STRUCT_SPECS  # noqa: E402
+
+
+def _strip_comments(text: str) -> str:
+    text = re.sub(r"/\*.*?\*/", "", text, flags=re.DOTALL)
+    return re.sub(r"//.*?$", "", text, flags=re.MULTILINE)
+
+
+def _normalize_type(value: str) -> str:
+    value = " ".join(value.split())
+    value = re.sub(r"\s*\*\s*", "*", value)
+    value = re.sub(r"\s*\[\s*(\d+)\s*\]", r"[\1]", value)
+    return value
+
+
+def parse_structs(text: str) -> dict[str, tuple[tuple[str, str], ...]]:
+    stripped = _strip_comments(text)
+    structs: dict[str, tuple[tuple[str, str], ...]] = {}
+    pattern = re.compile(
+        r"typedef\s+struct\s+\w+\s*\{(.*?)\}\s*(mmd_runtime_\w+_t)\s*;",
+        re.DOTALL,
+    )
+    for body, alias in pattern.findall(stripped):
+        fields: list[tuple[str, str]] = []
+        for declaration in body.split(";"):
+            declaration = declaration.strip()
+            if not declaration:
+                continue
+            match = re.fullmatch(r"(.+?)\s+(\w+)(\s*\[\s*\d+\s*\])?", declaration)
+            if match is None:
+                raise ValueError(f"could not parse {alias} field: {declaration!r}")
+            field_type = match.group(1) + (match.group(3) or "")
+            fields.append((match.group(2), _normalize_type(field_type)))
+        structs[alias] = tuple(fields)
+    return structs
+
+
+def parse_functions(text: str) -> dict[str, tuple[str, tuple[str, ...]]]:
+    stripped = _strip_comments(text)
+    functions: dict[str, tuple[str, tuple[str, ...]]] = {}
+    pattern = re.compile(
+        r"([^;{}#]+?)\s+(mmd_runtime_\w+)\s*\((.*?)\)\s*;", re.DOTALL
+    )
+    for return_type, name, parameters in pattern.findall(stripped):
+        argument_types: list[str] = []
+        parameters = parameters.strip()
+        if parameters and parameters != "void":
+            for declaration in parameters.split(","):
+                match = re.fullmatch(
+                    r"(.+?[\s*])\w+(\s*\[\s*\d+\s*\])?",
+                    declaration.strip(),
+                )
+                if match is None:
+                    raise ValueError(
+                        f"could not parse {name} parameter: {declaration.strip()!r}"
+                    )
+                argument_type = match.group(1)
+                if match.group(2):
+                    argument_type += "*"
+                argument_types.append(_normalize_type(argument_type))
+        functions[name] = (
+            _normalize_type(return_type),
+            tuple(argument_types),
+        )
+    return functions
+
+
+def check_header(header_text: str) -> tuple[list[str], list[str]]:
+    """Return fatal wrapped-ABI errors and non-fatal unwrapped symbols."""
+
+    actual_functions = parse_functions(header_text)
+    actual_structs = parse_structs(header_text)
+    errors: list[str] = []
+    for name, expected in FUNCTION_SPECS.items():
+        actual = actual_functions.get(name)
+        if actual is None:
+            errors.append(f"missing wrapped function: {name}")
+        elif actual != expected:
+            errors.append(f"function {name}: header={actual}, Python={expected}")
+    for name, expected in STRUCT_SPECS.items():
+        actual = actual_structs.get(name)
+        if actual is None:
+            errors.append(f"missing wrapped struct: {name}")
+        elif actual != expected:
+            errors.append(f"struct {name}: header={actual}, Python={expected}")
+    unwrapped = sorted(set(actual_functions) - set(FUNCTION_SPECS))
+    return errors, unwrapped
+
+
+def main() -> int:
+    errors, unwrapped = check_header(HEADER.read_text(encoding="utf-8"))
+    if errors:
+        print("Python ABI drift detected:", file=sys.stderr)
+        for error in errors:
+            print(f"  - {error}", file=sys.stderr)
+        return 1
+    print(
+        f"OK: {len(FUNCTION_SPECS)} Python-wrapped functions and "
+        f"{len(STRUCT_SPECS)} structs match mmd_runtime.h "
+        f"({len(unwrapped)} unwrapped functions allowed)."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- standardize CLI exit behavior as success `0`, execution failure `1`, and argument failure `2`, with path and format-detection diagnostics
- add an experimental dependency-free `ctypes` bridge with an ABI manifest/drift check, native lifecycle smokes, and CI coverage
- expose schema-versioned named physics parameter JSON through the C ABI with fail-atomic updates
- extend the internal Python layer with PMX/VMD model-clip-instance evaluation, frame/count queries, and caller-owned `array('f')` pose buffers
- wrap physics world parameter inspection/update with feature detection and structured native status errors
- prepare the workspace metadata and changelog for v0.3.1

## Design boundaries

The Python package remains an internal, low-level reference/evaluation harness:

- no NumPy dependency
- no stable public facade yet
- no additional C exports for the Python-only convenience layer
- batch evaluation remains deferred until Python loop/copy overhead is measured as a bottleneck

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace` — 796 passed, 3 ignored
- `python tools/check_ffi_header_symbols.py`
- `python tools/check_python_abi_drift.py` — 36 wrapped functions, 4 structs
- `cargo build -p mmd-anim-ffi --release`
- `python -B -m unittest discover -s bindings/python/tests -v` — 22 passed
- feature-off Python smoke — 21 passed, 1 explicit capability skip
- `crates/mmd-anim-ffi/scripts/smoke.ps1`
- verified no NumPy references under `bindings/python`
