### PR TITLE
Release v0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,45 @@
 # Changelog
 
+## 0.3.2 - 2026-07-24
+
+Runtime-neutral reduced-pose curves, safer native host contracts, faster PMX
+WASM payloads, and PMX morph metadata preservation.
+
+### Added
+
+- Added caller-owned C ABI enumeration for runtime-neutral DCC cubic reduced
+  bone and morph tracks, including versioned descriptors, extensible key
+  strides, normalized quaternion authority, and feature discovery.
+- Added a typed WASM vertex-morph offset handle and a non-geometry JSON path
+  that omits the duplicated vertex-offset payload for lower parse-time memory
+  and serialization cost.
+
+### Changed
+
+- Enabled the existing runtime IK convergence break by changing the default
+  tolerance from zero to `1e-4`, while preserving authored iteration counts and
+  allowing callers to request exact zero tolerance explicitly.
+- Clarified native model/instance lifetime ordering and kept reduced-pose curve
+  data readable for the documented handle lifetime.
+
+### Fixed
+
+- Preserved all five PMX morph panel categories across binary parse/export,
+  JSON compatibility defaults, FBX material splitting, and parts workflows.
+- Rejected non-canonical boolean and curve-flag bytes, invalid or overlapping
+  pointer ranges, aliased instance output views, undersized structs, and
+  misaligned or overflowing caller-owned buffers in the experimental C ABI.
+- Made native output-buffer failures initialize outputs consistently and report
+  required counts without partial writes.
+
+### Known limitations
+
+- The C ABI, WASM wrapper, reduced-curve surface, and Python binding remain
+  experimental and may change before 1.0.
+- The WASM non-geometry JSON compatibility method still includes vertex morph
+  offsets; consumers must opt into the new split payload methods to avoid the
+  duplicate data.
+
 ## 0.3.1 - 2026-07-19
 
 Python host integration, payload-free runtime model construction, consistent

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,9 @@ WASM payloads, and PMX morph metadata preservation.
 ### Fixed
 
 - Preserved all five PMX morph panel categories across binary parse/export,
-  JSON compatibility defaults, FBX material splitting, and parts workflows.
+  JSON compatibility defaults, FBX material splitting, and parts workflows;
+  parts export now rejects unknown panel labels instead of coercing them to
+  `other`.
 - Rejected non-canonical boolean and curve-flag bytes, invalid or overlapping
   pointer ranges, aliased instance output views, undersized structs, and
   misaligned or overflowing caller-owned buffers in the experimental C ABI.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -450,6 +450,7 @@ dependencies = [
  "js-sys",
  "mmd-anim-format",
  "mmd-anim-runtime",
+ "serde",
  "serde_json",
  "wasm-bindgen",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -418,6 +418,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
+ "web-time",
 ]
 
 [[package]]
@@ -711,6 +712,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -372,7 +372,7 @@ checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "mmd-anim"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "mmd-anim-format",
  "mmd-anim-runtime",
@@ -381,7 +381,7 @@ dependencies = [
 
 [[package]]
 name = "mmd-anim-cli"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -397,7 +397,7 @@ dependencies = [
 
 [[package]]
 name = "mmd-anim-ffi"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "glam",
  "mmd-anim-format",
@@ -409,7 +409,7 @@ dependencies = [
 
 [[package]]
 name = "mmd-anim-format"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "encoding_rs",
  "fbxcel",
@@ -422,7 +422,7 @@ dependencies = [
 
 [[package]]
 name = "mmd-anim-physics-bullet"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "cc",
  "glam",
@@ -434,7 +434,7 @@ dependencies = [
 
 [[package]]
 name = "mmd-anim-runtime"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "glam",
  "rayon",
@@ -443,7 +443,7 @@ dependencies = [
 
 [[package]]
 name = "mmd-anim-wasm"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "glam",
  "js-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -418,7 +418,6 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
- "web-time",
 ]
 
 [[package]]
@@ -713,16 +712,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "web-time"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.3.1"
+version = "0.3.2"
 edition = "2024"
 rust-version = "1.87"
 license = "MIT"
@@ -30,6 +30,6 @@ serde_json = "1.0.145"
 wasm-bindgen = "0.2.105"
 js-sys = "0.3"
 encoding_rs = "0.8"
-mmd-anim-runtime = { path = "crates/mmd-anim-runtime", version = "0.3.1" }
-mmd-anim-format = { path = "crates/mmd-anim-format", version = "0.3.1" }
+mmd-anim-runtime = { path = "crates/mmd-anim-runtime", version = "0.3.2" }
+mmd-anim-format = { path = "crates/mmd-anim-format", version = "0.3.2" }
  

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,6 @@ glam = { version = "0.32.1", features = ["debug-glam-assert", "fast-math"] }
 thiserror = "2.0.17"
 rayon = "1.10"
 serde = { version = "1.0.228", features = ["derive"] }
-web-time = "1.1.0"
 serde_json = "1.0.145"
 wasm-bindgen = "0.2.105"
 js-sys = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ glam = { version = "0.32.1", features = ["debug-glam-assert", "fast-math"] }
 thiserror = "2.0.17"
 rayon = "1.10"
 serde = { version = "1.0.228", features = ["derive"] }
+web-time = "1.1.0"
 serde_json = "1.0.145"
 wasm-bindgen = "0.2.105"
 js-sys = "0.3"

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Format support overview. "Loading" means parsing a file into structured data.
 
 ```toml
 [dependencies]
-mmd-anim = "0.3.1"
+mmd-anim = "0.3.2"
 ```
 
 ## Native Hosts (C ABI)

--- a/bindings/python/mmd_anim/__init__.py
+++ b/bindings/python/mmd_anim/__init__.py
@@ -1,5 +1,5 @@
 """Experimental in-repository Python support for mmd-anim.
 
 The native binding intentionally remains in ``mmd_anim._runtime`` while the
-0.3.1 ABI and Python API are being validated.  Nothing is re-exported here yet.
+0.3.2 ABI and Python API are being validated.  Nothing is re-exported here yet.
 """

--- a/bindings/python/tests/test_abi_drift.py
+++ b/bindings/python/tests/test_abi_drift.py
@@ -36,12 +36,12 @@ class AbiDriftCheckerTests(unittest.TestCase):
         mutated = self.header.replace(
             "typedef struct mmd_runtime_ffi_rig_ik_link {\n"
             "    uint32_t bone_slot;\n"
-            "    bool     has_angle_limit;\n"
+            "    uint8_t  has_angle_limit; /* must be 0 or 1 */\n"
             "    float    angle_limit_min_xyz[3];\n"
             "    float    angle_limit_max_xyz[3];",
             "typedef struct mmd_runtime_ffi_rig_ik_link {\n"
             "    uint32_t bone_slot;\n"
-            "    bool     has_angle_limit;\n"
+            "    uint8_t  has_angle_limit; /* must be 0 or 1 */\n"
             "    float    angle_limit_min_xyz[3];\n"
             "    float    angle_limit_max_xyz[4];",
             1,

--- a/crates/mmd-anim-cli/Cargo.toml
+++ b/crates/mmd-anim-cli/Cargo.toml
@@ -26,8 +26,8 @@ clap = { version = "4", features = ["derive"] }
 clap_complete = "4"
 glam.workspace = true
 mmd-anim-runtime.workspace = true
-mmd-anim-format = { path = "../mmd-anim-format", version = "0.3.1", features = ["fbx"] }
-mmd-anim-physics-bullet = { path = "../mmd-anim-physics-bullet", version = "0.3.1", features = ["native", "pmx-format", "runtime"], optional = true }
+mmd-anim-format = { path = "../mmd-anim-format", version = "0.3.2", features = ["fbx"] }
+mmd-anim-physics-bullet = { path = "../mmd-anim-physics-bullet", version = "0.3.2", features = ["native", "pmx-format", "runtime"], optional = true }
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true

--- a/crates/mmd-anim-ffi/Cargo.toml
+++ b/crates/mmd-anim-ffi/Cargo.toml
@@ -18,8 +18,8 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 glam.workspace = true
 mmd-anim-runtime.workspace = true
-mmd-anim-format = { path = "../mmd-anim-format", version = "0.3.1", features = ["fbx"] }
-mmd-anim-physics-bullet = { path = "../mmd-anim-physics-bullet", version = "0.3.1", optional = true, features = ["native", "runtime", "pmx-format"] }
+mmd-anim-format = { path = "../mmd-anim-format", version = "0.3.2", features = ["fbx"] }
+mmd-anim-physics-bullet = { path = "../mmd-anim-physics-bullet", version = "0.3.2", optional = true, features = ["native", "runtime", "pmx-format"] }
 serde.workspace = true
 serde_json.workspace = true
 

--- a/crates/mmd-anim-ffi/abi/python_abi_v2.json
+++ b/crates/mmd-anim-ffi/abi/python_abi_v2.json
@@ -19,7 +19,7 @@
       },
       {
         "name": "has_angle_limit",
-        "type": "bool"
+        "type": "uint8_t"
       },
       {
         "name": "angle_limit_min_xyz",

--- a/crates/mmd-anim-ffi/include/mmd_runtime.h
+++ b/crates/mmd-anim-ffi/include/mmd_runtime.h
@@ -47,11 +47,10 @@ extern "C" {
    ensuring that the bone indices used by the physics world match those of
    the instance it is paired with; index mismatches within bounds silently
    drive the wrong bones.
-   Free order: release instances before releasing the model they were
-   created from. Physics worlds may be freed in any order relative to
-   models. Freeing a model while instances still reference it is safe (Arc
-   keeps storage alive), but using any handle after it has been freed is
-   undefined behavior.
+   Models and instances may be released in either order: each instance keeps
+   its immutable model storage alive independently (Arc-backed). Physics
+   worlds may also be freed in any order relative to models and instances.
+   Using any individual handle after it has been freed is undefined behavior.
 
    Thread safety
    -------------

--- a/crates/mmd-anim-ffi/include/mmd_runtime.h
+++ b/crates/mmd-anim-ffi/include/mmd_runtime.h
@@ -30,7 +30,9 @@ extern "C" {
    bit 3 (MMD_RUNTIME_FEATURE_HOST_POSE_NATIVE_MORPHS) is set when HostPose
    local arrays are pre-Morph base values and Group/Bone Morph expansion is
    performed natively. Hosts that pre-apply Morph bone deltas must stop doing
-   so before using that contract.
+   so before using that contract; bit 4
+   (MMD_RUNTIME_FEATURE_REDUCED_POSE_GENERIC_CURVES) is set when runtime-neutral
+   reduced-pose sparse tracks are available.
    Check the relevant bit before calling any
    physics_world_* or evaluate_host_frame function; when the bit is unset
    those functions return MMD_RUNTIME_STATUS_UNSUPPORTED.
@@ -119,6 +121,8 @@ typedef struct mmd_runtime_reduced_pose_t mmd_runtime_reduced_pose_t;
 #define MMD_RUNTIME_FEATURE_PHYSICS_BULLET_NATIVE    (1u << 1)
 #define MMD_RUNTIME_FEATURE_MODEL_DESCRIPTOR         (1u << 2)
 #define MMD_RUNTIME_FEATURE_HOST_POSE_NATIVE_MORPHS  (1u << 3)
+#define MMD_RUNTIME_FEATURE_REDUCED_POSE_GENERIC_CURVES (1u << 4)
+#define MMD_RUNTIME_REDUCED_POSE_GENERIC_CURVE_ABI_VERSION_V1 1u
 #define MMD_RUNTIME_MODEL_DESCRIPTOR_VERSION_V1      1u
 #define MMD_RUNTIME_MODEL_DESCRIPTOR_FLAGS_NONE     0u
 
@@ -172,6 +176,76 @@ typedef struct mmd_runtime_ffi_pose_reduction_report {
     float max_world_rotation_error_radians;
     float max_morph_weight_error;
 } mmd_runtime_ffi_pose_reduction_report_t;
+
+typedef enum mmd_runtime_generic_curve_kind {
+    MMD_RUNTIME_GENERIC_CURVE_BONE_LOCAL = 0,
+    MMD_RUNTIME_GENERIC_CURVE_MORPH_WEIGHT = 1
+} mmd_runtime_generic_curve_kind_t;
+
+enum {
+    MMD_RUNTIME_GENERIC_VALUE_TRANSLATION = 1u << 0,
+    MMD_RUNTIME_GENERIC_VALUE_QUATERNION = 1u << 1,
+    MMD_RUNTIME_GENERIC_VALUE_SCALAR = 1u << 2
+};
+
+enum {
+    MMD_RUNTIME_GENERIC_COORDINATE_MMD_RUNTIME_NATIVE = 0,
+    MMD_RUNTIME_GENERIC_LENGTH_MODEL_UNITS = 0,
+    MMD_RUNTIME_GENERIC_ANGLE_RADIANS = 0,
+    MMD_RUNTIME_GENERIC_TIME_SAMPLE_FRAMES = 0,
+    MMD_RUNTIME_GENERIC_TANGENT_VALUE_PER_SAMPLE_FRAME = 0
+};
+
+enum {
+    MMD_RUNTIME_GENERIC_ROTATION_BASIS_NONE = 0,
+    MMD_RUNTIME_GENERIC_ROTATION_BASIS_RUNTIME_QUATERNION = 1,
+    MMD_RUNTIME_GENERIC_ROTATION_BASIS_EULER_XYZ_RADIANS_PER_FRAME = 2
+};
+
+typedef struct mmd_runtime_ffi_generic_curve_info {
+    uint32_t struct_size;
+    uint32_t abi_version;
+    uint32_t reduction_target;
+    uint32_t coordinate_system;
+    uint32_t length_unit;
+    uint32_t angle_unit;
+    uint32_t time_unit;
+    uint32_t tangent_unit;
+    uint64_t model_identity;
+    float    start_frame;
+    float    frame_step;
+    size_t   frame_count;
+    size_t   bone_count;
+    size_t   morph_count;
+} mmd_runtime_ffi_generic_curve_info_t;
+
+typedef struct mmd_runtime_ffi_generic_curve_descriptor {
+    uint32_t struct_size;
+    uint32_t abi_version;
+    uint32_t kind;
+    uint32_t target_index;
+    int32_t  parent_index;
+    uint32_t value_flags;
+    uint32_t interpolation;
+    uint32_t rotation_basis;
+    size_t   key_count;
+} mmd_runtime_ffi_generic_curve_descriptor_t;
+
+typedef struct mmd_runtime_ffi_generic_curve_key {
+    size_t sample_index;
+    float  frame;
+    float  translation_xyz[3];
+    float  rotation_xyzw[4];
+    float  scalar;
+    float  segment_prev_out_translation_xyz[3];
+    float  segment_current_in_translation_xyz[3];
+    float  segment_from_previous_start_euler_xyz[3];
+    float  segment_from_previous_end_euler_xyz[3];
+    float  segment_prev_out_rotation_xyz[3];
+    float  segment_current_in_rotation_xyz[3];
+    float  segment_prev_out_scalar;
+    float  segment_current_in_scalar;
+} mmd_runtime_ffi_generic_curve_key_t;
 
 typedef struct mmd_runtime_ffi_unity_curve_descriptor {
     uint32_t semantic;    /* mmd_runtime_unity_curve_semantic_t */
@@ -1295,7 +1369,40 @@ mmd_runtime_status_t mmd_runtime_reduced_pose_report(
     const mmd_runtime_reduced_pose_t*               pose,
     mmd_runtime_ffi_pose_reduction_report_t*        out_report);
 
-/* Enumerates target-native Unity scalar curves from a DCC_CUBIC reduced pose.
+/* Runtime-neutral sparse tracks from a DCC_CUBIC reduced pose. Values remain in
+   the dense/runtime numeric basis: model units, radians, source sample frames,
+   tangent value per sample frame, and unscaled morph weights. Bone tracks are
+   enumerated first in model index order, followed by morph tracks. Rotation
+   values are normalized local quaternions; Euler XYZ segment fields are
+   diagnostic DCC fit data and are not target-channel rotations. */
+mmd_runtime_status_t mmd_runtime_reduced_pose_generic_curve_info(
+    const mmd_runtime_reduced_pose_t*            pose,
+    mmd_runtime_ffi_generic_curve_info_t*        out_info);
+
+mmd_runtime_status_t mmd_runtime_reduced_pose_generic_curve_count(
+    const mmd_runtime_reduced_pose_t* pose,
+    size_t*                           out_curve_count);
+
+mmd_runtime_status_t mmd_runtime_reduced_pose_generic_curve_descriptor(
+    const mmd_runtime_reduced_pose_t*             pose,
+    size_t                                        curve_index,
+    mmd_runtime_ffi_generic_curve_descriptor_t*   out_descriptor);
+
+/* Two-call, caller-owned retrieval. Pass out_keys = NULL, capacity = 0, and
+   key_stride_bytes = sizeof(mmd_runtime_ffi_generic_curve_key_t) to receive
+   BUFFER_TOO_SMALL plus the required count. Short buffers are not partially
+   written. A larger aligned stride permits caller-side tail extension. */
+mmd_runtime_status_t mmd_runtime_reduced_pose_generic_curve_keys(
+    const mmd_runtime_reduced_pose_t* pose,
+    size_t                            curve_index,
+    mmd_runtime_ffi_generic_curve_key_t* out_keys,
+    size_t                            out_key_capacity,
+    size_t                            key_stride_bytes,
+    size_t*                           out_required_count);
+
+/* Deprecated compatibility adapter. New consumers, including Unity, must use
+   the generic curve API above and perform target conversion in the consumer.
+   Enumerates target-native Unity scalar curves from a DCC_CUBIC reduced pose.
    Curves are translation XYZ then local Euler XYZ for each bone, followed by
    one weight curve for each morph. frames_per_second must be finite and > 0;
    flip_z is uint8_t and must be exactly 0 or 1; other values return

--- a/crates/mmd-anim-ffi/include/mmd_runtime.h
+++ b/crates/mmd-anim-ffi/include/mmd_runtime.h
@@ -353,7 +353,7 @@ typedef struct mmd_runtime_model_descriptor {
 
 typedef struct mmd_runtime_ffi_rig_ik_link {
     uint32_t bone_slot;
-    bool     has_angle_limit;
+    uint8_t  has_angle_limit; /* must be 0 or 1 */
     float    angle_limit_min_xyz[3];
     float    angle_limit_max_xyz[3];
 } mmd_runtime_ffi_rig_ik_link_t;
@@ -367,11 +367,11 @@ typedef struct mmd_runtime_ffi_rig_bone {
 
 /* Additive v2 per-bone local-axis descriptor for primitive IK-chain creation.
    Existing mmd_runtime_ffi_rig_bone_t layout is intentionally unchanged.
-   has_local_axis == false means unit XYZ angle-limit frames for that bone.
-   When has_local_axis is true, local_axis_x_xyz / local_axis_z_xyz are the PMX
+   has_local_axis == 0 means unit XYZ angle-limit frames for that bone.
+   When has_local_axis is 1, local_axis_x_xyz / local_axis_z_xyz are the PMX
    bone-local X/Z directions used only as the IK angle-limit evaluation frame. */
 typedef struct mmd_runtime_ffi_rig_bone_local_axis_v2 {
-    bool  has_local_axis;
+    uint8_t has_local_axis; /* must be 0 or 1 */
     float local_axis_x_xyz[3];
     float local_axis_z_xyz[3];
 } mmd_runtime_ffi_rig_bone_local_axis_v2_t;
@@ -385,8 +385,8 @@ typedef struct mmd_runtime_ffi_ik_solve_stats {
 
 typedef struct mmd_runtime_ffi_append_config {
     float ratio;
-    bool  affect_rotation;
-    bool  affect_translation;
+    uint8_t affect_rotation;    /* must be 0 or 1 */
+    uint8_t affect_translation; /* must be 0 or 1 */
 } mmd_runtime_ffi_append_config_t;
 
 typedef struct mmd_runtime_ffi_bone_morph_offset {

--- a/crates/mmd-anim-ffi/include/mmd_runtime.h
+++ b/crates/mmd-anim-ffi/include/mmd_runtime.h
@@ -1299,20 +1299,22 @@ mmd_runtime_status_t mmd_runtime_reduced_pose_report(
 /* Enumerates target-native Unity scalar curves from a DCC_CUBIC reduced pose.
    Curves are translation XYZ then local Euler XYZ for each bone, followed by
    one weight curve for each morph. frames_per_second must be finite and > 0;
-   flip_z selects Unity handedness conversion. LINEAR_SLERP and VMD_BEZIER
+   flip_z is uint8_t and must be exactly 0 or 1; other values return
+   MMD_RUNTIME_STATUS_INVALID_INPUT. It selects Unity handedness conversion.
+   LINEAR_SLERP and VMD_BEZIER
    reduced poses return MMD_RUNTIME_STATUS_UNSUPPORTED rather than being
    silently converted to Hermite curves. The reduced handle owns its skeleton
    snapshot, so these calls remain valid after the source model is freed. */
 mmd_runtime_status_t mmd_runtime_reduced_pose_unity_curve_count(
     const mmd_runtime_reduced_pose_t* pose,
     float                             frames_per_second,
-    bool                              flip_z,
+    uint8_t                           flip_z,
     size_t*                           out_curve_count);
 
 mmd_runtime_status_t mmd_runtime_reduced_pose_unity_curve_descriptor(
     const mmd_runtime_reduced_pose_t*             pose,
     float                                         frames_per_second,
-    bool                                          flip_z,
+    uint8_t                                       flip_z,
     size_t                                        curve_index,
     mmd_runtime_ffi_unity_curve_descriptor_t*     out_descriptor);
 
@@ -1324,7 +1326,7 @@ mmd_runtime_status_t mmd_runtime_reduced_pose_unity_curve_descriptor(
 mmd_runtime_status_t mmd_runtime_reduced_pose_unity_curve_keys(
     const mmd_runtime_reduced_pose_t* pose,
     float                             frames_per_second,
-    bool                              flip_z,
+    uint8_t                           flip_z,
     size_t                            curve_index,
     mmd_runtime_ffi_unity_curve_key_t* out_keys,
     size_t                            out_key_capacity,

--- a/crates/mmd-anim-ffi/src/lib.rs
+++ b/crates/mmd-anim-ffi/src/lib.rs
@@ -392,7 +392,7 @@ pub struct MmdRuntimeModelDescriptor {
 #[repr(C)]
 pub struct MmdRuntimeFfiRigIkLink {
     pub bone_slot: u32,
-    pub has_angle_limit: bool,
+    pub has_angle_limit: u8,
     pub angle_limit_min_xyz: [f32; 3],
     pub angle_limit_max_xyz: [f32; 3],
 }
@@ -412,7 +412,7 @@ pub struct MmdRuntimeFfiRigBone {
 /// `mmd_runtime_ik_chain_create_v2`.
 #[repr(C)]
 pub struct MmdRuntimeFfiRigBoneLocalAxisV2 {
-    pub has_local_axis: bool,
+    pub has_local_axis: u8,
     pub local_axis_x_xyz: [f32; 3],
     pub local_axis_z_xyz: [f32; 3],
 }
@@ -428,8 +428,8 @@ pub struct MmdRuntimeFfiIkSolveStats {
 #[repr(C)]
 pub struct MmdRuntimeFfiAppendConfig {
     pub ratio: f32,
-    pub affect_rotation: bool,
-    pub affect_translation: bool,
+    pub affect_rotation: u8,
+    pub affect_translation: u8,
 }
 
 #[repr(C)]
@@ -1069,13 +1069,19 @@ pub unsafe extern "C" fn mmd_runtime_append_solver_create(
             return ptr::null_mut();
         }
         let config = unsafe { &*config };
+        let Some(affect_rotation) = parse_ffi_bool(config.affect_rotation) else {
+            return ptr::null_mut();
+        };
+        let Some(affect_translation) = parse_ffi_bool(config.affect_translation) else {
+            return ptr::null_mut();
+        };
         if !config.ratio.is_finite() {
             return ptr::null_mut();
         }
         Box::into_raw(Box::new(MmdRuntimeAppendSolver {
             ratio: config.ratio,
-            affect_rotation: config.affect_rotation,
-            affect_translation: config.affect_translation,
+            affect_rotation,
+            affect_translation,
         }))
     })
 }
@@ -7104,7 +7110,8 @@ unsafe fn build_ik_chain_definition(
             if link.bone_slot as usize >= bone_count {
                 return None;
             }
-            let angle_limit = if link.has_angle_limit {
+            let has_angle_limit = parse_ffi_bool(link.has_angle_limit)?;
+            let angle_limit = if has_angle_limit {
                 if !all_finite(&link.angle_limit_min_xyz) || !all_finite(&link.angle_limit_max_xyz)
                 {
                     return None;
@@ -7152,7 +7159,8 @@ unsafe fn build_ik_chain_local_axis_bases(
     let local_axes = unsafe { checked_slice(local_axes, bone_count) }?;
     let mut bases = Vec::with_capacity(bone_count);
     for axis in local_axes {
-        if !axis.has_local_axis {
+        let has_local_axis = parse_ffi_bool(axis.has_local_axis)?;
+        if !has_local_axis {
             bases.push(None);
             continue;
         }
@@ -7179,6 +7187,14 @@ unsafe fn build_ik_chain_local_axis_bases(
 fn checked_range<T>(slice: &[T], offset: usize, count: usize) -> Option<&[T]> {
     let end = offset.checked_add(count)?;
     slice.get(offset..end)
+}
+
+fn parse_ffi_bool(value: u8) -> Option<bool> {
+    match value {
+        0 => Some(false),
+        1 => Some(true),
+        _ => None,
+    }
 }
 
 fn descriptor_failure<T>(message: impl AsRef<str>) -> Option<T> {

--- a/crates/mmd-anim-ffi/src/lib.rs
+++ b/crates/mmd-anim-ffi/src/lib.rs
@@ -7042,6 +7042,14 @@ unsafe fn checked_slice<'a, T>(ptr: *const T, len: usize) -> Option<&'a [T]> {
     if ptr.is_null() {
         return None;
     }
+    let start = ptr as usize;
+    if !start.is_multiple_of(std::mem::align_of::<T>()) {
+        return None;
+    }
+    let byte_len = len.checked_mul(std::mem::size_of::<T>())?;
+    if byte_len > isize::MAX as usize || start.checked_add(byte_len).is_none() {
+        return None;
+    }
     Some(unsafe { slice::from_raw_parts(ptr, len) })
 }
 
@@ -7530,20 +7538,21 @@ unsafe fn build_model_from_ffi(input: RawModelInput) -> Option<ModelArena> {
     let inverse_bind_matrices = if input.inverse_bind_matrices.is_null() {
         &[]
     } else {
-        unsafe { slice::from_raw_parts(input.inverse_bind_matrices, input.bone_count * 16) }
+        let len = input.bone_count.checked_mul(16)?;
+        unsafe { checked_slice(input.inverse_bind_matrices, len) }?
     };
     let transform_orders = if input.transform_orders.is_null() {
         &[]
     } else {
-        unsafe { slice::from_raw_parts(input.transform_orders, input.bone_count) }
+        unsafe { checked_slice(input.transform_orders, input.bone_count) }?
     };
     let ik_solvers = unsafe { checked_slice(input.ik_solvers, input.ik_solver_count) }?;
     let ik_links = unsafe { checked_slice(input.ik_links, input.ik_link_count) }?;
     let append_transforms =
         unsafe { checked_slice(input.append_transforms, input.append_transform_count) }?;
-    let parents = unsafe { slice::from_raw_parts(input.parent_indices, input.bone_count) };
-    let positions =
-        unsafe { slice::from_raw_parts(input.rest_positions_xyz, input.bone_count * 3) };
+    let parents = unsafe { checked_slice(input.parent_indices, input.bone_count) }?;
+    let position_len = input.bone_count.checked_mul(3)?;
+    let positions = unsafe { checked_slice(input.rest_positions_xyz, position_len) }?;
     let bones = build_bones_from_flat(FlatBoneInput {
         parent_indices: parents,
         rest_positions_xyz: positions,

--- a/crates/mmd-anim-ffi/src/lib.rs
+++ b/crates/mmd-anim-ffi/src/lib.rs
@@ -5739,16 +5739,21 @@ pub unsafe extern "C" fn mmd_runtime_instance_evaluate_clip_frame_batch(
         let ik_count = instance.runtime.ik_enabled().len();
         let workers = resolve_batch_worker_count(worker_count, frame_count);
 
-        let out_world = if required_world_len == 0 {
-            &mut []
-        } else {
-            unsafe { slice::from_raw_parts_mut(out_world_matrices_f32, required_world_len) }
+        let Some(world_range) = checked_pointer_range(out_world_matrices_f32, required_world_len)
+        else {
+            return false;
         };
-        let out_morph = if required_morph_len == 0 {
-            &mut []
-        } else {
-            unsafe { slice::from_raw_parts_mut(out_morph_weights_f32, required_morph_len) }
+        let Some(morph_range) = checked_pointer_range(out_morph_weights_f32, required_morph_len)
+        else {
+            return false;
         };
+        if pointer_ranges_overlap(world_range, morph_range) {
+            return false;
+        }
+        let out_world = unsafe { checked_mut_slice(out_world_matrices_f32, required_world_len) }
+            .expect("output range was validated");
+        let out_morph = unsafe { checked_mut_slice(out_morph_weights_f32, required_morph_len) }
+            .expect("output range was validated");
 
         if workers <= 1 {
             let mut runtime = RuntimeInstance::new_with_counts(model, morph_count, ik_count);
@@ -5865,10 +5870,10 @@ pub unsafe extern "C" fn mmd_runtime_reduced_pose_create_from_dense(
     out_reduced_pose: *mut *mut MmdRuntimeReducedPose,
 ) -> MmdRuntimeStatus {
     ffi_guard(MmdRuntimeStatus::Error, || {
-        let Some(out_reduced_pose) = (unsafe { out_reduced_pose.as_mut() }) else {
+        if out_reduced_pose.is_null() {
             return status_failure(MmdRuntimeStatus::InvalidInput, FFI_ERR_INVALID_INPUT);
-        };
-        *out_reduced_pose = ptr::null_mut();
+        }
+        unsafe { ptr::write(out_reduced_pose, ptr::null_mut()) };
         let Some(model) = (unsafe { model.as_ref() }) else {
             return status_failure(MmdRuntimeStatus::InvalidInput, FFI_ERR_INVALID_INPUT);
         };
@@ -5949,10 +5954,15 @@ pub unsafe extern "C" fn mmd_runtime_reduced_pose_create_from_dense(
                     return status_failure(MmdRuntimeStatus::InvalidInput, &error.to_string());
                 }
             };
-        *out_reduced_pose = Box::into_raw(Box::new(MmdRuntimeReducedPose {
-            sequence,
-            unity_curve_cache: RefCell::new(None),
-        }));
+        unsafe {
+            ptr::write(
+                out_reduced_pose,
+                Box::into_raw(Box::new(MmdRuntimeReducedPose {
+                    sequence,
+                    unity_curve_cache: RefCell::new(None),
+                })),
+            )
+        };
         MmdRuntimeStatus::Ok
     })
 }
@@ -6018,10 +6028,10 @@ pub unsafe extern "C" fn mmd_runtime_reduced_pose_report(
         let Some(pose) = (unsafe { pose.as_ref() }) else {
             return status_failure(MmdRuntimeStatus::InvalidInput, FFI_ERR_INVALID_INPUT);
         };
-        let Some(out_report) = (unsafe { out_report.as_mut() }) else {
+        if out_report.is_null() {
             return status_failure(MmdRuntimeStatus::InvalidInput, FFI_ERR_INVALID_INPUT);
-        };
-        *out_report = ffi_reduction_report(pose.sequence.report());
+        }
+        unsafe { ptr::write(out_report, ffi_reduction_report(pose.sequence.report())) };
         MmdRuntimeStatus::Ok
     })
 }
@@ -6471,16 +6481,20 @@ fn physics_world_bake_clip_frames_impl(
         return status_failure(MmdRuntimeStatus::InvalidInput, FFI_ERR_INVALID_INPUT);
     }
 
-    let out_world = if required_world_len == 0 {
-        &mut []
-    } else {
-        unsafe { slice::from_raw_parts_mut(out_world_matrices_f32, required_world_len) }
+    let Some(world_range) = checked_pointer_range(out_world_matrices_f32, required_world_len)
+    else {
+        return status_failure(MmdRuntimeStatus::InvalidInput, FFI_ERR_INVALID_INPUT);
     };
-    let out_morph = if required_morph_len == 0 {
-        &mut []
-    } else {
-        unsafe { slice::from_raw_parts_mut(out_morph_weights_f32, required_morph_len) }
+    let Some(morph_range) = checked_pointer_range(out_morph_weights_f32, required_morph_len) else {
+        return status_failure(MmdRuntimeStatus::InvalidInput, FFI_ERR_INVALID_INPUT);
     };
+    if pointer_ranges_overlap(world_range, morph_range) {
+        return status_failure(MmdRuntimeStatus::InvalidInput, FFI_ERR_INVALID_INPUT);
+    }
+    let out_world = unsafe { checked_mut_slice(out_world_matrices_f32, required_world_len) }
+        .expect("output range was validated");
+    let out_morph = unsafe { checked_mut_slice(out_morph_weights_f32, required_morph_len) }
+        .expect("output range was validated");
 
     let mut last_report = MmdRuntimeFfiPhysicsWorldStepReport {
         tick: physics_step_stats_to_ffi(PhysicsStepStats::default()),
@@ -7036,8 +7050,24 @@ unsafe fn build_clip_from_ffi(input: RawClipInput) -> Option<AnimationClip> {
 }
 
 unsafe fn checked_slice<'a, T>(ptr: *const T, len: usize) -> Option<&'a [T]> {
+    checked_pointer_range(ptr, len)?;
     if len == 0 {
         return Some(&[]);
+    }
+    Some(unsafe { slice::from_raw_parts(ptr, len) })
+}
+
+unsafe fn checked_mut_slice<'a, T>(ptr: *mut T, len: usize) -> Option<&'a mut [T]> {
+    checked_pointer_range(ptr, len)?;
+    if len == 0 {
+        return Some(&mut []);
+    }
+    Some(unsafe { slice::from_raw_parts_mut(ptr, len) })
+}
+
+fn checked_pointer_range<T>(ptr: *const T, len: usize) -> Option<(usize, usize)> {
+    if len == 0 {
+        return Some((0, 0));
     }
     if ptr.is_null() {
         return None;
@@ -7047,10 +7077,14 @@ unsafe fn checked_slice<'a, T>(ptr: *const T, len: usize) -> Option<&'a [T]> {
         return None;
     }
     let byte_len = len.checked_mul(std::mem::size_of::<T>())?;
-    if byte_len > isize::MAX as usize || start.checked_add(byte_len).is_none() {
+    if byte_len > isize::MAX as usize {
         return None;
     }
-    Some(unsafe { slice::from_raw_parts(ptr, len) })
+    Some((start, start.checked_add(byte_len)?))
+}
+
+fn pointer_ranges_overlap(left: (usize, usize), right: (usize, usize)) -> bool {
+    left.0 < left.1 && right.0 < right.1 && left.0 < right.1 && right.0 < left.1
 }
 
 fn all_finite(values: &[f32]) -> bool {

--- a/crates/mmd-anim-ffi/src/lib.rs
+++ b/crates/mmd-anim-ffi/src/lib.rs
@@ -6603,8 +6603,13 @@ pub unsafe extern "C" fn mmd_runtime_instance_copy_world_matrices(
         if out_f32_len < required_len {
             return false;
         }
+        if output_overlaps_instance_views(instance, out_f32, required_len) {
+            return false;
+        }
 
-        let out = unsafe { slice::from_raw_parts_mut(out_f32, required_len) };
+        let Some(out) = (unsafe { checked_mut_slice(out_f32, required_len) }) else {
+            return false;
+        };
         flatten_matrices_into_slice(out, matrices);
         true
     })
@@ -6654,8 +6659,13 @@ pub unsafe extern "C" fn mmd_runtime_instance_copy_skinning_matrices(
         if out_f32_len < required_len {
             return false;
         }
+        if output_overlaps_instance_views(instance, out_f32, required_len) {
+            return false;
+        }
 
-        let out = unsafe { slice::from_raw_parts_mut(out_f32, required_len) };
+        let Some(out) = (unsafe { checked_mut_slice(out_f32, required_len) }) else {
+            return false;
+        };
         flatten_matrices_into_slice(out, matrices);
         true
     })
@@ -6765,7 +6775,12 @@ pub unsafe extern "C" fn mmd_runtime_instance_copy_morph_weights(
         if out_f32_len < weights.len() {
             return false;
         }
-        let out = unsafe { slice::from_raw_parts_mut(out_f32, weights.len()) };
+        if output_overlaps_instance_views(instance, out_f32, weights.len()) {
+            return false;
+        }
+        let Some(out) = (unsafe { checked_mut_slice(out_f32, weights.len()) }) else {
+            return false;
+        };
         out.copy_from_slice(weights);
         true
     })
@@ -6813,7 +6828,12 @@ pub unsafe extern "C" fn mmd_runtime_instance_copy_ik_enabled(
         if out_u8_len < states.len() {
             return false;
         }
-        let out = unsafe { slice::from_raw_parts_mut(out_u8, states.len()) };
+        if output_overlaps_instance_views(instance, out_u8, states.len()) {
+            return false;
+        }
+        let Some(out) = (unsafe { checked_mut_slice(out_u8, states.len()) }) else {
+            return false;
+        };
         out.copy_from_slice(states);
         true
     })
@@ -7085,6 +7105,38 @@ fn checked_pointer_range<T>(ptr: *const T, len: usize) -> Option<(usize, usize)>
 
 fn pointer_ranges_overlap(left: (usize, usize), right: (usize, usize)) -> bool {
     left.0 < left.1 && right.0 < right.1 && left.0 < right.1 && right.0 < left.1
+}
+
+fn output_overlaps_instance_views<T>(
+    instance: &MmdRuntimeInstance,
+    output: *const T,
+    output_len: usize,
+) -> bool {
+    let Some(output_range) = checked_pointer_range(output, output_len) else {
+        return true;
+    };
+    let view_ranges = [
+        checked_pointer_range(
+            instance.cached_world_matrices.as_ptr(),
+            instance.cached_world_matrices.len(),
+        ),
+        checked_pointer_range(
+            instance.cached_skinning_matrices.as_ptr(),
+            instance.cached_skinning_matrices.len(),
+        ),
+        checked_pointer_range(
+            instance.runtime.morph_weights().as_ptr(),
+            instance.runtime.morph_weights().len(),
+        ),
+        checked_pointer_range(
+            instance.runtime.ik_enabled().as_ptr(),
+            instance.runtime.ik_enabled().len(),
+        ),
+    ];
+    view_ranges
+        .into_iter()
+        .flatten()
+        .any(|view_range| pointer_ranges_overlap(output_range, view_range))
 }
 
 fn all_finite(values: &[f32]) -> bool {

--- a/crates/mmd-anim-ffi/src/lib.rs
+++ b/crates/mmd-anim-ffi/src/lib.rs
@@ -38,11 +38,15 @@ const FEATURE_SPLIT_PHYSICS_EVALUATION: u32 = 1 << 0;
 const FEATURE_PHYSICS_BULLET_NATIVE: u32 = 1 << 1;
 pub const MMD_RUNTIME_FEATURE_MODEL_DESCRIPTOR: u32 = 1 << 2;
 pub const MMD_RUNTIME_FEATURE_HOST_POSE_NATIVE_MORPHS: u32 = 1 << 3;
+pub const MMD_RUNTIME_FEATURE_REDUCED_POSE_GENERIC_CURVES: u32 = 1 << 4;
+pub const MMD_RUNTIME_REDUCED_POSE_GENERIC_CURVE_ABI_VERSION_V1: u32 = 1;
+pub const MMD_RUNTIME_REDUCTION_TARGET_DCC_CUBIC: u32 = 2;
 pub const MMD_RUNTIME_MODEL_DESCRIPTOR_VERSION_V1: u32 =
     mmd_anim_runtime::RUNTIME_MODEL_DESCRIPTOR_VERSION_V1;
 pub const MMD_RUNTIME_MODEL_DESCRIPTOR_FLAGS_NONE: u32 = 0;
 const FEATURE_MODEL_DESCRIPTOR: u32 = MMD_RUNTIME_FEATURE_MODEL_DESCRIPTOR;
 const FEATURE_HOST_POSE_NATIVE_MORPHS: u32 = MMD_RUNTIME_FEATURE_HOST_POSE_NATIVE_MORPHS;
+const FEATURE_REDUCED_POSE_GENERIC_CURVES: u32 = MMD_RUNTIME_FEATURE_REDUCED_POSE_GENERIC_CURVES;
 
 pub struct MmdRuntimeModel {
     model: Arc<ModelArena>,
@@ -477,6 +481,111 @@ pub struct MmdRuntimeFfiPoseReductionReport {
     pub max_morph_weight_error: f32,
 }
 
+pub const MMD_RUNTIME_GENERIC_CURVE_BONE_LOCAL: u32 = 0;
+pub const MMD_RUNTIME_GENERIC_CURVE_MORPH_WEIGHT: u32 = 1;
+
+pub const MMD_RUNTIME_GENERIC_VALUE_TRANSLATION: u32 = 1 << 0;
+pub const MMD_RUNTIME_GENERIC_VALUE_QUATERNION: u32 = 1 << 1;
+pub const MMD_RUNTIME_GENERIC_VALUE_SCALAR: u32 = 1 << 2;
+
+pub const MMD_RUNTIME_GENERIC_COORDINATE_MMD_RUNTIME_NATIVE: u32 = 0;
+pub const MMD_RUNTIME_GENERIC_LENGTH_MODEL_UNITS: u32 = 0;
+pub const MMD_RUNTIME_GENERIC_ANGLE_RADIANS: u32 = 0;
+pub const MMD_RUNTIME_GENERIC_TIME_SAMPLE_FRAMES: u32 = 0;
+pub const MMD_RUNTIME_GENERIC_TANGENT_VALUE_PER_SAMPLE_FRAME: u32 = 0;
+
+pub const MMD_RUNTIME_GENERIC_ROTATION_BASIS_NONE: u32 = 0;
+pub const MMD_RUNTIME_GENERIC_ROTATION_BASIS_RUNTIME_QUATERNION: u32 = 1;
+pub const MMD_RUNTIME_GENERIC_ROTATION_BASIS_EULER_XYZ_RADIANS_PER_FRAME: u32 = 2;
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct MmdRuntimeFfiGenericCurveInfo {
+    pub struct_size: u32,
+    pub abi_version: u32,
+    pub reduction_target: u32,
+    pub coordinate_system: u32,
+    pub length_unit: u32,
+    pub angle_unit: u32,
+    pub time_unit: u32,
+    pub tangent_unit: u32,
+    pub model_identity: u64,
+    pub start_frame: f32,
+    pub frame_step: f32,
+    pub frame_count: usize,
+    pub bone_count: usize,
+    pub morph_count: usize,
+}
+
+impl Default for MmdRuntimeFfiGenericCurveInfo {
+    fn default() -> Self {
+        Self {
+            struct_size: std::mem::size_of::<Self>() as u32,
+            abi_version: 0,
+            reduction_target: 0,
+            coordinate_system: 0,
+            length_unit: 0,
+            angle_unit: 0,
+            time_unit: 0,
+            tangent_unit: 0,
+            model_identity: 0,
+            start_frame: 0.0,
+            frame_step: 0.0,
+            frame_count: 0,
+            bone_count: 0,
+            morph_count: 0,
+        }
+    }
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct MmdRuntimeFfiGenericCurveDescriptor {
+    pub struct_size: u32,
+    pub abi_version: u32,
+    pub kind: u32,
+    pub target_index: u32,
+    pub parent_index: i32,
+    pub value_flags: u32,
+    pub interpolation: u32,
+    pub rotation_basis: u32,
+    pub key_count: usize,
+}
+
+impl Default for MmdRuntimeFfiGenericCurveDescriptor {
+    fn default() -> Self {
+        Self {
+            struct_size: std::mem::size_of::<Self>() as u32,
+            abi_version: 0,
+            kind: 0,
+            target_index: 0,
+            parent_index: 0,
+            value_flags: 0,
+            interpolation: 0,
+            rotation_basis: 0,
+            key_count: 0,
+        }
+    }
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct MmdRuntimeFfiGenericCurveKey {
+    pub sample_index: usize,
+    pub frame: f32,
+    pub translation_xyz: [f32; 3],
+    pub rotation_xyzw: [f32; 4],
+    pub scalar: f32,
+    pub segment_prev_out_translation_xyz: [f32; 3],
+    pub segment_current_in_translation_xyz: [f32; 3],
+    pub segment_from_previous_start_euler_xyz: [f32; 3],
+    pub segment_from_previous_end_euler_xyz: [f32; 3],
+    pub segment_prev_out_rotation_xyz: [f32; 3],
+    pub segment_current_in_rotation_xyz: [f32; 3],
+    pub segment_prev_out_scalar: f32,
+    pub segment_current_in_scalar: f32,
+}
+
 pub const MMD_RUNTIME_UNITY_CURVE_BONE_LOCAL_TRANSLATION: u32 = 0;
 pub const MMD_RUNTIME_UNITY_CURVE_BONE_LOCAL_EULER: u32 = 1;
 pub const MMD_RUNTIME_UNITY_CURVE_MORPH_WEIGHT: u32 = 2;
@@ -780,6 +889,7 @@ fn runtime_feature_flags() -> u32 {
     FEATURE_SPLIT_PHYSICS_EVALUATION
         | FEATURE_MODEL_DESCRIPTOR
         | FEATURE_HOST_POSE_NATIVE_MORPHS
+        | FEATURE_REDUCED_POSE_GENERIC_CURVES
         | if cfg!(feature = "physics-bullet-native") {
             FEATURE_PHYSICS_BULLET_NATIVE
         } else {
@@ -6032,6 +6142,455 @@ pub unsafe extern "C" fn mmd_runtime_reduced_pose_report(
             return status_failure(MmdRuntimeStatus::InvalidInput, FFI_ERR_INVALID_INPUT);
         }
         unsafe { ptr::write(out_report, ffi_reduction_report(pose.sequence.report())) };
+        MmdRuntimeStatus::Ok
+    })
+}
+
+unsafe fn initialize_sized_ffi_output<T: Default>(out: *mut T) -> Result<(), MmdRuntimeStatus> {
+    if out.is_null() || !(out as usize).is_multiple_of(std::mem::align_of::<T>()) {
+        return Err(status_failure(
+            MmdRuntimeStatus::InvalidInput,
+            FFI_ERR_INVALID_INPUT,
+        ));
+    }
+    let declared_size = unsafe { ptr::read(out.cast::<u32>()) } as usize;
+    if declared_size < std::mem::size_of::<T>() {
+        return Err(status_failure(
+            MmdRuntimeStatus::InvalidInput,
+            "output struct_size is smaller than the v1 structure",
+        ));
+    }
+    unsafe { ptr::write(out, T::default()) };
+    Ok(())
+}
+
+fn validate_generic_curve_request(pose: &MmdRuntimeReducedPose) -> Result<(), MmdRuntimeStatus> {
+    if pose.sequence.target() != ReductionTarget::DccCubic {
+        return Err(status_failure(
+            MmdRuntimeStatus::Unsupported,
+            "generic curve enumeration requires a DccCubic reduced pose",
+        ));
+    }
+    if !pose.sequence.start_frame().is_finite()
+        || !pose.sequence.frame_step().is_finite()
+        || pose
+            .sequence
+            .sample_frames()
+            .iter()
+            .any(|frame| !frame.is_finite())
+    {
+        return Err(status_failure(
+            MmdRuntimeStatus::InvalidInput,
+            "generic curve metadata must be finite",
+        ));
+    }
+    Ok(())
+}
+
+fn generic_curve_count(sequence: &ReducedPoseSequence) -> Option<usize> {
+    sequence
+        .bone_tracks()
+        .len()
+        .checked_add(sequence.morph_tracks().len())
+}
+
+fn generic_curve_descriptor(
+    sequence: &ReducedPoseSequence,
+    curve_index: usize,
+) -> Result<MmdRuntimeFfiGenericCurveDescriptor, MmdRuntimeStatus> {
+    if let Some(track) = sequence.bone_tracks().get(curve_index) {
+        let target_index = u32::try_from(curve_index).map_err(|_| {
+            status_failure(
+                MmdRuntimeStatus::InvalidInput,
+                "bone index exceeds uint32_t",
+            )
+        })?;
+        let parent_index = *sequence
+            .snapshot()
+            .parent_indices()
+            .get(curve_index)
+            .ok_or_else(|| {
+                status_failure(
+                    MmdRuntimeStatus::Error,
+                    "generic bone descriptor has no matching parent index",
+                )
+            })?;
+        return Ok(MmdRuntimeFfiGenericCurveDescriptor {
+            struct_size: std::mem::size_of::<MmdRuntimeFfiGenericCurveDescriptor>() as u32,
+            abi_version: MMD_RUNTIME_REDUCED_POSE_GENERIC_CURVE_ABI_VERSION_V1,
+            kind: MMD_RUNTIME_GENERIC_CURVE_BONE_LOCAL,
+            target_index,
+            parent_index,
+            value_flags: MMD_RUNTIME_GENERIC_VALUE_TRANSLATION
+                | MMD_RUNTIME_GENERIC_VALUE_QUATERNION,
+            interpolation: MMD_RUNTIME_REDUCTION_TARGET_DCC_CUBIC,
+            rotation_basis: MMD_RUNTIME_GENERIC_ROTATION_BASIS_RUNTIME_QUATERNION,
+            key_count: track.keys().len(),
+        });
+    }
+
+    let morph_index = curve_index
+        .checked_sub(sequence.bone_tracks().len())
+        .ok_or_else(|| {
+            status_failure(MmdRuntimeStatus::InvalidInput, "curve index out of range")
+        })?;
+    let track = sequence.morph_tracks().get(morph_index).ok_or_else(|| {
+        status_failure(MmdRuntimeStatus::InvalidInput, "curve index out of range")
+    })?;
+    let target_index = u32::try_from(morph_index).map_err(|_| {
+        status_failure(
+            MmdRuntimeStatus::InvalidInput,
+            "morph index exceeds uint32_t",
+        )
+    })?;
+    Ok(MmdRuntimeFfiGenericCurveDescriptor {
+        struct_size: std::mem::size_of::<MmdRuntimeFfiGenericCurveDescriptor>() as u32,
+        abi_version: MMD_RUNTIME_REDUCED_POSE_GENERIC_CURVE_ABI_VERSION_V1,
+        kind: MMD_RUNTIME_GENERIC_CURVE_MORPH_WEIGHT,
+        target_index,
+        parent_index: -1,
+        value_flags: MMD_RUNTIME_GENERIC_VALUE_SCALAR,
+        interpolation: MMD_RUNTIME_REDUCTION_TARGET_DCC_CUBIC,
+        rotation_basis: MMD_RUNTIME_GENERIC_ROTATION_BASIS_NONE,
+        key_count: track.keys().len(),
+    })
+}
+
+fn generic_curve_key(
+    sequence: &ReducedPoseSequence,
+    curve_index: usize,
+    key_index: usize,
+) -> Result<MmdRuntimeFfiGenericCurveKey, MmdRuntimeStatus> {
+    if let Some(track) = sequence.bone_tracks().get(curve_index) {
+        let key = track.keys().get(key_index).ok_or_else(|| {
+            status_failure(MmdRuntimeStatus::Error, "generic bone key index mismatch")
+        })?;
+        let frame = *sequence
+            .sample_frames()
+            .get(key.sample_index)
+            .ok_or_else(|| {
+                status_failure(
+                    MmdRuntimeStatus::Error,
+                    "generic bone key sample index is out of range",
+                )
+            })?;
+        let result = MmdRuntimeFfiGenericCurveKey {
+            sample_index: key.sample_index,
+            frame,
+            translation_xyz: key.translation.to_array(),
+            rotation_xyzw: key.rotation.to_array(),
+            scalar: 0.0,
+            segment_prev_out_translation_xyz: key.dcc_segment.translation_out_tangent.to_array(),
+            segment_current_in_translation_xyz: key.dcc_segment.translation_in_tangent.to_array(),
+            segment_from_previous_start_euler_xyz: key
+                .dcc_segment
+                .rotation_start_euler_xyz
+                .to_array(),
+            segment_from_previous_end_euler_xyz: key.dcc_segment.rotation_end_euler_xyz.to_array(),
+            segment_prev_out_rotation_xyz: key.dcc_segment.rotation_out_tangent.to_array(),
+            segment_current_in_rotation_xyz: key.dcc_segment.rotation_in_tangent.to_array(),
+            segment_prev_out_scalar: 0.0,
+            segment_current_in_scalar: 0.0,
+        };
+        if !generic_curve_key_is_finite(&result) {
+            return Err(status_failure(
+                MmdRuntimeStatus::InvalidInput,
+                "generic bone key contains a non-finite value",
+            ));
+        }
+        return Ok(result);
+    }
+
+    let morph_index = curve_index
+        .checked_sub(sequence.bone_tracks().len())
+        .ok_or_else(|| {
+            status_failure(MmdRuntimeStatus::InvalidInput, "curve index out of range")
+        })?;
+    let track = sequence.morph_tracks().get(morph_index).ok_or_else(|| {
+        status_failure(MmdRuntimeStatus::InvalidInput, "curve index out of range")
+    })?;
+    let key = track.keys().get(key_index).ok_or_else(|| {
+        status_failure(MmdRuntimeStatus::Error, "generic morph key index mismatch")
+    })?;
+    let frame = *sequence
+        .sample_frames()
+        .get(key.sample_index)
+        .ok_or_else(|| {
+            status_failure(
+                MmdRuntimeStatus::Error,
+                "generic morph key sample index is out of range",
+            )
+        })?;
+    let result = MmdRuntimeFfiGenericCurveKey {
+        sample_index: key.sample_index,
+        frame,
+        scalar: key.weight,
+        segment_prev_out_scalar: key.dcc_segment.out_tangent,
+        segment_current_in_scalar: key.dcc_segment.in_tangent,
+        ..MmdRuntimeFfiGenericCurveKey::default()
+    };
+    if !generic_curve_key_is_finite(&result) {
+        return Err(status_failure(
+            MmdRuntimeStatus::InvalidInput,
+            "generic morph key contains a non-finite value",
+        ));
+    }
+    Ok(result)
+}
+
+fn generic_curve_key_is_finite(key: &MmdRuntimeFfiGenericCurveKey) -> bool {
+    key.frame.is_finite()
+        && key.translation_xyz.iter().all(|value| value.is_finite())
+        && key.rotation_xyzw.iter().all(|value| value.is_finite())
+        && key.scalar.is_finite()
+        && key
+            .segment_prev_out_translation_xyz
+            .iter()
+            .all(|value| value.is_finite())
+        && key
+            .segment_current_in_translation_xyz
+            .iter()
+            .all(|value| value.is_finite())
+        && key
+            .segment_from_previous_start_euler_xyz
+            .iter()
+            .all(|value| value.is_finite())
+        && key
+            .segment_from_previous_end_euler_xyz
+            .iter()
+            .all(|value| value.is_finite())
+        && key
+            .segment_prev_out_rotation_xyz
+            .iter()
+            .all(|value| value.is_finite())
+        && key
+            .segment_current_in_rotation_xyz
+            .iter()
+            .all(|value| value.is_finite())
+        && key.segment_prev_out_scalar.is_finite()
+        && key.segment_current_in_scalar.is_finite()
+}
+
+/// Copies runtime-neutral metadata for a DCC cubic reduced pose.
+///
+/// # Safety
+///
+/// `pose` must be a live reduced-pose handle. `out_info` must point to writable,
+/// naturally aligned storage whose leading `struct_size` is at least the v1 size.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn mmd_runtime_reduced_pose_generic_curve_info(
+    pose: *const MmdRuntimeReducedPose,
+    out_info: *mut MmdRuntimeFfiGenericCurveInfo,
+) -> MmdRuntimeStatus {
+    ffi_guard(MmdRuntimeStatus::Error, || {
+        if let Err(status) = unsafe { initialize_sized_ffi_output(out_info) } {
+            return status;
+        }
+        let Some(pose) = (unsafe { pose.as_ref() }) else {
+            return status_failure(MmdRuntimeStatus::InvalidInput, FFI_ERR_INVALID_INPUT);
+        };
+        if let Err(status) = validate_generic_curve_request(pose) {
+            return status;
+        }
+        unsafe {
+            ptr::write(
+                out_info,
+                MmdRuntimeFfiGenericCurveInfo {
+                    struct_size: std::mem::size_of::<MmdRuntimeFfiGenericCurveInfo>() as u32,
+                    abi_version: MMD_RUNTIME_REDUCED_POSE_GENERIC_CURVE_ABI_VERSION_V1,
+                    reduction_target: MMD_RUNTIME_REDUCTION_TARGET_DCC_CUBIC,
+                    coordinate_system: MMD_RUNTIME_GENERIC_COORDINATE_MMD_RUNTIME_NATIVE,
+                    length_unit: MMD_RUNTIME_GENERIC_LENGTH_MODEL_UNITS,
+                    angle_unit: MMD_RUNTIME_GENERIC_ANGLE_RADIANS,
+                    time_unit: MMD_RUNTIME_GENERIC_TIME_SAMPLE_FRAMES,
+                    tangent_unit: MMD_RUNTIME_GENERIC_TANGENT_VALUE_PER_SAMPLE_FRAME,
+                    model_identity: pose.sequence.snapshot().model_identity(),
+                    start_frame: pose.sequence.start_frame(),
+                    frame_step: pose.sequence.frame_step(),
+                    frame_count: pose.sequence.frame_count(),
+                    bone_count: pose.sequence.bone_tracks().len(),
+                    morph_count: pose.sequence.morph_tracks().len(),
+                },
+            )
+        };
+        MmdRuntimeStatus::Ok
+    })
+}
+
+/// Returns the number of runtime-neutral sparse tracks.
+///
+/// # Safety
+///
+/// `pose` must be a live reduced-pose handle and `out_curve_count` writable.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn mmd_runtime_reduced_pose_generic_curve_count(
+    pose: *const MmdRuntimeReducedPose,
+    out_curve_count: *mut usize,
+) -> MmdRuntimeStatus {
+    ffi_guard(MmdRuntimeStatus::Error, || {
+        if out_curve_count.is_null()
+            || !(out_curve_count as usize).is_multiple_of(std::mem::align_of::<usize>())
+        {
+            return status_failure(MmdRuntimeStatus::InvalidInput, FFI_ERR_INVALID_INPUT);
+        }
+        unsafe { ptr::write(out_curve_count, 0) };
+        let Some(pose) = (unsafe { pose.as_ref() }) else {
+            return status_failure(MmdRuntimeStatus::InvalidInput, FFI_ERR_INVALID_INPUT);
+        };
+        if let Err(status) = validate_generic_curve_request(pose) {
+            return status;
+        }
+        let Some(count) = generic_curve_count(&pose.sequence) else {
+            return status_failure(
+                MmdRuntimeStatus::InvalidInput,
+                "generic curve count overflow",
+            );
+        };
+        unsafe { ptr::write(out_curve_count, count) };
+        MmdRuntimeStatus::Ok
+    })
+}
+
+/// Copies one runtime-neutral sparse-track descriptor.
+///
+/// # Safety
+///
+/// `pose` must be a live reduced-pose handle. `out_descriptor` must point to
+/// writable, naturally aligned storage whose leading `struct_size` is at least
+/// the v1 size.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn mmd_runtime_reduced_pose_generic_curve_descriptor(
+    pose: *const MmdRuntimeReducedPose,
+    curve_index: usize,
+    out_descriptor: *mut MmdRuntimeFfiGenericCurveDescriptor,
+) -> MmdRuntimeStatus {
+    ffi_guard(MmdRuntimeStatus::Error, || {
+        if let Err(status) = unsafe { initialize_sized_ffi_output(out_descriptor) } {
+            return status;
+        }
+        let Some(pose) = (unsafe { pose.as_ref() }) else {
+            return status_failure(MmdRuntimeStatus::InvalidInput, FFI_ERR_INVALID_INPUT);
+        };
+        if let Err(status) = validate_generic_curve_request(pose) {
+            return status;
+        }
+        let descriptor = match generic_curve_descriptor(&pose.sequence, curve_index) {
+            Ok(descriptor) => descriptor,
+            Err(status) => return status,
+        };
+        unsafe { ptr::write(out_descriptor, descriptor) };
+        MmdRuntimeStatus::Ok
+    })
+}
+
+/// Copies one runtime-neutral sparse track into a strided caller-owned buffer.
+///
+/// # Safety
+///
+/// `pose` must be a live reduced-pose handle and `out_required_count` writable.
+/// A non-empty output region must be writable, naturally aligned, large enough
+/// for `out_key_capacity * key_stride_bytes`, and must not alias the count.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn mmd_runtime_reduced_pose_generic_curve_keys(
+    pose: *const MmdRuntimeReducedPose,
+    curve_index: usize,
+    out_keys: *mut MmdRuntimeFfiGenericCurveKey,
+    out_key_capacity: usize,
+    key_stride_bytes: usize,
+    out_required_count: *mut usize,
+) -> MmdRuntimeStatus {
+    ffi_guard(MmdRuntimeStatus::Error, || {
+        if out_required_count.is_null()
+            || !(out_required_count as usize).is_multiple_of(std::mem::align_of::<usize>())
+        {
+            return status_failure(MmdRuntimeStatus::InvalidInput, FFI_ERR_INVALID_INPUT);
+        }
+        unsafe { ptr::write(out_required_count, 0) };
+        let key_size = std::mem::size_of::<MmdRuntimeFfiGenericCurveKey>();
+        let key_align = std::mem::align_of::<MmdRuntimeFfiGenericCurveKey>();
+        if key_stride_bytes < key_size || !key_stride_bytes.is_multiple_of(key_align) {
+            return status_failure(
+                MmdRuntimeStatus::InvalidInput,
+                "key stride is smaller than or misaligned for the v1 key",
+            );
+        }
+        let Some(output_bytes) = out_key_capacity.checked_mul(key_stride_bytes) else {
+            return status_failure(MmdRuntimeStatus::InvalidInput, "key buffer size overflow");
+        };
+        if output_bytes > isize::MAX as usize {
+            return status_failure(MmdRuntimeStatus::InvalidInput, "key buffer is too large");
+        }
+        let Some(pose) = (unsafe { pose.as_ref() }) else {
+            return status_failure(MmdRuntimeStatus::InvalidInput, FFI_ERR_INVALID_INPUT);
+        };
+        if let Err(status) = validate_generic_curve_request(pose) {
+            return status;
+        }
+        let descriptor = match generic_curve_descriptor(&pose.sequence, curve_index) {
+            Ok(descriptor) => descriptor,
+            Err(status) => return status,
+        };
+        if descriptor
+            .key_count
+            .checked_mul(key_stride_bytes)
+            .is_none_or(|bytes| bytes > isize::MAX as usize)
+        {
+            return status_failure(MmdRuntimeStatus::InvalidInput, "required key size overflow");
+        }
+        if !out_keys.is_null() {
+            if !(out_keys as usize).is_multiple_of(key_align) {
+                return status_failure(MmdRuntimeStatus::InvalidInput, "key buffer is misaligned");
+            }
+            let start = out_keys as usize;
+            let Some(end) = start.checked_add(output_bytes) else {
+                return status_failure(MmdRuntimeStatus::InvalidInput, "key buffer range overflow");
+            };
+            let count_start = out_required_count as usize;
+            let Some(count_end) = count_start.checked_add(std::mem::size_of::<usize>()) else {
+                return status_failure(
+                    MmdRuntimeStatus::InvalidInput,
+                    "required-count range overflow",
+                );
+            };
+            if start < count_end && count_start < end {
+                return status_failure(
+                    MmdRuntimeStatus::InvalidInput,
+                    "key buffer must not alias out_required_count",
+                );
+            }
+        }
+        unsafe { ptr::write(out_required_count, descriptor.key_count) };
+        if descriptor.key_count == 0 {
+            return MmdRuntimeStatus::Ok;
+        }
+        if out_keys.is_null() || out_key_capacity < descriptor.key_count {
+            return status_failure(MmdRuntimeStatus::BufferTooSmall, "output buffer too small");
+        }
+
+        // Validate every source key before the first write so errors never leave
+        // a partially initialized caller buffer.
+        for key_index in 0..descriptor.key_count {
+            if let Err(status) = generic_curve_key(&pose.sequence, curve_index, key_index) {
+                unsafe { ptr::write(out_required_count, 0) };
+                return status;
+            }
+        }
+        for key_index in 0..descriptor.key_count {
+            let key = match generic_curve_key(&pose.sequence, curve_index, key_index) {
+                Ok(key) => key,
+                Err(status) => {
+                    unsafe { ptr::write(out_required_count, 0) };
+                    return status;
+                }
+            };
+            let destination = unsafe {
+                out_keys
+                    .cast::<u8>()
+                    .add(key_index * key_stride_bytes)
+                    .cast::<MmdRuntimeFfiGenericCurveKey>()
+            };
+            unsafe { ptr::write(destination, key) };
+        }
         MmdRuntimeStatus::Ok
     })
 }

--- a/crates/mmd-anim-ffi/src/lib.rs
+++ b/crates/mmd-anim-ffi/src/lib.rs
@@ -6039,6 +6039,17 @@ fn validate_unity_curve_request(
     Ok(())
 }
 
+fn parse_unity_curve_flip_z(raw: u8) -> Result<bool, MmdRuntimeStatus> {
+    match raw {
+        0 => Ok(false),
+        1 => Ok(true),
+        _ => Err(status_failure(
+            MmdRuntimeStatus::InvalidInput,
+            "flip_z must be 0 or 1",
+        )),
+    }
+}
+
 fn unity_curve_count(sequence: &ReducedPoseSequence) -> Option<usize> {
     sequence
         .bone_tracks()
@@ -6129,19 +6140,24 @@ fn ensure_unity_curve_cache(
 ///
 /// # Safety
 ///
-/// `pose` must be a live reduced-pose handle and `out_curve_count` writable.
+/// `pose` must be a live reduced-pose handle, `flip_z` must be 0 or 1, and
+/// `out_curve_count` writable.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn mmd_runtime_reduced_pose_unity_curve_count(
     pose: *const MmdRuntimeReducedPose,
     frames_per_second: f32,
-    flip_z: bool,
+    flip_z: u8,
     out_curve_count: *mut usize,
 ) -> MmdRuntimeStatus {
     ffi_guard(MmdRuntimeStatus::Error, || {
-        let Some(out_curve_count) = (unsafe { out_curve_count.as_mut() }) else {
+        if out_curve_count.is_null() {
             return status_failure(MmdRuntimeStatus::InvalidInput, FFI_ERR_INVALID_INPUT);
+        }
+        unsafe { ptr::write(out_curve_count, 0) };
+        let flip_z = match parse_unity_curve_flip_z(flip_z) {
+            Ok(flip_z) => flip_z,
+            Err(status) => return status,
         };
-        *out_curve_count = 0;
         let Some(pose) = (unsafe { pose.as_ref() }) else {
             return status_failure(MmdRuntimeStatus::InvalidInput, FFI_ERR_INVALID_INPUT);
         };
@@ -6151,7 +6167,7 @@ pub unsafe extern "C" fn mmd_runtime_reduced_pose_unity_curve_count(
         let Some(count) = unity_curve_count(&pose.sequence) else {
             return status_failure(MmdRuntimeStatus::Error, "Unity curve count overflow");
         };
-        *out_curve_count = count;
+        unsafe { ptr::write(out_curve_count, count) };
         MmdRuntimeStatus::Ok
     })
 }
@@ -6163,20 +6179,25 @@ pub unsafe extern "C" fn mmd_runtime_reduced_pose_unity_curve_count(
 ///
 /// # Safety
 ///
-/// `pose` must be a live reduced-pose handle and `out_descriptor` writable.
+/// `pose` must be a live reduced-pose handle, `flip_z` must be 0 or 1, and
+/// `out_descriptor` writable.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn mmd_runtime_reduced_pose_unity_curve_descriptor(
     pose: *const MmdRuntimeReducedPose,
     frames_per_second: f32,
-    flip_z: bool,
+    flip_z: u8,
     curve_index: usize,
     out_descriptor: *mut MmdRuntimeFfiUnityCurveDescriptor,
 ) -> MmdRuntimeStatus {
     ffi_guard(MmdRuntimeStatus::Error, || {
-        let Some(out_descriptor) = (unsafe { out_descriptor.as_mut() }) else {
+        if out_descriptor.is_null() {
             return status_failure(MmdRuntimeStatus::InvalidInput, FFI_ERR_INVALID_INPUT);
+        }
+        unsafe { ptr::write(out_descriptor, MmdRuntimeFfiUnityCurveDescriptor::default()) };
+        let flip_z = match parse_unity_curve_flip_z(flip_z) {
+            Ok(flip_z) => flip_z,
+            Err(status) => return status,
         };
-        *out_descriptor = MmdRuntimeFfiUnityCurveDescriptor::default();
         let Some(pose) = (unsafe { pose.as_ref() }) else {
             return status_failure(MmdRuntimeStatus::InvalidInput, FFI_ERR_INVALID_INPUT);
         };
@@ -6186,7 +6207,7 @@ pub unsafe extern "C" fn mmd_runtime_reduced_pose_unity_curve_descriptor(
         let Some(descriptor) = unity_curve_descriptor(&pose.sequence, curve_index) else {
             return status_failure(MmdRuntimeStatus::InvalidInput, "curve index out of range");
         };
-        *out_descriptor = descriptor;
+        unsafe { ptr::write(out_descriptor, descriptor) };
         MmdRuntimeStatus::Ok
     })
 }
@@ -6199,24 +6220,28 @@ pub unsafe extern "C" fn mmd_runtime_reduced_pose_unity_curve_descriptor(
 ///
 /// # Safety
 ///
-/// `pose` must be a live reduced-pose handle. `out_required_count` must be
-/// writable. A non-empty key output region must be writable and must not alias
-/// `out_required_count`.
+/// `pose` must be a live reduced-pose handle and `flip_z` must be 0 or 1.
+/// `out_required_count` must be writable. A non-empty key output region must
+/// be writable and must not alias `out_required_count`.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn mmd_runtime_reduced_pose_unity_curve_keys(
     pose: *const MmdRuntimeReducedPose,
     frames_per_second: f32,
-    flip_z: bool,
+    flip_z: u8,
     curve_index: usize,
     out_keys: *mut MmdRuntimeFfiUnityCurveKey,
     out_key_capacity: usize,
     out_required_count: *mut usize,
 ) -> MmdRuntimeStatus {
     ffi_guard(MmdRuntimeStatus::Error, || {
-        let Some(out_required_count) = (unsafe { out_required_count.as_mut() }) else {
+        if out_required_count.is_null() {
             return status_failure(MmdRuntimeStatus::InvalidInput, FFI_ERR_INVALID_INPUT);
+        }
+        unsafe { ptr::write(out_required_count, 0) };
+        let flip_z = match parse_unity_curve_flip_z(flip_z) {
+            Ok(flip_z) => flip_z,
+            Err(status) => return status,
         };
-        *out_required_count = 0;
         let Some(pose) = (unsafe { pose.as_ref() }) else {
             return status_failure(MmdRuntimeStatus::InvalidInput, FFI_ERR_INVALID_INPUT);
         };
@@ -6226,7 +6251,7 @@ pub unsafe extern "C" fn mmd_runtime_reduced_pose_unity_curve_keys(
         let Some(descriptor) = unity_curve_descriptor(&pose.sequence, curve_index) else {
             return status_failure(MmdRuntimeStatus::InvalidInput, "curve index out of range");
         };
-        *out_required_count = descriptor.key_count;
+        unsafe { ptr::write(out_required_count, descriptor.key_count) };
         if out_key_capacity < descriptor.key_count || out_keys.is_null() {
             return status_failure(MmdRuntimeStatus::BufferTooSmall, "output buffer too small");
         }
@@ -6240,14 +6265,15 @@ pub unsafe extern "C" fn mmd_runtime_reduced_pose_unity_curve_keys(
         if curve.keys.len() != descriptor.key_count {
             return status_failure(MmdRuntimeStatus::Error, "Unity curve key count mismatch");
         }
-        let out_keys = unsafe { slice::from_raw_parts_mut(out_keys, descriptor.key_count) };
-        for (out, key) in out_keys.iter_mut().zip(&curve.keys) {
-            *out = MmdRuntimeFfiUnityCurveKey {
-                time_seconds: key.time_seconds,
-                value: key.value,
-                in_tangent: key.in_tangent,
-                out_tangent: key.out_tangent,
-            };
+        for (index, key) in curve.keys.iter().enumerate() {
+            unsafe {
+                out_keys.add(index).write(MmdRuntimeFfiUnityCurveKey {
+                    time_seconds: key.time_seconds,
+                    value: key.value,
+                    in_tangent: key.in_tangent,
+                    out_tangent: key.out_tangent,
+                });
+            }
         }
         MmdRuntimeStatus::Ok
     })

--- a/crates/mmd-anim-ffi/src/tests.rs
+++ b/crates/mmd-anim-ffi/src/tests.rs
@@ -1596,12 +1596,24 @@ fn instance_remains_valid_when_model_handle_is_freed_first() {
     let rest_positions = [1.0_f32, 2.0, 3.0];
     let model = unsafe { mmd_runtime_model_create(parents.as_ptr(), rest_positions.as_ptr(), 1) };
     assert!(!model.is_null());
-    let instance = unsafe { mmd_runtime_instance_create(model, 0) };
+    let instance = unsafe { mmd_runtime_instance_create(model, 1) };
     assert!(!instance.is_null());
 
     unsafe { mmd_runtime_model_free(model) };
     assert!(unsafe { mmd_runtime_instance_evaluate_rest_pose(instance) });
     assert_eq!(unsafe { mmd_runtime_instance_bone_count(instance) }, 1);
+    let world_view = unsafe { mmd_runtime_instance_world_matrices(instance) };
+    assert!(!unsafe {
+        mmd_runtime_instance_copy_world_matrices(instance, world_view.cast_mut(), 16)
+    });
+    let skinning_view = unsafe { mmd_runtime_instance_skinning_matrices(instance) };
+    assert!(!unsafe {
+        mmd_runtime_instance_copy_skinning_matrices(instance, skinning_view.cast_mut(), 16)
+    });
+    let morph_view = unsafe { mmd_runtime_instance_morph_weights(instance) };
+    assert!(!unsafe {
+        mmd_runtime_instance_copy_morph_weights(instance, morph_view.cast_mut(), 1)
+    });
     let mut world = [0.0_f32; 16];
     assert!(unsafe {
         mmd_runtime_instance_copy_world_matrices(instance, world.as_mut_ptr(), world.len())

--- a/crates/mmd-anim-ffi/src/tests.rs
+++ b/crates/mmd-anim-ffi/src/tests.rs
@@ -1,5 +1,6 @@
 use super::*;
 use std::ffi::CStr;
+use std::mem::MaybeUninit;
 
 fn last_error_cstr() -> Option<&'static CStr> {
     let ptr = mmd_runtime_last_error_message();
@@ -339,7 +340,7 @@ fn copy_unity_curve_keys(
             mmd_runtime_reduced_pose_unity_curve_keys(
                 reduced,
                 frames_per_second,
-                flip_z,
+                u8::from(flip_z),
                 curve_index,
                 ptr::null_mut(),
                 0,
@@ -354,7 +355,7 @@ fn copy_unity_curve_keys(
             mmd_runtime_reduced_pose_unity_curve_keys(
                 reduced,
                 frames_per_second,
-                flip_z,
+                u8::from(flip_z),
                 curve_index,
                 keys.as_mut_ptr(),
                 keys.len(),
@@ -378,7 +379,7 @@ fn reduced_pose_unity_curves_are_two_call_and_match_rust_dto_after_model_free() 
             mmd_runtime_reduced_pose_unity_curve_count(
                 reduced,
                 frames_per_second,
-                flip_z,
+                u8::from(flip_z),
                 &mut curve_count,
             )
         },
@@ -410,7 +411,7 @@ fn reduced_pose_unity_curves_are_two_call_and_match_rust_dto_after_model_free() 
                 mmd_runtime_reduced_pose_unity_curve_descriptor(
                     reduced,
                     frames_per_second,
-                    flip_z,
+                    u8::from(flip_z),
                     curve_index,
                     &mut descriptor,
                 )
@@ -444,7 +445,7 @@ fn reduced_pose_unity_curves_are_two_call_and_match_rust_dto_after_model_free() 
                 mmd_runtime_reduced_pose_unity_curve_keys(
                     reduced,
                     frames_per_second,
-                    flip_z,
+                    u8::from(flip_z),
                     curve_index,
                     ptr::null_mut(),
                     0,
@@ -462,7 +463,7 @@ fn reduced_pose_unity_curves_are_two_call_and_match_rust_dto_after_model_free() 
                     mmd_runtime_reduced_pose_unity_curve_keys(
                         reduced,
                         frames_per_second,
-                        flip_z,
+                        u8::from(flip_z),
                         curve_index,
                         keys.as_mut_ptr(),
                         required - 1,
@@ -477,7 +478,7 @@ fn reduced_pose_unity_curves_are_two_call_and_match_rust_dto_after_model_free() 
                 mmd_runtime_reduced_pose_unity_curve_keys(
                     reduced,
                     frames_per_second,
-                    flip_z,
+                    u8::from(flip_z),
                     curve_index,
                     keys.as_mut_ptr(),
                     keys.len(),
@@ -500,7 +501,7 @@ fn reduced_pose_unity_curves_are_two_call_and_match_rust_dto_after_model_free() 
             mmd_runtime_reduced_pose_unity_curve_descriptor(
                 reduced,
                 frames_per_second,
-                flip_z,
+                u8::from(flip_z),
                 curve_count,
                 &mut descriptor,
             )
@@ -515,17 +516,17 @@ fn reduced_pose_unity_curves_validate_handle_fps_outputs_and_target() {
     let dcc = reduced_pose_curve_fixture(2);
     let mut count = usize::MAX;
     assert_eq!(
-        unsafe { mmd_runtime_reduced_pose_unity_curve_count(ptr::null(), 30.0, false, &mut count) },
+        unsafe { mmd_runtime_reduced_pose_unity_curve_count(ptr::null(), 30.0, 0, &mut count) },
         MmdRuntimeStatus::InvalidInput
     );
     assert_eq!(count, 0);
     assert_eq!(
-        unsafe { mmd_runtime_reduced_pose_unity_curve_count(dcc, f32::NAN, false, &mut count) },
+        unsafe { mmd_runtime_reduced_pose_unity_curve_count(dcc, f32::NAN, 0, &mut count) },
         MmdRuntimeStatus::InvalidInput
     );
     assert_eq!(count, 0);
     assert_eq!(
-        unsafe { mmd_runtime_reduced_pose_unity_curve_count(dcc, 0.0, false, &mut count) },
+        unsafe { mmd_runtime_reduced_pose_unity_curve_count(dcc, 0.0, 0, &mut count) },
         MmdRuntimeStatus::InvalidInput
     );
     for frames_per_second in [f32::MAX, f32::from_bits(1)] {
@@ -538,12 +539,7 @@ fn reduced_pose_unity_curves_validate_handle_fps_outputs_and_target() {
         let mut required = usize::MAX;
         assert_eq!(
             unsafe {
-                mmd_runtime_reduced_pose_unity_curve_count(
-                    dcc,
-                    frames_per_second,
-                    false,
-                    &mut count,
-                )
+                mmd_runtime_reduced_pose_unity_curve_count(dcc, frames_per_second, 0, &mut count)
             },
             MmdRuntimeStatus::InvalidInput
         );
@@ -553,7 +549,7 @@ fn reduced_pose_unity_curves_validate_handle_fps_outputs_and_target() {
                 mmd_runtime_reduced_pose_unity_curve_descriptor(
                     dcc,
                     frames_per_second,
-                    false,
+                    0,
                     0,
                     &mut descriptor,
                 )
@@ -566,7 +562,7 @@ fn reduced_pose_unity_curves_validate_handle_fps_outputs_and_target() {
                 mmd_runtime_reduced_pose_unity_curve_keys(
                     dcc,
                     frames_per_second,
-                    false,
+                    0,
                     0,
                     ptr::null_mut(),
                     0,
@@ -578,18 +574,219 @@ fn reduced_pose_unity_curves_validate_handle_fps_outputs_and_target() {
         assert_eq!(required, 0);
     }
     assert_eq!(
-        unsafe { mmd_runtime_reduced_pose_unity_curve_count(dcc, 30.0, false, ptr::null_mut()) },
+        unsafe { mmd_runtime_reduced_pose_unity_curve_count(dcc, 30.0, 0, ptr::null_mut()) },
         MmdRuntimeStatus::InvalidInput
     );
     unsafe { mmd_runtime_reduced_pose_free(dcc) };
 
     let linear = reduced_pose_curve_fixture(0);
     assert_eq!(
-        unsafe { mmd_runtime_reduced_pose_unity_curve_count(linear, 30.0, false, &mut count) },
+        unsafe { mmd_runtime_reduced_pose_unity_curve_count(linear, 30.0, 0, &mut count) },
         MmdRuntimeStatus::Unsupported
     );
     assert_eq!(count, 0);
     unsafe { mmd_runtime_reduced_pose_free(linear) };
+}
+
+#[test]
+fn reduced_pose_unity_curves_validate_raw_flip_z_flags() {
+    let reduced = reduced_pose_curve_fixture(2);
+    let mut keys_by_flag = Vec::new();
+
+    for flip_z in [0_u8, 1] {
+        let mut count = usize::MAX;
+        assert_eq!(
+            unsafe {
+                mmd_runtime_reduced_pose_unity_curve_count(reduced, 30.0, flip_z, &mut count)
+            },
+            MmdRuntimeStatus::Ok
+        );
+        assert_eq!(count, 7);
+
+        let mut descriptor = MmdRuntimeFfiUnityCurveDescriptor::default();
+        assert_eq!(
+            unsafe {
+                mmd_runtime_reduced_pose_unity_curve_descriptor(
+                    reduced,
+                    30.0,
+                    flip_z,
+                    2,
+                    &mut descriptor,
+                )
+            },
+            MmdRuntimeStatus::Ok
+        );
+        assert_eq!(
+            descriptor.semantic,
+            MMD_RUNTIME_UNITY_CURVE_BONE_LOCAL_TRANSLATION
+        );
+        assert_eq!(descriptor.axis, MMD_RUNTIME_UNITY_CURVE_AXIS_Z);
+
+        let mut required = usize::MAX;
+        assert_eq!(
+            unsafe {
+                mmd_runtime_reduced_pose_unity_curve_keys(
+                    reduced,
+                    30.0,
+                    flip_z,
+                    2,
+                    ptr::null_mut(),
+                    0,
+                    &mut required,
+                )
+            },
+            MmdRuntimeStatus::BufferTooSmall
+        );
+        assert!(required > 0);
+        let mut keys = vec![MmdRuntimeFfiUnityCurveKey::default(); required];
+        assert_eq!(
+            unsafe {
+                mmd_runtime_reduced_pose_unity_curve_keys(
+                    reduced,
+                    30.0,
+                    flip_z,
+                    2,
+                    keys.as_mut_ptr(),
+                    keys.len(),
+                    &mut required,
+                )
+            },
+            MmdRuntimeStatus::Ok
+        );
+        keys_by_flag.push(keys);
+    }
+
+    assert!(
+        keys_by_flag[0]
+            .iter()
+            .zip(&keys_by_flag[1])
+            .any(|(unflipped, flipped)| unflipped.value != flipped.value)
+    );
+
+    let mut count = usize::MAX;
+    assert_eq!(
+        unsafe { mmd_runtime_reduced_pose_unity_curve_count(reduced, 30.0, 2, &mut count) },
+        MmdRuntimeStatus::InvalidInput
+    );
+    assert_eq!(count, 0);
+
+    let mut descriptor = MmdRuntimeFfiUnityCurveDescriptor {
+        semantic: u32::MAX,
+        target_index: u32::MAX,
+        axis: u32::MAX,
+        key_count: usize::MAX,
+    };
+    assert_eq!(
+        unsafe {
+            mmd_runtime_reduced_pose_unity_curve_descriptor(reduced, 30.0, 2, 2, &mut descriptor)
+        },
+        MmdRuntimeStatus::InvalidInput
+    );
+    assert_eq!(descriptor, MmdRuntimeFfiUnityCurveDescriptor::default());
+
+    let sentinel = MmdRuntimeFfiUnityCurveKey {
+        time_seconds: 9.0,
+        value: 8.0,
+        in_tangent: 7.0,
+        out_tangent: 6.0,
+    };
+    let mut keys = [sentinel];
+    let mut required = usize::MAX;
+    assert_eq!(
+        unsafe {
+            mmd_runtime_reduced_pose_unity_curve_keys(
+                reduced,
+                30.0,
+                2,
+                2,
+                keys.as_mut_ptr(),
+                keys.len(),
+                &mut required,
+            )
+        },
+        MmdRuntimeStatus::InvalidInput
+    );
+    assert_eq!(required, 0);
+    assert_eq!(keys, [sentinel]);
+
+    unsafe { mmd_runtime_reduced_pose_free(reduced) };
+}
+
+#[test]
+fn reduced_pose_unity_curves_initialize_maybe_uninit_outputs() {
+    let reduced = reduced_pose_curve_fixture(2);
+
+    let mut count = MaybeUninit::<usize>::uninit();
+    assert_eq!(
+        unsafe { mmd_runtime_reduced_pose_unity_curve_count(reduced, 30.0, 0, count.as_mut_ptr()) },
+        MmdRuntimeStatus::Ok
+    );
+    assert_eq!(unsafe { count.assume_init() }, 7);
+
+    let mut descriptor = MaybeUninit::<MmdRuntimeFfiUnityCurveDescriptor>::uninit();
+    assert_eq!(
+        unsafe {
+            mmd_runtime_reduced_pose_unity_curve_descriptor(
+                reduced,
+                30.0,
+                0,
+                2,
+                descriptor.as_mut_ptr(),
+            )
+        },
+        MmdRuntimeStatus::Ok
+    );
+    let descriptor = unsafe { descriptor.assume_init() };
+    assert!(descriptor.key_count > 0);
+
+    let mut required = MaybeUninit::<usize>::uninit();
+    assert_eq!(
+        unsafe {
+            mmd_runtime_reduced_pose_unity_curve_keys(
+                reduced,
+                30.0,
+                0,
+                2,
+                ptr::null_mut(),
+                0,
+                required.as_mut_ptr(),
+            )
+        },
+        MmdRuntimeStatus::BufferTooSmall
+    );
+    let required = unsafe { required.assume_init() };
+    assert_eq!(required, descriptor.key_count);
+
+    let mut keys = vec![MaybeUninit::<MmdRuntimeFfiUnityCurveKey>::uninit(); required];
+    let mut written_required = MaybeUninit::<usize>::uninit();
+    assert_eq!(
+        unsafe {
+            mmd_runtime_reduced_pose_unity_curve_keys(
+                reduced,
+                30.0,
+                0,
+                2,
+                keys.as_mut_ptr().cast(),
+                keys.len(),
+                written_required.as_mut_ptr(),
+            )
+        },
+        MmdRuntimeStatus::Ok
+    );
+    assert_eq!(unsafe { written_required.assume_init() }, required);
+    let keys = keys
+        .into_iter()
+        .map(|key| unsafe { key.assume_init() })
+        .collect::<Vec<_>>();
+    assert_eq!(keys.len(), required);
+    assert!(keys.iter().all(|key| {
+        key.time_seconds.is_finite()
+            && key.value.is_finite()
+            && key.in_tangent.is_finite()
+            && key.out_tangent.is_finite()
+    }));
+
+    unsafe { mmd_runtime_reduced_pose_free(reduced) };
 }
 
 #[test]
@@ -699,9 +896,7 @@ fn reduced_pose_handle_reports_and_enumerates_sparse_curves_after_model_free() {
 
     let mut curve_count = 0;
     assert_eq!(
-        unsafe {
-            mmd_runtime_reduced_pose_unity_curve_count(reduced, 30.0, false, &mut curve_count)
-        },
+        unsafe { mmd_runtime_reduced_pose_unity_curve_count(reduced, 30.0, 0, &mut curve_count) },
         MmdRuntimeStatus::Ok
     );
     assert_eq!(curve_count, 7);

--- a/crates/mmd-anim-ffi/src/tests.rs
+++ b/crates/mmd-anim-ffi/src/tests.rs
@@ -943,6 +943,37 @@ fn simple_ik_chain() -> *mut MmdRuntimeIkChain {
 }
 
 #[test]
+fn flat_model_create_rejects_misaligned_and_oversized_slices_before_deref() {
+    let parent = [-1_i32];
+    let rest = [0.0_f32; 3];
+    let storage = [0_u8; 8];
+    let misaligned_offset = (0..std::mem::align_of::<i32>())
+        .find(|offset| {
+            !(storage.as_ptr() as usize + offset).is_multiple_of(std::mem::align_of::<i32>())
+        })
+        .expect("an i32 alignment always has misaligned byte offsets");
+    let misaligned_parent = unsafe { storage.as_ptr().add(misaligned_offset).cast::<i32>() };
+    assert!(unsafe { mmd_runtime_model_create(misaligned_parent, rest.as_ptr(), 1) }.is_null());
+    assert!(
+        unsafe { mmd_runtime_model_create(parent.as_ptr(), rest.as_ptr(), usize::MAX) }.is_null()
+    );
+
+    let inverse_bind = [0.0_f32; 16];
+    let overflowing_bone_count = usize::MAX / 16 + 1;
+    assert!(
+        unsafe {
+            mmd_runtime_model_create_with_inverse_bind(
+                parent.as_ptr(),
+                rest.as_ptr(),
+                inverse_bind.as_ptr(),
+                overflowing_bone_count,
+            )
+        }
+        .is_null()
+    );
+}
+
+#[test]
 fn primitive_creators_reject_noncanonical_boolean_bytes() {
     let invalid_append = MmdRuntimeFfiAppendConfig {
         ratio: 1.0,

--- a/crates/mmd-anim-ffi/src/tests.rs
+++ b/crates/mmd-anim-ffi/src/tests.rs
@@ -1591,6 +1591,27 @@ fn evaluates_rest_pose_through_c_abi() {
 }
 
 #[test]
+fn instance_remains_valid_when_model_handle_is_freed_first() {
+    let parents = [-1_i32];
+    let rest_positions = [1.0_f32, 2.0, 3.0];
+    let model = unsafe { mmd_runtime_model_create(parents.as_ptr(), rest_positions.as_ptr(), 1) };
+    assert!(!model.is_null());
+    let instance = unsafe { mmd_runtime_instance_create(model, 0) };
+    assert!(!instance.is_null());
+
+    unsafe { mmd_runtime_model_free(model) };
+    assert!(unsafe { mmd_runtime_instance_evaluate_rest_pose(instance) });
+    assert_eq!(unsafe { mmd_runtime_instance_bone_count(instance) }, 1);
+    let mut world = [0.0_f32; 16];
+    assert!(unsafe {
+        mmd_runtime_instance_copy_world_matrices(instance, world.as_mut_ptr(), world.len())
+    });
+    assert_slice_near(&world[12..15], &rest_positions, 0.0);
+
+    unsafe { mmd_runtime_instance_free(instance) };
+}
+
+#[test]
 fn applies_inverse_bind_through_c_abi() {
     let parents = [-1];
     let rest_positions = [2.0, 0.0, 0.0];

--- a/crates/mmd-anim-ffi/src/tests.rs
+++ b/crates/mmd-anim-ffi/src/tests.rs
@@ -329,6 +329,403 @@ fn reduced_pose_curve_fixture(target: u32) -> *mut MmdRuntimeReducedPose {
     reduced
 }
 
+fn copy_generic_curve_keys(
+    reduced: *const MmdRuntimeReducedPose,
+    curve_index: usize,
+) -> Vec<MmdRuntimeFfiGenericCurveKey> {
+    let stride = std::mem::size_of::<MmdRuntimeFfiGenericCurveKey>();
+    let mut required = usize::MAX;
+    assert_eq!(
+        unsafe {
+            mmd_runtime_reduced_pose_generic_curve_keys(
+                reduced,
+                curve_index,
+                ptr::null_mut(),
+                0,
+                stride,
+                &mut required,
+            )
+        },
+        MmdRuntimeStatus::BufferTooSmall
+    );
+    let mut keys = vec![MmdRuntimeFfiGenericCurveKey::default(); required];
+    assert_eq!(
+        unsafe {
+            mmd_runtime_reduced_pose_generic_curve_keys(
+                reduced,
+                curve_index,
+                keys.as_mut_ptr(),
+                keys.len(),
+                stride,
+                &mut required,
+            )
+        },
+        MmdRuntimeStatus::Ok
+    );
+    assert_eq!(required, keys.len());
+    keys
+}
+
+#[test]
+fn reduced_pose_generic_curves_match_raw_tracks_after_model_free() {
+    if std::mem::size_of::<usize>() == 8 {
+        assert_eq!(std::mem::size_of::<MmdRuntimeFfiGenericCurveInfo>(), 72);
+        assert_eq!(std::mem::align_of::<MmdRuntimeFfiGenericCurveInfo>(), 8);
+        assert_eq!(
+            std::mem::offset_of!(MmdRuntimeFfiGenericCurveInfo, model_identity),
+            32
+        );
+        assert_eq!(
+            std::mem::offset_of!(MmdRuntimeFfiGenericCurveInfo, frame_count),
+            48
+        );
+        assert_eq!(
+            std::mem::size_of::<MmdRuntimeFfiGenericCurveDescriptor>(),
+            40
+        );
+        assert_eq!(
+            std::mem::offset_of!(MmdRuntimeFfiGenericCurveDescriptor, key_count),
+            32
+        );
+        assert_eq!(std::mem::size_of::<MmdRuntimeFfiGenericCurveKey>(), 128);
+        assert_eq!(std::mem::align_of::<MmdRuntimeFfiGenericCurveKey>(), 8);
+        assert_eq!(
+            std::mem::offset_of!(MmdRuntimeFfiGenericCurveKey, rotation_xyzw),
+            24
+        );
+        assert_eq!(
+            std::mem::offset_of!(MmdRuntimeFfiGenericCurveKey, segment_current_in_scalar),
+            120
+        );
+    }
+    let reduced = reduced_pose_curve_fixture(MMD_RUNTIME_REDUCTION_TARGET_DCC_CUBIC);
+    assert_eq!(mmd_runtime_abi_version(), 2);
+    assert_eq!(
+        mmd_runtime_feature_flags() & MMD_RUNTIME_FEATURE_REDUCED_POSE_GENERIC_CURVES,
+        MMD_RUNTIME_FEATURE_REDUCED_POSE_GENERIC_CURVES
+    );
+
+    let mut info = MmdRuntimeFfiGenericCurveInfo::default();
+    assert_eq!(
+        unsafe { mmd_runtime_reduced_pose_generic_curve_info(reduced, &mut info) },
+        MmdRuntimeStatus::Ok
+    );
+    assert_eq!(
+        info.struct_size as usize,
+        std::mem::size_of::<MmdRuntimeFfiGenericCurveInfo>()
+    );
+    assert_eq!(
+        info.abi_version,
+        MMD_RUNTIME_REDUCED_POSE_GENERIC_CURVE_ABI_VERSION_V1
+    );
+    assert_eq!(
+        info.reduction_target,
+        MMD_RUNTIME_REDUCTION_TARGET_DCC_CUBIC
+    );
+    assert_eq!(info.coordinate_system, 0);
+    assert_eq!(info.length_unit, 0);
+    assert_eq!(info.angle_unit, 0);
+    assert_eq!(info.time_unit, 0);
+    assert_eq!(info.tangent_unit, 0);
+    assert_eq!(info.model_identity, 77);
+    assert_eq!(info.start_frame, 0.0);
+    assert_eq!(info.frame_step, 1.0);
+    assert_eq!(info.frame_count, 5);
+    assert_eq!(info.bone_count, 1);
+    assert_eq!(info.morph_count, 1);
+
+    let mut curve_count = usize::MAX;
+    assert_eq!(
+        unsafe { mmd_runtime_reduced_pose_generic_curve_count(reduced, &mut curve_count) },
+        MmdRuntimeStatus::Ok
+    );
+    assert_eq!(curve_count, info.bone_count + info.morph_count);
+
+    let sequence = unsafe { &(*reduced).sequence };
+    for curve_index in 0..curve_count {
+        let mut descriptor = MmdRuntimeFfiGenericCurveDescriptor::default();
+        assert_eq!(
+            unsafe {
+                mmd_runtime_reduced_pose_generic_curve_descriptor(
+                    reduced,
+                    curve_index,
+                    &mut descriptor,
+                )
+            },
+            MmdRuntimeStatus::Ok
+        );
+        assert_eq!(
+            descriptor.struct_size as usize,
+            std::mem::size_of::<MmdRuntimeFfiGenericCurveDescriptor>()
+        );
+        assert_eq!(
+            descriptor.abi_version,
+            MMD_RUNTIME_REDUCED_POSE_GENERIC_CURVE_ABI_VERSION_V1
+        );
+        assert_eq!(
+            descriptor.interpolation,
+            MMD_RUNTIME_REDUCTION_TARGET_DCC_CUBIC
+        );
+        let keys = copy_generic_curve_keys(reduced, curve_index);
+        assert_eq!(keys.len(), descriptor.key_count);
+        assert!(
+            keys.iter()
+                .all(|key| key.frame == sequence.sample_frames()[key.sample_index])
+        );
+
+        if curve_index < info.bone_count {
+            assert_eq!(descriptor.kind, MMD_RUNTIME_GENERIC_CURVE_BONE_LOCAL);
+            assert_eq!(descriptor.target_index as usize, curve_index);
+            assert_eq!(descriptor.parent_index, -1);
+            assert_eq!(
+                descriptor.value_flags,
+                MMD_RUNTIME_GENERIC_VALUE_TRANSLATION | MMD_RUNTIME_GENERIC_VALUE_QUATERNION
+            );
+            assert_eq!(
+                descriptor.rotation_basis,
+                MMD_RUNTIME_GENERIC_ROTATION_BASIS_RUNTIME_QUATERNION
+            );
+            let raw_keys = sequence.bone_tracks()[curve_index].keys();
+            for (key, raw) in keys.iter().zip(raw_keys) {
+                assert_eq!(key.sample_index, raw.sample_index);
+                assert_slice_near(&key.translation_xyz, &raw.translation.to_array(), 1.0e-7);
+                assert_slice_near(&key.rotation_xyzw, &raw.rotation.to_array(), 1.0e-7);
+                assert_near(
+                    key.rotation_xyzw
+                        .iter()
+                        .map(|value| value * value)
+                        .sum::<f32>(),
+                    1.0,
+                    1.0e-5,
+                );
+                assert_slice_near(
+                    &key.segment_prev_out_translation_xyz,
+                    &raw.dcc_segment.translation_out_tangent.to_array(),
+                    1.0e-7,
+                );
+                assert_slice_near(
+                    &key.segment_current_in_translation_xyz,
+                    &raw.dcc_segment.translation_in_tangent.to_array(),
+                    1.0e-7,
+                );
+                assert_slice_near(
+                    &key.segment_from_previous_start_euler_xyz,
+                    &raw.dcc_segment.rotation_start_euler_xyz.to_array(),
+                    1.0e-7,
+                );
+                assert_slice_near(
+                    &key.segment_from_previous_end_euler_xyz,
+                    &raw.dcc_segment.rotation_end_euler_xyz.to_array(),
+                    1.0e-7,
+                );
+            }
+            assert_eq!(keys[0].segment_prev_out_translation_xyz, [0.0; 3]);
+            assert_eq!(
+                keys.last().unwrap().segment_current_in_translation_xyz,
+                raw_keys
+                    .last()
+                    .unwrap()
+                    .dcc_segment
+                    .translation_in_tangent
+                    .to_array()
+            );
+        } else {
+            let morph_index = curve_index - info.bone_count;
+            assert_eq!(descriptor.kind, MMD_RUNTIME_GENERIC_CURVE_MORPH_WEIGHT);
+            assert_eq!(descriptor.target_index as usize, morph_index);
+            assert_eq!(descriptor.parent_index, -1);
+            assert_eq!(descriptor.value_flags, MMD_RUNTIME_GENERIC_VALUE_SCALAR);
+            assert_eq!(
+                descriptor.rotation_basis,
+                MMD_RUNTIME_GENERIC_ROTATION_BASIS_NONE
+            );
+            let raw_keys = sequence.morph_tracks()[morph_index].keys();
+            for (key, raw) in keys.iter().zip(raw_keys) {
+                assert_eq!(key.sample_index, raw.sample_index);
+                assert_near(key.scalar, raw.weight, 1.0e-7);
+                assert_near(
+                    key.segment_prev_out_scalar,
+                    raw.dcc_segment.out_tangent,
+                    1.0e-7,
+                );
+                assert_near(
+                    key.segment_current_in_scalar,
+                    raw.dcc_segment.in_tangent,
+                    1.0e-7,
+                );
+                assert_eq!(key.translation_xyz, [0.0; 3]);
+                assert_eq!(key.rotation_xyzw, [0.0; 4]);
+            }
+            assert_eq!(keys[0].segment_prev_out_scalar, 0.0);
+            assert_eq!(
+                keys.last().unwrap().segment_current_in_scalar,
+                raw_keys.last().unwrap().dcc_segment.in_tangent
+            );
+        }
+    }
+
+    unsafe { mmd_runtime_reduced_pose_free(reduced) };
+}
+
+#[repr(C)]
+struct PaddedGenericCurveKey {
+    key: MmdRuntimeFfiGenericCurveKey,
+    tail: [u64; 2],
+}
+
+#[test]
+fn reduced_pose_generic_curves_validate_sized_outputs_stride_and_short_buffers() {
+    let reduced = reduced_pose_curve_fixture(MMD_RUNTIME_REDUCTION_TARGET_DCC_CUBIC);
+    let key_size = std::mem::size_of::<MmdRuntimeFfiGenericCurveKey>();
+
+    assert_eq!(
+        unsafe { mmd_runtime_reduced_pose_generic_curve_info(reduced, ptr::null_mut()) },
+        MmdRuntimeStatus::InvalidInput
+    );
+    assert_eq!(
+        unsafe { mmd_runtime_reduced_pose_generic_curve_count(reduced, ptr::null_mut()) },
+        MmdRuntimeStatus::InvalidInput
+    );
+    assert_eq!(
+        unsafe { mmd_runtime_reduced_pose_generic_curve_descriptor(reduced, 0, ptr::null_mut(),) },
+        MmdRuntimeStatus::InvalidInput
+    );
+    let mut info = MmdRuntimeFfiGenericCurveInfo::default();
+    assert_eq!(
+        unsafe { mmd_runtime_reduced_pose_generic_curve_info(ptr::null(), &mut info) },
+        MmdRuntimeStatus::InvalidInput
+    );
+    assert_eq!(info.abi_version, 0);
+    let mut null_pose_count = usize::MAX;
+    assert_eq!(
+        unsafe { mmd_runtime_reduced_pose_generic_curve_count(ptr::null(), &mut null_pose_count) },
+        MmdRuntimeStatus::InvalidInput
+    );
+    assert_eq!(null_pose_count, 0);
+
+    let mut descriptor = MmdRuntimeFfiGenericCurveDescriptor::default();
+    descriptor.struct_size -= 1;
+    let undersized = descriptor.struct_size;
+    assert_eq!(
+        unsafe { mmd_runtime_reduced_pose_generic_curve_descriptor(reduced, 0, &mut descriptor) },
+        MmdRuntimeStatus::InvalidInput
+    );
+    assert_eq!(descriptor.struct_size, undersized);
+
+    let mut required = usize::MAX;
+    assert_eq!(
+        unsafe {
+            mmd_runtime_reduced_pose_generic_curve_keys(
+                reduced,
+                0,
+                ptr::null_mut(),
+                0,
+                key_size - 1,
+                &mut required,
+            )
+        },
+        MmdRuntimeStatus::InvalidInput
+    );
+    assert_eq!(required, 0);
+    let overflowing_capacity = usize::MAX / key_size + 1;
+    assert_eq!(
+        unsafe {
+            mmd_runtime_reduced_pose_generic_curve_keys(
+                reduced,
+                0,
+                ptr::null_mut(),
+                overflowing_capacity,
+                key_size,
+                &mut required,
+            )
+        },
+        MmdRuntimeStatus::InvalidInput
+    );
+    assert_eq!(required, 0);
+    assert_eq!(
+        unsafe {
+            mmd_runtime_reduced_pose_generic_curve_keys(
+                reduced,
+                0,
+                ptr::null_mut(),
+                0,
+                key_size + 1,
+                &mut required,
+            )
+        },
+        MmdRuntimeStatus::InvalidInput
+    );
+
+    let keys = copy_generic_curve_keys(reduced, 0);
+    let sentinel = MmdRuntimeFfiGenericCurveKey {
+        frame: -123.0,
+        ..MmdRuntimeFfiGenericCurveKey::default()
+    };
+    let mut short = vec![sentinel; keys.len().saturating_sub(1)];
+    assert_eq!(
+        unsafe {
+            mmd_runtime_reduced_pose_generic_curve_keys(
+                reduced,
+                0,
+                short.as_mut_ptr(),
+                short.len(),
+                key_size,
+                &mut required,
+            )
+        },
+        MmdRuntimeStatus::BufferTooSmall
+    );
+    assert_eq!(required, keys.len());
+    assert!(short.iter().all(|key| *key == sentinel));
+
+    let mut padded = (0..keys.len())
+        .map(|_| PaddedGenericCurveKey {
+            key: MmdRuntimeFfiGenericCurveKey::default(),
+            tail: [u64::MAX; 2],
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        unsafe {
+            mmd_runtime_reduced_pose_generic_curve_keys(
+                reduced,
+                0,
+                padded.as_mut_ptr().cast(),
+                padded.len(),
+                std::mem::size_of::<PaddedGenericCurveKey>(),
+                &mut required,
+            )
+        },
+        MmdRuntimeStatus::Ok
+    );
+    assert_eq!(padded.iter().map(|slot| slot.key).collect::<Vec<_>>(), keys);
+    assert!(padded.iter().all(|slot| slot.tail == [u64::MAX; 2]));
+
+    assert_eq!(
+        unsafe {
+            mmd_runtime_reduced_pose_generic_curve_keys(
+                reduced,
+                usize::MAX,
+                ptr::null_mut(),
+                0,
+                key_size,
+                &mut required,
+            )
+        },
+        MmdRuntimeStatus::InvalidInput
+    );
+    assert_eq!(required, 0);
+    unsafe { mmd_runtime_reduced_pose_free(reduced) };
+
+    let linear = reduced_pose_curve_fixture(0);
+    let mut count = usize::MAX;
+    assert_eq!(
+        unsafe { mmd_runtime_reduced_pose_generic_curve_count(linear, &mut count) },
+        MmdRuntimeStatus::Unsupported
+    );
+    assert_eq!(count, 0);
+    unsafe { mmd_runtime_reduced_pose_free(linear) };
+}
+
 fn copy_unity_curve_keys(
     reduced: *const MmdRuntimeReducedPose,
     frames_per_second: f32,

--- a/crates/mmd-anim-ffi/src/tests.rs
+++ b/crates/mmd-anim-ffi/src/tests.rs
@@ -925,7 +925,7 @@ fn simple_ik_chain() -> *mut MmdRuntimeIkChain {
     ];
     let links = [MmdRuntimeFfiRigIkLink {
         bone_slot: 0,
-        has_angle_limit: false,
+        has_angle_limit: 0,
         angle_limit_min_xyz: [0.0, 0.0, 0.0],
         angle_limit_max_xyz: [0.0, 0.0, 0.0],
     }];
@@ -943,11 +943,75 @@ fn simple_ik_chain() -> *mut MmdRuntimeIkChain {
 }
 
 #[test]
+fn primitive_creators_reject_noncanonical_boolean_bytes() {
+    let invalid_append = MmdRuntimeFfiAppendConfig {
+        ratio: 1.0,
+        affect_rotation: 2,
+        affect_translation: 1,
+    };
+    assert!(unsafe { mmd_runtime_append_solver_create(&invalid_append) }.is_null());
+
+    let bones = [MmdRuntimeFfiRigBone {
+        parent_slot: -1,
+        rest_position_xyz: [0.0, 0.0, 0.0],
+        flags: 0,
+        fixed_axis_xyz: [0.0, 0.0, 0.0],
+    }];
+    let invalid_link = [MmdRuntimeFfiRigIkLink {
+        bone_slot: 0,
+        has_angle_limit: 2,
+        angle_limit_min_xyz: [0.0; 3],
+        angle_limit_max_xyz: [0.0; 3],
+    }];
+    assert!(
+        unsafe {
+            mmd_runtime_ik_chain_create(
+                bones.as_ptr(),
+                bones.len(),
+                0,
+                invalid_link.as_ptr(),
+                invalid_link.len(),
+                1,
+                0.0,
+            )
+        }
+        .is_null()
+    );
+
+    let valid_link = [MmdRuntimeFfiRigIkLink {
+        bone_slot: 0,
+        has_angle_limit: 0,
+        angle_limit_min_xyz: [0.0; 3],
+        angle_limit_max_xyz: [0.0; 3],
+    }];
+    let invalid_local_axis = [MmdRuntimeFfiRigBoneLocalAxisV2 {
+        has_local_axis: 2,
+        local_axis_x_xyz: [0.0; 3],
+        local_axis_z_xyz: [0.0; 3],
+    }];
+    assert!(
+        unsafe {
+            mmd_runtime_ik_chain_create_v2(
+                bones.as_ptr(),
+                bones.len(),
+                invalid_local_axis.as_ptr(),
+                0,
+                valid_link.as_ptr(),
+                valid_link.len(),
+                1,
+                0.0,
+            )
+        }
+        .is_null()
+    );
+}
+
+#[test]
 fn append_solver_lifecycle_and_expected_output_use_xyzw_quaternion() {
     let config = MmdRuntimeFfiAppendConfig {
         ratio: 0.5,
-        affect_rotation: true,
-        affect_translation: true,
+        affect_rotation: 1,
+        affect_translation: 1,
     };
     let solver = unsafe { mmd_runtime_append_solver_create(&config) };
     assert!(!solver.is_null());
@@ -985,8 +1049,8 @@ fn append_solver_lifecycle_and_expected_output_use_xyzw_quaternion() {
 fn append_solver_rejects_null_inputs() {
     let config = MmdRuntimeFfiAppendConfig {
         ratio: 1.0,
-        affect_rotation: true,
-        affect_translation: true,
+        affect_rotation: 1,
+        affect_translation: 1,
     };
     assert!(unsafe { mmd_runtime_append_solver_create(ptr::null()) }.is_null());
     let solver = unsafe { mmd_runtime_append_solver_create(&config) };
@@ -1101,7 +1165,7 @@ fn ik_chain_create_v2_null_local_axes_matches_v1() {
     ];
     let links = [MmdRuntimeFfiRigIkLink {
         bone_slot: 0,
-        has_angle_limit: false,
+        has_angle_limit: 0,
         angle_limit_min_xyz: [0.0, 0.0, 0.0],
         angle_limit_max_xyz: [0.0, 0.0, 0.0],
     }];
@@ -1191,19 +1255,19 @@ fn ik_chain_create_v2_local_axis_changes_limited_solve() {
     let half_pi = std::f32::consts::FRAC_PI_2;
     let links = [MmdRuntimeFfiRigIkLink {
         bone_slot: 0,
-        has_angle_limit: true,
+        has_angle_limit: 1,
         angle_limit_min_xyz: [-half_pi, 0.0, 0.0],
         angle_limit_max_xyz: [half_pi, 0.0, 0.0],
     }];
     // localAxis x=(0,0,1), z=(0,1,0) rebuilds a non-identity LA frame.
     let local_axes = [
         MmdRuntimeFfiRigBoneLocalAxisV2 {
-            has_local_axis: true,
+            has_local_axis: 1,
             local_axis_x_xyz: [0.0, 0.0, 1.0],
             local_axis_z_xyz: [0.0, 1.0, 0.0],
         },
         MmdRuntimeFfiRigBoneLocalAxisV2 {
-            has_local_axis: false,
+            has_local_axis: 0,
             local_axis_x_xyz: [0.0, 0.0, 0.0],
             local_axis_z_xyz: [0.0, 0.0, 0.0],
         },

--- a/crates/mmd-anim-ffi/src/tests.rs
+++ b/crates/mmd-anim-ffi/src/tests.rs
@@ -303,7 +303,7 @@ fn reduced_pose_curve_fixture(target: u32) -> *mut MmdRuntimeReducedPose {
         world_rotation_radians: 1.0e-5,
         morph_weight: 1.0e-5,
     };
-    let mut reduced = ptr::null_mut();
+    let mut reduced = MaybeUninit::<*mut MmdRuntimeReducedPose>::uninit();
     assert_eq!(
         unsafe {
             mmd_runtime_reduced_pose_create_from_dense(
@@ -318,12 +318,13 @@ fn reduced_pose_curve_fixture(target: u32) -> *mut MmdRuntimeReducedPose {
                 1.0,
                 target,
                 tolerances,
-                &mut reduced,
+                reduced.as_mut_ptr(),
             )
         },
         MmdRuntimeStatus::Ok
     );
     unsafe { mmd_runtime_model_free(model) };
+    let reduced = unsafe { reduced.assume_init() };
     assert!(!reduced.is_null());
     reduced
 }
@@ -884,11 +885,12 @@ fn reduced_pose_handle_reports_and_enumerates_sparse_curves_after_model_free() {
     assert!(invalid.is_null());
     unsafe { mmd_runtime_model_free(model) };
 
-    let mut report = MmdRuntimeFfiPoseReductionReport::default();
+    let mut report = MaybeUninit::<MmdRuntimeFfiPoseReductionReport>::uninit();
     assert_eq!(
-        unsafe { mmd_runtime_reduced_pose_report(reduced, &mut report) },
+        unsafe { mmd_runtime_reduced_pose_report(reduced, report.as_mut_ptr()) },
         MmdRuntimeStatus::Ok
     );
+    let report = unsafe { report.assume_init() };
     assert_eq!(report.source_bone_key_count, 3);
     assert_eq!(report.reduced_bone_key_count, 2);
     assert_eq!(report.source_morph_key_count, 3);
@@ -3317,6 +3319,20 @@ fn evaluates_clip_frame_batch_through_c_abi_without_mutating_source_instance() {
             batch_world.len() - 1,
             batch_morphs.as_mut_ptr(),
             batch_morphs.len(),
+        )
+    });
+    assert!(!unsafe {
+        mmd_runtime_instance_evaluate_clip_frame_batch(
+            instance,
+            clip,
+            0.0,
+            30.0,
+            3,
+            2,
+            batch_world.as_mut_ptr(),
+            batch_world.len(),
+            batch_world.as_mut_ptr(),
+            3,
         )
     });
     assert!(!unsafe {

--- a/crates/mmd-anim-format/Cargo.toml
+++ b/crates/mmd-anim-format/Cargo.toml
@@ -19,7 +19,6 @@ glam.workspace = true
 thiserror.workspace = true
 encoding_rs.workspace = true
 serde.workspace = true
-web-time.workspace = true
 fbxcel = { version = "0.9", optional = true }
 
 [dev-dependencies]

--- a/crates/mmd-anim-format/Cargo.toml
+++ b/crates/mmd-anim-format/Cargo.toml
@@ -19,6 +19,7 @@ glam.workspace = true
 thiserror.workspace = true
 encoding_rs.workspace = true
 serde.workspace = true
+web-time.workspace = true
 fbxcel = { version = "0.9", optional = true }
 
 [dev-dependencies]

--- a/crates/mmd-anim-format/src/fbx/mod.rs
+++ b/crates/mmd-anim-format/src/fbx/mod.rs
@@ -4526,6 +4526,7 @@ mod tests {
             PmxParsedMorph {
                 name: "Smile".to_owned(),
                 english_name: "smile".to_owned(),
+                panel: "mouth".to_owned(),
                 kind: "vertex".to_owned(),
                 vertex_offsets: vec![PmxParsedVertexMorphOffset {
                     vertex_index: 1,
@@ -4542,6 +4543,7 @@ mod tests {
             PmxParsedMorph {
                 name: "BoneMorph".to_owned(),
                 english_name: "bone".to_owned(),
+                panel: "other".to_owned(),
                 kind: "bone".to_owned(),
                 vertex_offsets: Vec::new(),
                 group_offsets: Vec::new(),
@@ -4662,6 +4664,7 @@ mod tests {
         model.morphs = vec![PmxParsedMorph {
             name: "Smile".to_owned(),
             english_name: "smile".to_owned(),
+            panel: "mouth".to_owned(),
             kind: "vertex".to_owned(),
             vertex_offsets: vec![PmxParsedVertexMorphOffset {
                 vertex_index: 1,
@@ -4804,6 +4807,7 @@ mod tests {
         model.morphs = vec![PmxParsedMorph {
             name: "Smile".to_owned(),
             english_name: "smile".to_owned(),
+            panel: "mouth".to_owned(),
             kind: "vertex".to_owned(),
             vertex_offsets: vec![PmxParsedVertexMorphOffset {
                 vertex_index: 1,

--- a/crates/mmd-anim-format/src/lib.rs
+++ b/crates/mmd-anim-format/src/lib.rs
@@ -33,14 +33,13 @@ pub use pmm::{
 pub use pmx::{
     PmxBoneImport, PmxMaterialSplit, PmxMaterialSplitManifest, PmxMaterialSplitManifestMesh,
     PmxMaterialSplitMesh, PmxMaterialSplitMorphIndexMap, PmxMaterialSplitResult, PmxMorphNames,
-    PmxParseProfile, PmxParseSectionProfile, PmxParsedModel, PmxPartsBoneDescriptor,
-    PmxPartsDescriptor, PmxPartsDisplayFrameDescriptor, PmxPartsDisplayFrameItem,
-    PmxPartsGroupMorphOffset, PmxPartsIndexSizes, PmxPartsInput, PmxPartsJointDescriptor,
-    PmxPartsMaterialDescriptor, PmxPartsMaterialFlags, PmxPartsMorphDescriptor,
-    PmxPartsRigidBodyDescriptor, PmxPartsVertexMorphOffset, PmxRigSpec, PmxRigSpecBone,
-    PmxRigSpecGrant, PmxRigSpecIkChain, PmxRigSpecIkLink, PmxRigSpecLocalAxis, PmxRuntimeImport,
-    build_pmx_model_from_parts, export_pmx_model, import_pmx_model, import_pmx_runtime,
-    parse_pmx_material_split, parse_pmx_model, parse_pmx_model_profiled, parse_pmx_rig_spec,
+    PmxParsedModel, PmxPartsBoneDescriptor, PmxPartsDescriptor, PmxPartsDisplayFrameDescriptor,
+    PmxPartsDisplayFrameItem, PmxPartsGroupMorphOffset, PmxPartsIndexSizes, PmxPartsInput,
+    PmxPartsJointDescriptor, PmxPartsMaterialDescriptor, PmxPartsMaterialFlags,
+    PmxPartsMorphDescriptor, PmxPartsRigidBodyDescriptor, PmxPartsVertexMorphOffset, PmxRigSpec,
+    PmxRigSpecBone, PmxRigSpecGrant, PmxRigSpecIkChain, PmxRigSpecIkLink, PmxRigSpecLocalAxis,
+    PmxRuntimeImport, build_pmx_model_from_parts, export_pmx_model, import_pmx_model,
+    import_pmx_runtime, parse_pmx_material_split, parse_pmx_model, parse_pmx_rig_spec,
     split_pmx_model_by_material, validate_pmx_export_model,
 };
 pub use vmd::{

--- a/crates/mmd-anim-format/src/lib.rs
+++ b/crates/mmd-anim-format/src/lib.rs
@@ -33,13 +33,14 @@ pub use pmm::{
 pub use pmx::{
     PmxBoneImport, PmxMaterialSplit, PmxMaterialSplitManifest, PmxMaterialSplitManifestMesh,
     PmxMaterialSplitMesh, PmxMaterialSplitMorphIndexMap, PmxMaterialSplitResult, PmxMorphNames,
-    PmxParsedModel, PmxPartsBoneDescriptor, PmxPartsDescriptor, PmxPartsDisplayFrameDescriptor,
-    PmxPartsDisplayFrameItem, PmxPartsGroupMorphOffset, PmxPartsIndexSizes, PmxPartsInput,
-    PmxPartsJointDescriptor, PmxPartsMaterialDescriptor, PmxPartsMaterialFlags,
-    PmxPartsMorphDescriptor, PmxPartsRigidBodyDescriptor, PmxPartsVertexMorphOffset, PmxRigSpec,
-    PmxRigSpecBone, PmxRigSpecGrant, PmxRigSpecIkChain, PmxRigSpecIkLink, PmxRigSpecLocalAxis,
-    PmxRuntimeImport, build_pmx_model_from_parts, export_pmx_model, import_pmx_model,
-    import_pmx_runtime, parse_pmx_material_split, parse_pmx_model, parse_pmx_rig_spec,
+    PmxParseProfile, PmxParseSectionProfile, PmxParsedModel, PmxPartsBoneDescriptor,
+    PmxPartsDescriptor, PmxPartsDisplayFrameDescriptor, PmxPartsDisplayFrameItem,
+    PmxPartsGroupMorphOffset, PmxPartsIndexSizes, PmxPartsInput, PmxPartsJointDescriptor,
+    PmxPartsMaterialDescriptor, PmxPartsMaterialFlags, PmxPartsMorphDescriptor,
+    PmxPartsRigidBodyDescriptor, PmxPartsVertexMorphOffset, PmxRigSpec, PmxRigSpecBone,
+    PmxRigSpecGrant, PmxRigSpecIkChain, PmxRigSpecIkLink, PmxRigSpecLocalAxis, PmxRuntimeImport,
+    build_pmx_model_from_parts, export_pmx_model, import_pmx_model, import_pmx_runtime,
+    parse_pmx_material_split, parse_pmx_model, parse_pmx_model_profiled, parse_pmx_rig_spec,
     split_pmx_model_by_material, validate_pmx_export_model,
 };
 pub use vmd::{

--- a/crates/mmd-anim-format/src/pmx/mod.rs
+++ b/crates/mmd-anim-format/src/pmx/mod.rs
@@ -1283,6 +1283,8 @@ fn bytes_to_hex(bytes: &[u8]) -> String {
 pub struct PmxParsedMorph {
     pub name: String,
     pub english_name: String,
+    #[serde(default = "default_pmx_morph_panel")]
+    pub panel: String,
     #[serde(rename = "type")]
     pub kind: String,
     pub vertex_offsets: Vec<PmxParsedVertexMorphOffset>,
@@ -1671,6 +1673,8 @@ pub struct PmxPartsMorphDescriptor {
     pub name: String,
     #[serde(default)]
     pub english_name: String,
+    #[serde(default = "default_pmx_morph_panel")]
+    pub panel: String,
     #[serde(default = "default_pmx_parts_morph_kind", alias = "type")]
     pub kind: String,
     #[serde(default)]
@@ -1875,6 +1879,10 @@ fn default_pmx_parts_display_frame_kind() -> String {
 
 fn default_pmx_parts_morph_kind() -> String {
     "vertex".to_owned()
+}
+
+fn default_pmx_morph_panel() -> String {
+    "other".to_owned()
 }
 
 fn default_pmx_parts_rigid_body_shape() -> String {
@@ -2699,6 +2707,7 @@ fn pmx_parts_morph_from_descriptor(morph: &PmxPartsMorphDescriptor) -> PmxParsed
     let mut parsed = PmxParsedMorph {
         name: morph.name.clone(),
         english_name: morph.english_name.clone(),
+        panel: morph.panel.clone(),
         kind: morph.kind.clone(),
         vertex_offsets: Vec::new(),
         group_offsets: Vec::new(),
@@ -3100,7 +3109,7 @@ pub fn export_pmx_model(model: &PmxParsedModel) -> Vec<u8> {
     for morph in &model.morphs {
         write_pmx_string(&mut out, &morph.name, encoding);
         write_pmx_string(&mut out, &morph.english_name, encoding);
-        out.push(0);
+        out.push(morph_panel_byte(&morph.panel));
         let morph_type = morph_type_byte(morph);
         out.push(morph_type);
         write_i32(&mut out, morph_offset_count(morph, morph_type) as i32);
@@ -3868,6 +3877,7 @@ fn empty_pmx_material_split_morph_like(morph: &PmxParsedMorph) -> PmxParsedMorph
     PmxParsedMorph {
         name: morph.name.clone(),
         english_name: morph.english_name.clone(),
+        panel: morph.panel.clone(),
         kind: morph.kind.clone(),
         vertex_offsets: Vec::new(),
         group_offsets: Vec::new(),
@@ -4269,6 +4279,29 @@ fn morph_type_byte(morph: &PmxParsedMorph) -> u8 {
     }
 }
 
+fn morph_panel_name(panel: u8) -> String {
+    match panel {
+        0 => "system",
+        1 => "brow",
+        2 => "eye",
+        3 => "mouth",
+        4 => "other",
+        _ => "unknown",
+    }
+    .to_owned()
+}
+
+fn morph_panel_byte(panel: &str) -> u8 {
+    match panel {
+        "system" => 0,
+        "brow" => 1,
+        "eye" => 2,
+        "mouth" => 3,
+        "other" => 4,
+        _ => 4,
+    }
+}
+
 fn morph_offset_count(morph: &PmxParsedMorph, morph_type: u8) -> usize {
     match morph_type {
         0 => morph.group_offsets.len(),
@@ -4428,7 +4461,7 @@ fn read_parsed_morphs(
     for _ in 0..count {
         let name = r.read_string(header.encoding)?;
         let english_name = r.read_string(header.encoding)?;
-        let _panel = r.read_u8()?;
+        let panel = morph_panel_name(r.read_u8()?);
         let morph_type = r.read_u8()?;
         let min_offset_size = match morph_type {
             0 => header.morph_index_size as usize + 4,
@@ -4444,6 +4477,7 @@ fn read_parsed_morphs(
         let mut morph = PmxParsedMorph {
             name,
             english_name,
+            panel,
             kind: match morph_type {
                 0 => "group",
                 1 => "vertex",
@@ -5021,6 +5055,7 @@ mod tests {
             morphs: vec![PmxParsedMorph {
                 name: "Smile".to_owned(),
                 english_name: "SmileEn".to_owned(),
+                panel: "eye".to_owned(),
                 kind: "vertex".to_owned(),
                 vertex_offsets: vec![PmxParsedVertexMorphOffset {
                     vertex_index: 0,
@@ -5181,6 +5216,7 @@ mod tests {
             PmxParsedMorph {
                 name: "left-raise".to_owned(),
                 english_name: "left-raise-en".to_owned(),
+                panel: "brow".to_owned(),
                 kind: "vertex".to_owned(),
                 vertex_offsets: vec![PmxParsedVertexMorphOffset {
                     vertex_index: 1,
@@ -5197,6 +5233,7 @@ mod tests {
             PmxParsedMorph {
                 name: "right-raise".to_owned(),
                 english_name: "right-raise-en".to_owned(),
+                panel: "eye".to_owned(),
                 kind: "vertex".to_owned(),
                 vertex_offsets: vec![PmxParsedVertexMorphOffset {
                     vertex_index: 3,
@@ -5213,6 +5250,7 @@ mod tests {
             PmxParsedMorph {
                 name: "right-material".to_owned(),
                 english_name: "right-material-en".to_owned(),
+                panel: "other".to_owned(),
                 kind: "material".to_owned(),
                 vertex_offsets: Vec::new(),
                 group_offsets: Vec::new(),
@@ -5226,6 +5264,7 @@ mod tests {
             PmxParsedMorph {
                 name: "all-material".to_owned(),
                 english_name: "all-material-en".to_owned(),
+                panel: "other".to_owned(),
                 kind: "material".to_owned(),
                 vertex_offsets: Vec::new(),
                 group_offsets: Vec::new(),
@@ -5239,6 +5278,7 @@ mod tests {
             PmxParsedMorph {
                 name: "combo".to_owned(),
                 english_name: "combo-en".to_owned(),
+                panel: "other".to_owned(),
                 kind: "group".to_owned(),
                 vertex_offsets: Vec::new(),
                 group_offsets: vec![
@@ -5410,6 +5450,7 @@ mod tests {
         model.morphs.push(PmxParsedMorph {
             name: "forward-combo".to_owned(),
             english_name: "forward-combo-en".to_owned(),
+            panel: "other".to_owned(),
             kind: "group".to_owned(),
             vertex_offsets: Vec::new(),
             group_offsets: vec![PmxParsedGroupMorphOffset {
@@ -5426,6 +5467,7 @@ mod tests {
         model.morphs.push(PmxParsedMorph {
             name: "later-combo".to_owned(),
             english_name: "later-combo-en".to_owned(),
+            panel: "other".to_owned(),
             kind: "group".to_owned(),
             vertex_offsets: Vec::new(),
             group_offsets: vec![PmxParsedGroupMorphOffset {
@@ -6237,6 +6279,19 @@ mod tests {
         let reparsed = parse_pmx_model(&exported).unwrap();
 
         assert_pmx_roundtrip_eq(&parsed, &reparsed);
+    }
+
+    #[test]
+    fn exports_all_pmx_morph_panels_without_falling_back_to_other() {
+        for panel in ["system", "brow", "eye", "mouth", "other"] {
+            let mut parsed = parsed_pmx_fixture();
+            parsed.morphs[0].panel = panel.to_owned();
+
+            let exported = export_pmx_model(&parsed);
+            let reparsed = parse_pmx_model(&exported).unwrap();
+
+            assert_eq!(reparsed.morphs[0].panel, panel);
+        }
     }
 
     #[test]

--- a/crates/mmd-anim-format/src/pmx/mod.rs
+++ b/crates/mmd-anim-format/src/pmx/mod.rs
@@ -2,7 +2,6 @@ use std::collections::HashMap;
 
 use glam::{Mat4, Quat};
 use serde::{Deserialize, Serialize};
-use web_time::Instant;
 
 use mmd_anim_runtime::{
     AppendTransformInit, BoneIndex, BoneInit, BoneMorphOffset, GroupMorphOffset, IkAngleLimit,
@@ -901,23 +900,6 @@ pub struct PmxParsedModel {
     pub joints: Vec<PmxParsedJoint>,
     pub soft_bodies: Vec<PmxParsedSoftBody>,
     pub diagnostics: Vec<PmxParserDiagnostic>,
-}
-
-#[derive(Debug, Clone, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct PmxParseProfile {
-    pub input_bytes: usize,
-    pub total_duration_ns: u64,
-    pub sections: Vec<PmxParseSectionProfile>,
-}
-
-#[derive(Debug, Clone, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct PmxParseSectionProfile {
-    pub name: &'static str,
-    pub offset: usize,
-    pub bytes: usize,
-    pub duration_ns: u64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -2868,151 +2850,42 @@ fn default_pmx_parts_root_bone() -> PmxParsedBone {
     }
 }
 
-struct PmxParseProfiler {
-    input_bytes: usize,
-    total_started: Option<Instant>,
-    active_section: Option<(&'static str, usize, Instant)>,
-    sections: Vec<PmxParseSectionProfile>,
-}
-
-impl PmxParseProfiler {
-    fn disabled(input_bytes: usize) -> Self {
-        Self {
-            input_bytes,
-            total_started: None,
-            active_section: None,
-            sections: Vec::new(),
-        }
-    }
-
-    fn enabled(input_bytes: usize) -> Self {
-        Self {
-            input_bytes,
-            total_started: Some(Instant::now()),
-            active_section: None,
-            sections: Vec::new(),
-        }
-    }
-
-    fn begin(&mut self, name: &'static str, offset: usize) {
-        if self.total_started.is_some() {
-            debug_assert!(self.active_section.is_none());
-            self.active_section = Some((name, offset, Instant::now()));
-        }
-    }
-
-    fn end(&mut self, offset: usize) {
-        let Some((name, start_offset, started)) = self.active_section.take() else {
-            return;
-        };
-        self.sections.push(PmxParseSectionProfile {
-            name,
-            offset: start_offset,
-            bytes: offset.saturating_sub(start_offset),
-            duration_ns: duration_ns(started.elapsed()),
-        });
-    }
-
-    fn finish(self) -> PmxParseProfile {
-        debug_assert!(self.active_section.is_none());
-        PmxParseProfile {
-            input_bytes: self.input_bytes,
-            total_duration_ns: self
-                .total_started
-                .map(|started| duration_ns(started.elapsed()))
-                .unwrap_or(0),
-            sections: self.sections,
-        }
-    }
-}
-
-fn duration_ns(duration: std::time::Duration) -> u64 {
-    duration.as_nanos().min(u128::from(u64::MAX)) as u64
-}
-
 pub fn parse_pmx_model(data: &[u8]) -> Result<PmxParsedModel, ImportError> {
-    let mut profiler = PmxParseProfiler::disabled(data.len());
-    parse_pmx_model_inner(data, &mut profiler)
-}
-
-pub fn parse_pmx_model_profiled(
-    data: &[u8],
-) -> Result<(PmxParsedModel, PmxParseProfile), ImportError> {
-    let mut profiler = PmxParseProfiler::enabled(data.len());
-    let model = parse_pmx_model_inner(data, &mut profiler)?;
-    Ok((model, profiler.finish()))
-}
-
-fn parse_pmx_model_inner(
-    data: &[u8],
-    profiler: &mut PmxParseProfiler,
-) -> Result<PmxParsedModel, ImportError> {
-    profiler.begin("header", 0);
     let (header, pos) = read_header(data)?;
-    profiler.end(pos);
     let mut r = Reader { data, pos };
-
-    profiler.begin("metadata", r.pos);
     let name = r.read_string(header.encoding)?;
     let english_name = r.read_string(header.encoding)?;
     let comment = r.read_string(header.encoding)?;
     let english_comment = r.read_string(header.encoding)?;
-    profiler.end(r.pos);
 
-    profiler.begin("vertices", r.pos);
     let vertex_count = read_section_count_with_min_record(&mut r, 12 + 12 + 8 + 1 + 4)?;
-    let geometry = read_parsed_geometry(&mut r, &header, vertex_count, profiler)?;
+    let geometry = read_parsed_geometry(&mut r, &header, vertex_count)?;
     let index_count = geometry.indices.len();
-
-    profiler.begin("textures", r.pos);
     let textures = read_parsed_textures(&mut r, header.encoding)?;
-    profiler.end(r.pos);
-
-    profiler.begin("materials", r.pos);
     let materials = read_parsed_materials(&mut r, &header, &textures)?;
     let material_groups = build_material_groups(&materials);
-    profiler.end(r.pos);
-
-    profiler.begin("bones", r.pos);
     let bone_count = read_section_count_with_min_record(&mut r, 4 + 4 + 12)?;
     let skeleton = PmxParsedSkeleton {
         bones: read_parsed_bones(&mut r, &header, bone_count)?,
     };
-    profiler.end(r.pos);
-
-    profiler.begin("morphs", r.pos);
     let morphs = read_parsed_morphs(&mut r, &header)?;
-    profiler.end(r.pos);
-
-    profiler.begin("display_frames", r.pos);
     let display_frames = read_parsed_display_frames(&mut r, &header)?;
-    profiler.end(r.pos);
-
-    profiler.begin("rigid_bodies", r.pos);
     let rigid_bodies = if r.remaining() >= 4 {
         read_parsed_rigid_bodies(&mut r, &header)?
     } else {
         Vec::new()
     };
-    profiler.end(r.pos);
-
-    profiler.begin("joints", r.pos);
     let joints = if r.remaining() >= 4 {
         read_parsed_joints(&mut r, &header)?
     } else {
         Vec::new()
     };
-    profiler.end(r.pos);
-
-    profiler.begin("soft_bodies", r.pos);
     let soft_bodies = if header.version >= 2.05 && r.remaining() >= 4 {
         read_parsed_soft_bodies(&mut r, &header)?
     } else {
         Vec::new()
     };
-    profiler.end(r.pos);
 
-    profiler.begin("finalize", r.pos);
     let mut geometry = geometry;
     geometry.material_groups = material_groups;
     let mut diagnostics = Vec::new();
@@ -3034,7 +2907,7 @@ fn parse_pmx_model_inner(
         });
     }
 
-    let model = PmxParsedModel {
+    Ok(PmxParsedModel {
         metadata: PmxParsedMetadata {
             format: "pmx".to_owned(),
             version: header.version,
@@ -3076,9 +2949,7 @@ fn parse_pmx_model_inner(
         joints,
         soft_bodies,
         diagnostics,
-    };
-    profiler.end(r.pos);
-    Ok(model)
+    })
 }
 
 pub fn export_pmx_model(model: &PmxParsedModel) -> Vec<u8> {
@@ -3432,7 +3303,6 @@ fn read_parsed_geometry(
     r: &mut Reader<'_>,
     header: &PmxHeader,
     vertex_count: usize,
-    profiler: &mut PmxParseProfiler,
 ) -> Result<PmxParsedGeometry, ImportError> {
     r.require_record_bytes(vertex_count, 12 + 12 + 8 + 1 + 4)?;
     let position_capacity = vertex_count
@@ -3540,14 +3410,11 @@ fn read_parsed_geometry(
         edge_scale.push(r.read_f32_le()?);
     }
 
-    profiler.end(r.pos);
-    profiler.begin("indices", r.pos);
     let index_count = read_section_count_with_min_record(r, header.vertex_index_size as usize)?;
     let mut indices = Vec::with_capacity(index_count);
     for _ in 0..index_count {
         indices.push(r.read_vertex_index(header.vertex_index_size)?);
     }
-    profiler.end(r.pos);
 
     Ok(PmxParsedGeometry {
         positions,
@@ -6412,51 +6279,6 @@ mod tests {
         let reparsed = parse_pmx_model(&exported).unwrap();
 
         assert_pmx_roundtrip_eq(&parsed, &reparsed);
-    }
-
-    #[test]
-    fn profiled_parse_reports_ordered_sections_without_changing_the_model() {
-        let input = ik_multi_axis_limit_pmx_fixture();
-        let regular = parse_pmx_model(input).unwrap();
-        let (profiled, profile) = parse_pmx_model_profiled(input).unwrap();
-
-        assert_eq!(profile.input_bytes, input.len());
-        assert_eq!(
-            profiled.metadata.counts.vertices,
-            regular.metadata.counts.vertices
-        );
-        assert_eq!(
-            profiled.metadata.counts.morphs,
-            regular.metadata.counts.morphs
-        );
-        assert_eq!(profiled.geometry.positions, regular.geometry.positions);
-        assert_eq!(
-            profile
-                .sections
-                .iter()
-                .map(|section| section.name)
-                .collect::<Vec<_>>(),
-            [
-                "header",
-                "metadata",
-                "vertices",
-                "indices",
-                "textures",
-                "materials",
-                "bones",
-                "morphs",
-                "display_frames",
-                "rigid_bodies",
-                "joints",
-                "soft_bodies",
-                "finalize",
-            ]
-        );
-        for sections in profile.sections.windows(2) {
-            assert_eq!(sections[0].offset + sections[0].bytes, sections[1].offset);
-        }
-        let last = profile.sections.last().unwrap();
-        assert_eq!(last.offset + last.bytes, input.len());
     }
 
     #[test]

--- a/crates/mmd-anim-format/src/pmx/mod.rs
+++ b/crates/mmd-anim-format/src/pmx/mod.rs
@@ -2371,6 +2371,12 @@ fn validate_pmx_parts_morphs(
         ));
     }
     for (morph_index, morph) in descriptor.morphs.iter().enumerate() {
+        if morph_panel_byte_checked(&morph.panel).is_none() {
+            return Err(format!(
+                "morphs[{morph_index}].panel must be system, brow, eye, mouth, or other, got {}",
+                morph.panel
+            ));
+        }
         match morph.kind.as_str() {
             "vertex" => {
                 for (offset_index, offset) in morph.vertex_offsets.iter().enumerate() {
@@ -4292,13 +4298,17 @@ fn morph_panel_name(panel: u8) -> String {
 }
 
 fn morph_panel_byte(panel: &str) -> u8 {
+    morph_panel_byte_checked(panel).unwrap_or(4)
+}
+
+fn morph_panel_byte_checked(panel: &str) -> Option<u8> {
     match panel {
-        "system" => 0,
-        "brow" => 1,
-        "eye" => 2,
-        "mouth" => 3,
-        "other" => 4,
-        _ => 4,
+        "system" => Some(0),
+        "brow" => Some(1),
+        "eye" => Some(2),
+        "mouth" => Some(3),
+        "other" => Some(4),
+        _ => None,
     }
 }
 
@@ -6556,6 +6566,30 @@ mod tests {
         .unwrap_err();
 
         assert!(error.contains("materials faceCount sum"));
+    }
+
+    #[test]
+    fn rejects_invalid_pmx_parts_morph_panel() {
+        let descriptor: PmxPartsDescriptor = serde_json::from_value(serde_json::json!({
+            "morphs": [{ "name": "typo", "kind": "vertex", "panel": "moutn" }]
+        }))
+        .unwrap();
+        let error = build_pmx_model_from_parts(PmxPartsInput {
+            descriptor,
+            positions_xyz: &[0.0, 0.0, 0.0],
+            normals_xyz: &[0.0, 1.0, 0.0],
+            uvs_xy: &[0.0, 0.0],
+            indices: &[],
+            skin_indices: &[],
+            skin_weights: &[],
+            edge_scale: &[],
+        })
+        .unwrap_err();
+
+        assert_eq!(
+            error,
+            "morphs[0].panel must be system, brow, eye, mouth, or other, got moutn"
+        );
     }
 
     #[test]

--- a/crates/mmd-anim-format/src/pmx/mod.rs
+++ b/crates/mmd-anim-format/src/pmx/mod.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 use glam::{Mat4, Quat};
 use serde::{Deserialize, Serialize};
+use web_time::Instant;
 
 use mmd_anim_runtime::{
     AppendTransformInit, BoneIndex, BoneInit, BoneMorphOffset, GroupMorphOffset, IkAngleLimit,
@@ -900,6 +901,23 @@ pub struct PmxParsedModel {
     pub joints: Vec<PmxParsedJoint>,
     pub soft_bodies: Vec<PmxParsedSoftBody>,
     pub diagnostics: Vec<PmxParserDiagnostic>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PmxParseProfile {
+    pub input_bytes: usize,
+    pub total_duration_ns: u64,
+    pub sections: Vec<PmxParseSectionProfile>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PmxParseSectionProfile {
+    pub name: &'static str,
+    pub offset: usize,
+    pub bytes: usize,
+    pub duration_ns: u64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -2850,42 +2868,151 @@ fn default_pmx_parts_root_bone() -> PmxParsedBone {
     }
 }
 
+struct PmxParseProfiler {
+    input_bytes: usize,
+    total_started: Option<Instant>,
+    active_section: Option<(&'static str, usize, Instant)>,
+    sections: Vec<PmxParseSectionProfile>,
+}
+
+impl PmxParseProfiler {
+    fn disabled(input_bytes: usize) -> Self {
+        Self {
+            input_bytes,
+            total_started: None,
+            active_section: None,
+            sections: Vec::new(),
+        }
+    }
+
+    fn enabled(input_bytes: usize) -> Self {
+        Self {
+            input_bytes,
+            total_started: Some(Instant::now()),
+            active_section: None,
+            sections: Vec::new(),
+        }
+    }
+
+    fn begin(&mut self, name: &'static str, offset: usize) {
+        if self.total_started.is_some() {
+            debug_assert!(self.active_section.is_none());
+            self.active_section = Some((name, offset, Instant::now()));
+        }
+    }
+
+    fn end(&mut self, offset: usize) {
+        let Some((name, start_offset, started)) = self.active_section.take() else {
+            return;
+        };
+        self.sections.push(PmxParseSectionProfile {
+            name,
+            offset: start_offset,
+            bytes: offset.saturating_sub(start_offset),
+            duration_ns: duration_ns(started.elapsed()),
+        });
+    }
+
+    fn finish(self) -> PmxParseProfile {
+        debug_assert!(self.active_section.is_none());
+        PmxParseProfile {
+            input_bytes: self.input_bytes,
+            total_duration_ns: self
+                .total_started
+                .map(|started| duration_ns(started.elapsed()))
+                .unwrap_or(0),
+            sections: self.sections,
+        }
+    }
+}
+
+fn duration_ns(duration: std::time::Duration) -> u64 {
+    duration.as_nanos().min(u128::from(u64::MAX)) as u64
+}
+
 pub fn parse_pmx_model(data: &[u8]) -> Result<PmxParsedModel, ImportError> {
+    let mut profiler = PmxParseProfiler::disabled(data.len());
+    parse_pmx_model_inner(data, &mut profiler)
+}
+
+pub fn parse_pmx_model_profiled(
+    data: &[u8],
+) -> Result<(PmxParsedModel, PmxParseProfile), ImportError> {
+    let mut profiler = PmxParseProfiler::enabled(data.len());
+    let model = parse_pmx_model_inner(data, &mut profiler)?;
+    Ok((model, profiler.finish()))
+}
+
+fn parse_pmx_model_inner(
+    data: &[u8],
+    profiler: &mut PmxParseProfiler,
+) -> Result<PmxParsedModel, ImportError> {
+    profiler.begin("header", 0);
     let (header, pos) = read_header(data)?;
+    profiler.end(pos);
     let mut r = Reader { data, pos };
+
+    profiler.begin("metadata", r.pos);
     let name = r.read_string(header.encoding)?;
     let english_name = r.read_string(header.encoding)?;
     let comment = r.read_string(header.encoding)?;
     let english_comment = r.read_string(header.encoding)?;
+    profiler.end(r.pos);
 
+    profiler.begin("vertices", r.pos);
     let vertex_count = read_section_count_with_min_record(&mut r, 12 + 12 + 8 + 1 + 4)?;
-    let geometry = read_parsed_geometry(&mut r, &header, vertex_count)?;
+    let geometry = read_parsed_geometry(&mut r, &header, vertex_count, profiler)?;
     let index_count = geometry.indices.len();
+
+    profiler.begin("textures", r.pos);
     let textures = read_parsed_textures(&mut r, header.encoding)?;
+    profiler.end(r.pos);
+
+    profiler.begin("materials", r.pos);
     let materials = read_parsed_materials(&mut r, &header, &textures)?;
     let material_groups = build_material_groups(&materials);
+    profiler.end(r.pos);
+
+    profiler.begin("bones", r.pos);
     let bone_count = read_section_count_with_min_record(&mut r, 4 + 4 + 12)?;
     let skeleton = PmxParsedSkeleton {
         bones: read_parsed_bones(&mut r, &header, bone_count)?,
     };
+    profiler.end(r.pos);
+
+    profiler.begin("morphs", r.pos);
     let morphs = read_parsed_morphs(&mut r, &header)?;
+    profiler.end(r.pos);
+
+    profiler.begin("display_frames", r.pos);
     let display_frames = read_parsed_display_frames(&mut r, &header)?;
+    profiler.end(r.pos);
+
+    profiler.begin("rigid_bodies", r.pos);
     let rigid_bodies = if r.remaining() >= 4 {
         read_parsed_rigid_bodies(&mut r, &header)?
     } else {
         Vec::new()
     };
+    profiler.end(r.pos);
+
+    profiler.begin("joints", r.pos);
     let joints = if r.remaining() >= 4 {
         read_parsed_joints(&mut r, &header)?
     } else {
         Vec::new()
     };
+    profiler.end(r.pos);
+
+    profiler.begin("soft_bodies", r.pos);
     let soft_bodies = if header.version >= 2.05 && r.remaining() >= 4 {
         read_parsed_soft_bodies(&mut r, &header)?
     } else {
         Vec::new()
     };
+    profiler.end(r.pos);
 
+    profiler.begin("finalize", r.pos);
     let mut geometry = geometry;
     geometry.material_groups = material_groups;
     let mut diagnostics = Vec::new();
@@ -2907,7 +3034,7 @@ pub fn parse_pmx_model(data: &[u8]) -> Result<PmxParsedModel, ImportError> {
         });
     }
 
-    Ok(PmxParsedModel {
+    let model = PmxParsedModel {
         metadata: PmxParsedMetadata {
             format: "pmx".to_owned(),
             version: header.version,
@@ -2949,7 +3076,9 @@ pub fn parse_pmx_model(data: &[u8]) -> Result<PmxParsedModel, ImportError> {
         joints,
         soft_bodies,
         diagnostics,
-    })
+    };
+    profiler.end(r.pos);
+    Ok(model)
 }
 
 pub fn export_pmx_model(model: &PmxParsedModel) -> Vec<u8> {
@@ -3303,6 +3432,7 @@ fn read_parsed_geometry(
     r: &mut Reader<'_>,
     header: &PmxHeader,
     vertex_count: usize,
+    profiler: &mut PmxParseProfiler,
 ) -> Result<PmxParsedGeometry, ImportError> {
     r.require_record_bytes(vertex_count, 12 + 12 + 8 + 1 + 4)?;
     let position_capacity = vertex_count
@@ -3410,11 +3540,14 @@ fn read_parsed_geometry(
         edge_scale.push(r.read_f32_le()?);
     }
 
+    profiler.end(r.pos);
+    profiler.begin("indices", r.pos);
     let index_count = read_section_count_with_min_record(r, header.vertex_index_size as usize)?;
     let mut indices = Vec::with_capacity(index_count);
     for _ in 0..index_count {
         indices.push(r.read_vertex_index(header.vertex_index_size)?);
     }
+    profiler.end(r.pos);
 
     Ok(PmxParsedGeometry {
         positions,
@@ -6279,6 +6412,51 @@ mod tests {
         let reparsed = parse_pmx_model(&exported).unwrap();
 
         assert_pmx_roundtrip_eq(&parsed, &reparsed);
+    }
+
+    #[test]
+    fn profiled_parse_reports_ordered_sections_without_changing_the_model() {
+        let input = ik_multi_axis_limit_pmx_fixture();
+        let regular = parse_pmx_model(input).unwrap();
+        let (profiled, profile) = parse_pmx_model_profiled(input).unwrap();
+
+        assert_eq!(profile.input_bytes, input.len());
+        assert_eq!(
+            profiled.metadata.counts.vertices,
+            regular.metadata.counts.vertices
+        );
+        assert_eq!(
+            profiled.metadata.counts.morphs,
+            regular.metadata.counts.morphs
+        );
+        assert_eq!(profiled.geometry.positions, regular.geometry.positions);
+        assert_eq!(
+            profile
+                .sections
+                .iter()
+                .map(|section| section.name)
+                .collect::<Vec<_>>(),
+            [
+                "header",
+                "metadata",
+                "vertices",
+                "indices",
+                "textures",
+                "materials",
+                "bones",
+                "morphs",
+                "display_frames",
+                "rigid_bodies",
+                "joints",
+                "soft_bodies",
+                "finalize",
+            ]
+        );
+        for sections in profile.sections.windows(2) {
+            assert_eq!(sections[0].offset + sections[0].bytes, sections[1].offset);
+        }
+        let last = profile.sections.last().unwrap();
+        assert_eq!(last.offset + last.bytes, input.len());
     }
 
     #[test]

--- a/crates/mmd-anim-runtime/src/runtime.rs
+++ b/crates/mmd-anim-runtime/src/runtime.rs
@@ -96,7 +96,9 @@ impl IkSolverRuntimeStats {
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IkSolveOptions {
+    /// Goal distance at or below which the solver stops. Defaults to `1e-4` model units.
     pub tolerance: f32,
+    /// Optional per-chain iteration cap. Defaults to the iteration count stored in the model.
     pub max_iterations_cap: Option<u32>,
 }
 
@@ -105,7 +107,10 @@ pub use physics::{PhysicsMode, PhysicsStepStats, PhysicsTickConfig};
 impl Default for IkSolveOptions {
     fn default() -> Self {
         Self {
-            tolerance: 0.0,
+            // A zero tolerance effectively disables convergence breaks for ordinary floating-point
+            // poses. This matches the TypeScript runtime while leaving slow-converging chains free
+            // to use the full iteration count authored in the model.
+            tolerance: 1.0e-4,
             max_iterations_cap: None,
         }
     }

--- a/crates/mmd-anim-runtime/src/runtime/tests.rs
+++ b/crates/mmd-anim-runtime/src/runtime/tests.rs
@@ -9,6 +9,14 @@ use crate::{
     PhysicsMode, PhysicsTickConfig, RuntimeInstance,
 };
 
+#[test]
+fn default_ik_options_enable_convergence_without_capping_authored_iterations() {
+    let options = IkSolveOptions::default();
+
+    assert_eq!(options.tolerance, 1.0e-4);
+    assert_eq!(options.max_iterations_cap, None);
+}
+
 fn translation(matrix: glam::Mat4) -> Vec3A {
     Vec3A::from_vec4(matrix.w_axis)
 }
@@ -513,7 +521,14 @@ fn primitive_ik_solver_matches_runtime_ik_driver_for_two_link_chain() {
         max_iterations_cap: None,
     });
 
-    runtime.solve_ik_solver(0, IkSolveOptions::default(), false);
+    runtime.solve_ik_solver(
+        0,
+        IkSolveOptions {
+            tolerance: 0.0,
+            max_iterations_cap: None,
+        },
+        false,
+    );
 
     assert_quat_near(
         runtime.pose().local_rotation(BoneIndex(1)),
@@ -1116,10 +1131,34 @@ fn evaluate_pose_category_snapshot(
     runtime: &mut RuntimeInstance,
 ) -> WorldMatrixBoneUpdateCategorySnapshot {
     runtime.reset_world_matrix_bone_update_count();
-    runtime.evaluate_current_pose();
+    // Preserve the worst-case full-iteration characterization independently of the
+    // user-facing default convergence tolerance.
+    runtime.evaluate_current_pose_with_ik_options(IkSolveOptions {
+        tolerance: 0.0,
+        max_iterations_cap: None,
+    });
     let snapshot = WorldMatrixBoneUpdateCategorySnapshot::from_runtime(runtime);
     snapshot.assert_matches_total(runtime.world_matrix_bone_update_count());
     snapshot
+}
+
+#[test]
+fn default_ik_tolerance_stops_converged_chains_without_capping_authored_iterations() {
+    let model = build_late_chain_multi_link_ik_model(32, 3, 20);
+    let mut default_runtime = RuntimeInstance::new(Arc::clone(&model));
+    default_runtime.evaluate_current_pose();
+    let default_stats = default_runtime.ik_runtime_stats()[0];
+
+    let mut exact_runtime = RuntimeInstance::new(model);
+    exact_runtime.evaluate_current_pose_with_ik_options(IkSolveOptions {
+        tolerance: 0.0,
+        max_iterations_cap: None,
+    });
+    let exact_stats = exact_runtime.ik_runtime_stats()[0];
+
+    assert!(default_stats.final_distance_max <= IkSolveOptions::default().tolerance);
+    assert!(default_stats.executed_iterations < exact_stats.executed_iterations);
+    assert_eq!(default_stats.max_iteration_exhaustions, 0);
 }
 
 #[test]

--- a/crates/mmd-anim-wasm/Cargo.toml
+++ b/crates/mmd-anim-wasm/Cargo.toml
@@ -20,4 +20,5 @@ mmd-anim-runtime.workspace = true
 mmd-anim-format = { path = "../mmd-anim-format", version = "0.3.1" }
 wasm-bindgen.workspace = true
 js-sys.workspace = true
+serde.workspace = true
 serde_json.workspace = true

--- a/crates/mmd-anim-wasm/Cargo.toml
+++ b/crates/mmd-anim-wasm/Cargo.toml
@@ -17,7 +17,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 glam.workspace = true
 mmd-anim-runtime.workspace = true
-mmd-anim-format = { path = "../mmd-anim-format", version = "0.3.1" }
+mmd-anim-format = { path = "../mmd-anim-format", version = "0.3.2" }
 wasm-bindgen.workspace = true
 js-sys.workspace = true
 serde.workspace = true

--- a/crates/mmd-anim-wasm/src/lib.rs
+++ b/crates/mmd-anim-wasm/src/lib.rs
@@ -547,6 +547,7 @@ impl WasmPmxGeometry {
 #[wasm_bindgen]
 pub struct WasmPmxParsedModel {
     parsed: mmd_anim_format::pmx::PmxParsedModel,
+    profile: Option<mmd_anim_format::PmxParseProfile>,
 }
 
 impl WasmPmxParsedModel {
@@ -555,7 +556,30 @@ impl WasmPmxParsedModel {
             return Err("PMX data is empty".to_owned());
         }
         let parsed = mmd_anim_format::parse_pmx_model(data).map_err(|e| e.to_string())?;
-        Ok(Self { parsed })
+        Ok(Self {
+            parsed,
+            profile: None,
+        })
+    }
+
+    fn parse_profiled_inner(data: &[u8]) -> Result<Self, String> {
+        if data.is_empty() {
+            return Err("PMX data is empty".to_owned());
+        }
+        let (parsed, profile) =
+            mmd_anim_format::parse_pmx_model_profiled(data).map_err(|e| e.to_string())?;
+        Ok(Self {
+            parsed,
+            profile: Some(profile),
+        })
+    }
+
+    fn profile_json_inner(&self) -> Result<String, String> {
+        let profile = self
+            .profile
+            .as_ref()
+            .ok_or_else(|| "PMX parse profiling was not enabled".to_owned())?;
+        serde_json::to_string(profile).map_err(|error| error.to_string())
     }
 }
 
@@ -566,6 +590,20 @@ impl WasmPmxParsedModel {
     pub fn parse(data: &[u8]) -> Result<WasmPmxParsedModel, JsValue> {
         Self::parse_inner(data)
             .map_err(|error| js_parser_error("PMX", "parsePmxParsedModel", None, error))
+    }
+
+    /// Parse PMX bytes once while collecting per-section timings.
+    #[wasm_bindgen(js_name = parseProfiled)]
+    pub fn parse_profiled(data: &[u8]) -> Result<WasmPmxParsedModel, JsValue> {
+        Self::parse_profiled_inner(data)
+            .map_err(|error| js_parser_error("PMX", "parsePmxParsedModelProfiled", None, error))
+    }
+
+    /// Return the opt-in parse profile collected by `parseProfiled`.
+    #[wasm_bindgen(js_name = profileJson)]
+    pub fn profile_json(&self) -> Result<String, JsValue> {
+        self.profile_json_inner()
+            .map_err(|error| js_parser_error("PMX", "profileJson", None, error))
     }
 
     /// Return JSON with all model data except geometry.
@@ -3472,5 +3510,26 @@ TextureFilename { "tex/main.png"; }
     #[test]
     fn pmx_parsed_model_handle_rejects_empty_input() {
         assert!(WasmPmxParsedModel::parse_inner(&[]).is_err());
+    }
+
+    #[test]
+    fn pmx_profiled_handle_exposes_parse_sections() {
+        let pmx_bytes = minimal_pmx_bytes();
+        let parsed = WasmPmxParsedModel::parse_profiled_inner(&pmx_bytes).unwrap();
+        let value: serde_json::Value =
+            serde_json::from_str(&parsed.profile_json_inner().unwrap()).unwrap();
+
+        assert_eq!(value["inputBytes"], pmx_bytes.len());
+        assert_eq!(value["sections"][0]["name"], "header");
+        assert_eq!(value["sections"][12]["name"], "finalize");
+    }
+
+    #[test]
+    fn pmx_regular_handle_has_no_parse_profile() {
+        let parsed = WasmPmxParsedModel::parse_inner(&minimal_pmx_bytes()).unwrap();
+        assert_eq!(
+            parsed.profile_json_inner().unwrap_err(),
+            "PMX parse profiling was not enabled"
+        );
     }
 }

--- a/crates/mmd-anim-wasm/src/lib.rs
+++ b/crates/mmd-anim-wasm/src/lib.rs
@@ -671,7 +671,6 @@ impl WasmPmxVertexMorphOffsets {
 #[wasm_bindgen]
 pub struct WasmPmxParsedModel {
     parsed: mmd_anim_format::pmx::PmxParsedModel,
-    profile: Option<mmd_anim_format::PmxParseProfile>,
 }
 
 impl WasmPmxParsedModel {
@@ -680,30 +679,7 @@ impl WasmPmxParsedModel {
             return Err("PMX data is empty".to_owned());
         }
         let parsed = mmd_anim_format::parse_pmx_model(data).map_err(|e| e.to_string())?;
-        Ok(Self {
-            parsed,
-            profile: None,
-        })
-    }
-
-    fn parse_profiled_inner(data: &[u8]) -> Result<Self, String> {
-        if data.is_empty() {
-            return Err("PMX data is empty".to_owned());
-        }
-        let (parsed, profile) =
-            mmd_anim_format::parse_pmx_model_profiled(data).map_err(|e| e.to_string())?;
-        Ok(Self {
-            parsed,
-            profile: Some(profile),
-        })
-    }
-
-    fn profile_json_inner(&self) -> Result<String, String> {
-        let profile = self
-            .profile
-            .as_ref()
-            .ok_or_else(|| "PMX parse profiling was not enabled".to_owned())?;
-        serde_json::to_string(profile).map_err(|error| error.to_string())
+        Ok(Self { parsed })
     }
 }
 
@@ -714,20 +690,6 @@ impl WasmPmxParsedModel {
     pub fn parse(data: &[u8]) -> Result<WasmPmxParsedModel, JsValue> {
         Self::parse_inner(data)
             .map_err(|error| js_parser_error("PMX", "parsePmxParsedModel", None, error))
-    }
-
-    /// Parse PMX bytes once while collecting per-section timings.
-    #[wasm_bindgen(js_name = parseProfiled)]
-    pub fn parse_profiled(data: &[u8]) -> Result<WasmPmxParsedModel, JsValue> {
-        Self::parse_profiled_inner(data)
-            .map_err(|error| js_parser_error("PMX", "parsePmxParsedModelProfiled", None, error))
-    }
-
-    /// Return the opt-in parse profile collected by `parseProfiled`.
-    #[wasm_bindgen(js_name = profileJson)]
-    pub fn profile_json(&self) -> Result<String, JsValue> {
-        self.profile_json_inner()
-            .map_err(|error| js_parser_error("PMX", "profileJson", None, error))
     }
 
     /// Return JSON with all model data except geometry.
@@ -3677,7 +3639,6 @@ TextureFilename { "tex/main.png"; }
     fn pmx_parsed_model_handle_rejects_empty_input() {
         assert!(WasmPmxParsedModel::parse_inner(&[]).is_err());
     }
-
     #[test]
     fn pmx_parsed_model_handle_splits_vertex_morph_offsets_from_json() {
         let parsed = WasmPmxParsedModel::parse_inner(&vertex_morph_pmx_bytes()).unwrap();
@@ -3691,26 +3652,5 @@ TextureFilename { "tex/main.png"; }
         assert_eq!(offsets.morph_spans(), vec![0, 2]);
         assert_eq!(offsets.vertex_indices(), vec![0, 2]);
         assert_eq!(offsets.positions(), vec![1.0, 2.0, 3.0, -1.0, 0.5, 4.0]);
-    }
-
-    #[test]
-    fn pmx_profiled_handle_exposes_parse_sections() {
-        let pmx_bytes = minimal_pmx_bytes();
-        let parsed = WasmPmxParsedModel::parse_profiled_inner(&pmx_bytes).unwrap();
-        let value: serde_json::Value =
-            serde_json::from_str(&parsed.profile_json_inner().unwrap()).unwrap();
-
-        assert_eq!(value["inputBytes"], pmx_bytes.len());
-        assert_eq!(value["sections"][0]["name"], "header");
-        assert_eq!(value["sections"][12]["name"], "finalize");
-    }
-
-    #[test]
-    fn pmx_regular_handle_has_no_parse_profile() {
-        let parsed = WasmPmxParsedModel::parse_inner(&minimal_pmx_bytes()).unwrap();
-        assert_eq!(
-            parsed.profile_json_inner().unwrap_err(),
-            "PMX parse profiling was not enabled"
-        );
     }
 }

--- a/crates/mmd-anim-wasm/src/lib.rs
+++ b/crates/mmd-anim-wasm/src/lib.rs
@@ -45,6 +45,61 @@ pub fn parse_pmx_model_json(data: &[u8]) -> Result<String, JsValue> {
 fn pmx_model_non_geometry_json_from_parsed(
     parsed: &mmd_anim_format::pmx::PmxParsedModel,
 ) -> Result<String, String> {
+    pmx_model_non_geometry_json_from_parsed_with_morphs(
+        parsed,
+        serde_json::to_value(&parsed.morphs).map_err(|error| error.to_string())?,
+    )
+}
+
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct PmxMorphWithoutVertexOffsets<'a> {
+    name: &'a str,
+    english_name: &'a str,
+    panel: &'a str,
+    #[serde(rename = "type")]
+    kind: &'a str,
+    vertex_offsets: [mmd_anim_format::pmx::PmxParsedVertexMorphOffset; 0],
+    group_offsets: &'a [mmd_anim_format::pmx::PmxParsedGroupMorphOffset],
+    bone_offsets: &'a [mmd_anim_format::pmx::PmxParsedBoneMorphOffset],
+    uv_offsets: &'a [mmd_anim_format::pmx::PmxParsedUvMorphOffset],
+    additional_uv_offsets: &'a [mmd_anim_format::pmx::PmxParsedAdditionalUvMorphOffset],
+    material_offsets: &'a [mmd_anim_format::pmx::PmxParsedMaterialMorphOffset],
+    flip_offsets: &'a [mmd_anim_format::pmx::PmxParsedGroupMorphOffset],
+    impulse_offsets: &'a [mmd_anim_format::pmx::PmxParsedImpulseMorphOffset],
+}
+
+fn pmx_model_non_geometry_json_without_vertex_offsets_from_parsed(
+    parsed: &mmd_anim_format::pmx::PmxParsedModel,
+) -> Result<String, String> {
+    let morphs = parsed
+        .morphs
+        .iter()
+        .map(|morph| PmxMorphWithoutVertexOffsets {
+            name: &morph.name,
+            english_name: &morph.english_name,
+            panel: &morph.panel,
+            kind: &morph.kind,
+            vertex_offsets: [],
+            group_offsets: &morph.group_offsets,
+            bone_offsets: &morph.bone_offsets,
+            uv_offsets: &morph.uv_offsets,
+            additional_uv_offsets: &morph.additional_uv_offsets,
+            material_offsets: &morph.material_offsets,
+            flip_offsets: &morph.flip_offsets,
+            impulse_offsets: &morph.impulse_offsets,
+        })
+        .collect::<Vec<_>>();
+    pmx_model_non_geometry_json_from_parsed_with_morphs(
+        parsed,
+        serde_json::to_value(morphs).map_err(|error| error.to_string())?,
+    )
+}
+
+fn pmx_model_non_geometry_json_from_parsed_with_morphs(
+    parsed: &mmd_anim_format::pmx::PmxParsedModel,
+    morphs: serde_json::Value,
+) -> Result<String, String> {
     // Serialize each non-geometry field individually into a JSON object.
     // `parsed.geometry` is intentionally omitted — no geometry JSON is constructed.
     let mut obj = serde_json::Map::with_capacity(9);
@@ -55,7 +110,7 @@ fn pmx_model_non_geometry_json_from_parsed(
     sv("metadata", serde_json::to_value(&parsed.metadata))?;
     sv("materials", serde_json::to_value(&parsed.materials))?;
     sv("skeleton", serde_json::to_value(&parsed.skeleton))?;
-    sv("morphs", serde_json::to_value(&parsed.morphs))?;
+    sv("morphs", Ok(morphs))?;
     sv(
         "displayFrames",
         serde_json::to_value(&parsed.display_frames),
@@ -539,6 +594,75 @@ impl WasmPmxGeometry {
     }
 }
 
+/// Typed-array DTO for all PMX vertex morph offsets.
+///
+/// `morphSpans` stores `[start, count]` per morph. `vertexIndices` stores one
+/// vertex index per offset and `positions` stores the matching XYZ triples.
+#[wasm_bindgen]
+pub struct WasmPmxVertexMorphOffsets {
+    morph_spans: Vec<u32>,
+    vertex_indices: Vec<u32>,
+    positions: Vec<f32>,
+}
+
+impl WasmPmxVertexMorphOffsets {
+    fn from_morphs(morphs: &[mmd_anim_format::pmx::PmxParsedMorph]) -> Result<Self, String> {
+        let offset_count = morphs
+            .iter()
+            .try_fold(0usize, |total, morph| {
+                total.checked_add(morph.vertex_offsets.len())
+            })
+            .ok_or_else(|| "PMX vertex morph offset count overflow".to_owned())?;
+        if offset_count > u32::MAX as usize {
+            return Err("PMX vertex morph offset count exceeds the Wasm DTO range".to_owned());
+        }
+        let span_capacity = morphs
+            .len()
+            .checked_mul(2)
+            .ok_or_else(|| "PMX vertex morph span count overflow".to_owned())?;
+        let position_capacity = offset_count
+            .checked_mul(3)
+            .ok_or_else(|| "PMX vertex morph position count overflow".to_owned())?;
+        let mut morph_spans = Vec::with_capacity(span_capacity);
+        let mut vertex_indices = Vec::with_capacity(offset_count);
+        let mut positions = Vec::with_capacity(position_capacity);
+        for morph in morphs {
+            morph_spans.push(vertex_indices.len() as u32);
+            morph_spans.push(morph.vertex_offsets.len() as u32);
+            for offset in &morph.vertex_offsets {
+                vertex_indices.push(offset.vertex_index);
+                positions.extend_from_slice(&offset.position);
+            }
+        }
+        Ok(Self {
+            morph_spans,
+            vertex_indices,
+            positions,
+        })
+    }
+}
+
+#[wasm_bindgen]
+impl WasmPmxVertexMorphOffsets {
+    /// Copy of `[start, count]` spans for every morph.
+    #[wasm_bindgen(js_name = morphSpans)]
+    pub fn morph_spans(&self) -> Vec<u32> {
+        self.morph_spans.clone()
+    }
+
+    /// Copy of one vertex index per flattened vertex morph offset.
+    #[wasm_bindgen(js_name = vertexIndices)]
+    pub fn vertex_indices(&self) -> Vec<u32> {
+        self.vertex_indices.clone()
+    }
+
+    /// Copy of flattened XYZ position offsets.
+    #[wasm_bindgen(js_name = positions)]
+    pub fn positions(&self) -> Vec<f32> {
+        self.positions.clone()
+    }
+}
+
 /// Parsed PMX handle for the split loader ABI.
 ///
 /// Use this when both non-geometry JSON and geometry typed arrays are needed
@@ -611,6 +735,21 @@ impl WasmPmxParsedModel {
     pub fn non_geometry_json(&self) -> Result<String, JsValue> {
         pmx_model_non_geometry_json_from_parsed(&self.parsed)
             .map_err(|error| js_parser_error("PMX", "nonGeometryJson", None, error))
+    }
+
+    /// Return non-geometry JSON with vertex morph offsets replaced by empty arrays.
+    #[wasm_bindgen(js_name = nonGeometryJsonWithoutVertexOffsets)]
+    pub fn non_geometry_json_without_vertex_offsets(&self) -> Result<String, JsValue> {
+        pmx_model_non_geometry_json_without_vertex_offsets_from_parsed(&self.parsed).map_err(
+            |error| js_parser_error("PMX", "nonGeometryJsonWithoutVertexOffsets", None, error),
+        )
+    }
+
+    /// Return all vertex morph offsets through compact typed arrays.
+    #[wasm_bindgen(js_name = vertexMorphOffsets)]
+    pub fn vertex_morph_offsets(&self) -> Result<WasmPmxVertexMorphOffsets, JsValue> {
+        WasmPmxVertexMorphOffsets::from_morphs(&self.parsed.morphs)
+            .map_err(|error| js_parser_error("PMX", "vertexMorphOffsets", None, error))
     }
 
     /// Return copied geometry typed arrays for this parsed PMX model.
@@ -3442,6 +3581,33 @@ TextureFilename { "tex/main.png"; }
         .unwrap()
     }
 
+    fn vertex_morph_pmx_bytes() -> Vec<u8> {
+        export_pmx_from_parts(
+            &serde_json::json!({
+                "name": "vertex morph test",
+                "encoding": "utf-8",
+                "indexSizes": { "vertex": 1, "texture": 1, "material": 1, "bone": 1, "morph": 1, "rigidBody": 1 },
+                "morphs": [{
+                    "name": "move",
+                    "kind": "vertex",
+                    "vertexOffsets": [
+                        { "vertexIndex": 0, "position": [1.0, 2.0, 3.0] },
+                        { "vertexIndex": 2, "position": [-1.0, 0.5, 4.0] }
+                    ]
+                }]
+            })
+            .to_string(),
+            &[0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0],
+            &[0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0],
+            &[0.0, 0.0, 1.0, 0.0, 0.0, 1.0],
+            &[0, 1, 2],
+            &[],
+            &[],
+            &[],
+        )
+        .unwrap()
+    }
+
     #[test]
     fn pmx_non_geometry_json_excludes_geometry_key() {
         let pmx_bytes = minimal_pmx_bytes();
@@ -3510,6 +3676,21 @@ TextureFilename { "tex/main.png"; }
     #[test]
     fn pmx_parsed_model_handle_rejects_empty_input() {
         assert!(WasmPmxParsedModel::parse_inner(&[]).is_err());
+    }
+
+    #[test]
+    fn pmx_parsed_model_handle_splits_vertex_morph_offsets_from_json() {
+        let parsed = WasmPmxParsedModel::parse_inner(&vertex_morph_pmx_bytes()).unwrap();
+        let compact_json =
+            pmx_model_non_geometry_json_without_vertex_offsets_from_parsed(&parsed.parsed).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&compact_json).unwrap();
+        let offsets = WasmPmxVertexMorphOffsets::from_morphs(&parsed.parsed.morphs).unwrap();
+
+        assert_eq!(value["morphs"][0]["name"], "move");
+        assert_eq!(value["morphs"][0]["vertexOffsets"], serde_json::json!([]));
+        assert_eq!(offsets.morph_spans(), vec![0, 2]);
+        assert_eq!(offsets.vertex_indices(), vec![0, 2]);
+        assert_eq!(offsets.positions(), vec![1.0, 2.0, 3.0, -1.0, 0.5, 4.0]);
     }
 
     #[test]

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -74,7 +74,7 @@ Rust API、C ABI、WASM wrapper を通じて、他のホストや製品にも同
 
 ```toml
 [dependencies]
-mmd-anim = "0.3.1"
+mmd-anim = "0.3.2"
 ```
 
 ## ネイティブ (C ABI) から使う

--- a/tools/check_ffi_header_symbols.py
+++ b/tools/check_ffi_header_symbols.py
@@ -56,7 +56,7 @@ UNITY_FUNCTIONS = {
         [
             ("pose", "const_reduced_pose_ptr"),
             ("frames_per_second", "f32"),
-            ("flip_z", "bool"),
+            ("flip_z", "u8"),
             ("out_curve_count", "usize_ptr"),
         ],
     ),
@@ -65,7 +65,7 @@ UNITY_FUNCTIONS = {
         [
             ("pose", "const_reduced_pose_ptr"),
             ("frames_per_second", "f32"),
-            ("flip_z", "bool"),
+            ("flip_z", "u8"),
             ("curve_index", "usize"),
             ("out_descriptor", "unity_descriptor_ptr"),
         ],
@@ -75,7 +75,7 @@ UNITY_FUNCTIONS = {
         [
             ("pose", "const_reduced_pose_ptr"),
             ("frames_per_second", "f32"),
-            ("flip_z", "bool"),
+            ("flip_z", "u8"),
             ("curve_index", "usize"),
             ("out_keys", "unity_key_ptr"),
             ("out_key_capacity", "usize"),
@@ -143,6 +143,7 @@ def strip_c_comments(text: str) -> str:
 def canonical_rust_type(type_name: str) -> str:
     compact = " ".join(type_name.split())
     return {
+        "u8": "u8",
         "u32": "u32",
         "usize": "usize",
         "f32": "f32",
@@ -162,6 +163,7 @@ def canonical_rust_type(type_name: str) -> str:
 def canonical_c_type(type_name: str) -> str:
     compact = re.sub(r"\s*\*\s*", "*", " ".join(type_name.split()))
     return {
+        "uint8_t": "u8",
         "uint32_t": "u32",
         "size_t": "usize",
         "float": "f32",

--- a/tools/check_ffi_header_symbols.py
+++ b/tools/check_ffi_header_symbols.py
@@ -84,6 +84,104 @@ UNITY_FUNCTIONS = {
     ),
 }
 
+GENERIC_CONSTANTS = {
+    "MMD_RUNTIME_REDUCED_POSE_GENERIC_CURVE_ABI_VERSION_V1": 1,
+    "MMD_RUNTIME_GENERIC_CURVE_BONE_LOCAL": 0,
+    "MMD_RUNTIME_GENERIC_CURVE_MORPH_WEIGHT": 1,
+    "MMD_RUNTIME_GENERIC_COORDINATE_MMD_RUNTIME_NATIVE": 0,
+    "MMD_RUNTIME_GENERIC_LENGTH_MODEL_UNITS": 0,
+    "MMD_RUNTIME_GENERIC_ANGLE_RADIANS": 0,
+    "MMD_RUNTIME_GENERIC_TIME_SAMPLE_FRAMES": 0,
+    "MMD_RUNTIME_GENERIC_TANGENT_VALUE_PER_SAMPLE_FRAME": 0,
+    "MMD_RUNTIME_GENERIC_ROTATION_BASIS_NONE": 0,
+    "MMD_RUNTIME_GENERIC_ROTATION_BASIS_RUNTIME_QUATERNION": 1,
+    "MMD_RUNTIME_GENERIC_ROTATION_BASIS_EULER_XYZ_RADIANS_PER_FRAME": 2,
+}
+
+GENERIC_STRUCTS = {
+    "MmdRuntimeFfiGenericCurveInfo": (
+        "mmd_runtime_ffi_generic_curve_info_t",
+        [
+            ("struct_size", "u32"),
+            ("abi_version", "u32"),
+            ("reduction_target", "u32"),
+            ("coordinate_system", "u32"),
+            ("length_unit", "u32"),
+            ("angle_unit", "u32"),
+            ("time_unit", "u32"),
+            ("tangent_unit", "u32"),
+            ("model_identity", "u64"),
+            ("start_frame", "f32"),
+            ("frame_step", "f32"),
+            ("frame_count", "usize"),
+            ("bone_count", "usize"),
+            ("morph_count", "usize"),
+        ],
+    ),
+    "MmdRuntimeFfiGenericCurveDescriptor": (
+        "mmd_runtime_ffi_generic_curve_descriptor_t",
+        [
+            ("struct_size", "u32"),
+            ("abi_version", "u32"),
+            ("kind", "u32"),
+            ("target_index", "u32"),
+            ("parent_index", "i32"),
+            ("value_flags", "u32"),
+            ("interpolation", "u32"),
+            ("rotation_basis", "u32"),
+            ("key_count", "usize"),
+        ],
+    ),
+    "MmdRuntimeFfiGenericCurveKey": (
+        "mmd_runtime_ffi_generic_curve_key_t",
+        [
+            ("sample_index", "usize"),
+            ("frame", "f32"),
+            ("translation_xyz", "f32[3]"),
+            ("rotation_xyzw", "f32[4]"),
+            ("scalar", "f32"),
+            ("segment_prev_out_translation_xyz", "f32[3]"),
+            ("segment_current_in_translation_xyz", "f32[3]"),
+            ("segment_from_previous_start_euler_xyz", "f32[3]"),
+            ("segment_from_previous_end_euler_xyz", "f32[3]"),
+            ("segment_prev_out_rotation_xyz", "f32[3]"),
+            ("segment_current_in_rotation_xyz", "f32[3]"),
+            ("segment_prev_out_scalar", "f32"),
+            ("segment_current_in_scalar", "f32"),
+        ],
+    ),
+}
+
+GENERIC_FUNCTIONS = {
+    "mmd_runtime_reduced_pose_generic_curve_info": (
+        "status",
+        [("pose", "const_reduced_pose_ptr"), ("out_info", "generic_info_ptr")],
+    ),
+    "mmd_runtime_reduced_pose_generic_curve_count": (
+        "status",
+        [("pose", "const_reduced_pose_ptr"), ("out_curve_count", "usize_ptr")],
+    ),
+    "mmd_runtime_reduced_pose_generic_curve_descriptor": (
+        "status",
+        [
+            ("pose", "const_reduced_pose_ptr"),
+            ("curve_index", "usize"),
+            ("out_descriptor", "generic_descriptor_ptr"),
+        ],
+    ),
+    "mmd_runtime_reduced_pose_generic_curve_keys": (
+        "status",
+        [
+            ("pose", "const_reduced_pose_ptr"),
+            ("curve_index", "usize"),
+            ("out_keys", "generic_key_ptr"),
+            ("out_key_capacity", "usize"),
+            ("key_stride_bytes", "usize"),
+            ("out_required_count", "usize_ptr"),
+        ],
+    ),
+}
+
 PHYSICS_PARAM_FUNCTIONS = {
     "mmd_runtime_physics_params_get_json": (
         "ffi_byte_buffer",
@@ -142,9 +240,14 @@ def strip_c_comments(text: str) -> str:
 
 def canonical_rust_type(type_name: str) -> str:
     compact = " ".join(type_name.split())
+    array_match = re.fullmatch(r"\[f32;\s*(\d+)\]", compact)
+    if array_match:
+        return f"f32[{array_match.group(1)}]"
     return {
         "u8": "u8",
         "u32": "u32",
+        "u64": "u64",
+        "i32": "i32",
         "usize": "usize",
         "f32": "f32",
         "bool": "bool",
@@ -157,6 +260,9 @@ def canonical_rust_type(type_name: str) -> str:
         "*mut usize": "usize_ptr",
         "*mut MmdRuntimeFfiUnityCurveDescriptor": "unity_descriptor_ptr",
         "*mut MmdRuntimeFfiUnityCurveKey": "unity_key_ptr",
+        "*mut MmdRuntimeFfiGenericCurveInfo": "generic_info_ptr",
+        "*mut MmdRuntimeFfiGenericCurveDescriptor": "generic_descriptor_ptr",
+        "*mut MmdRuntimeFfiGenericCurveKey": "generic_key_ptr",
     }.get(compact, compact)
 
 
@@ -165,6 +271,8 @@ def canonical_c_type(type_name: str) -> str:
     return {
         "uint8_t": "u8",
         "uint32_t": "u32",
+        "uint64_t": "u64",
+        "int32_t": "i32",
         "size_t": "usize",
         "float": "f32",
         "bool": "bool",
@@ -177,6 +285,9 @@ def canonical_c_type(type_name: str) -> str:
         "size_t*": "usize_ptr",
         "mmd_runtime_ffi_unity_curve_descriptor_t*": "unity_descriptor_ptr",
         "mmd_runtime_ffi_unity_curve_key_t*": "unity_key_ptr",
+        "mmd_runtime_ffi_generic_curve_info_t*": "generic_info_ptr",
+        "mmd_runtime_ffi_generic_curve_descriptor_t*": "generic_descriptor_ptr",
+        "mmd_runtime_ffi_generic_curve_key_t*": "generic_key_ptr",
     }.get(compact, compact)
 
 
@@ -205,10 +316,13 @@ def c_struct_fields(text: str, alias: str) -> list[tuple[str, str]]:
         declaration = declaration.strip()
         if not declaration:
             continue
-        field_match = re.fullmatch(r"(.+?)\s+(\w+)", declaration)
+        field_match = re.fullmatch(r"(.+?)\s+(\w+)(?:\[(\d+)\])?", declaration)
         if field_match is None:
             raise ValueError(f"could not parse C field in {alias}: {declaration!r}")
-        fields.append((field_match.group(2), canonical_c_type(field_match.group(1))))
+        field_type = canonical_c_type(field_match.group(1))
+        if field_match.group(3):
+            field_type = f"{field_type}[{field_match.group(3)}]"
+        fields.append((field_match.group(2), field_type))
     return fields
 
 
@@ -244,7 +358,7 @@ def c_function_shape(text: str, name: str) -> tuple[str, list[tuple[str, str]]]:
     return canonical_c_type(match.group(1)), params
 
 
-def check_unity_abi_shapes(rust_text: str, header_text: str) -> list[str]:
+def check_abi_shapes(rust_text: str, header_text: str) -> list[str]:
     errors: list[str] = []
     for name, expected in UNITY_CONSTANTS.items():
         rust_match = re.search(rf"pub const {name}: u32 = (\d+);", rust_text)
@@ -263,6 +377,29 @@ def check_unity_abi_shapes(rust_text: str, header_text: str) -> list[str]:
                 f"struct {rust_name}/{c_alias}: Rust={rust_fields}, header={c_fields}, expected={expected}"
             )
     for name, expected in UNITY_FUNCTIONS.items():
+        rust_shape = rust_function_shape(rust_text, name)
+        c_shape = c_function_shape(header_text, name)
+        if rust_shape != expected or c_shape != expected or rust_shape != c_shape:
+            errors.append(
+                f"function {name}: Rust={rust_shape}, header={c_shape}, expected={expected}"
+            )
+    for name, expected in GENERIC_CONSTANTS.items():
+        rust_match = re.search(rf"pub const {name}: u32 = (\d+);", rust_text)
+        header_match = re.search(rf"\b{name}(?:\s+|\s*=\s*)(\d+)(?:u)?\b", header_text)
+        rust_value = int(rust_match.group(1)) if rust_match else None
+        header_value = int(header_match.group(1)) if header_match else None
+        if rust_value != expected or header_value != expected or rust_value != header_value:
+            errors.append(
+                f"constant {name}: Rust={rust_value}, header={header_value}, expected={expected}"
+            )
+    for rust_name, (c_alias, expected) in GENERIC_STRUCTS.items():
+        rust_fields = rust_struct_fields(rust_text, rust_name)
+        c_fields = c_struct_fields(header_text, c_alias)
+        if rust_fields != expected or c_fields != expected or rust_fields != c_fields:
+            errors.append(
+                f"struct {rust_name}/{c_alias}: Rust={rust_fields}, header={c_fields}, expected={expected}"
+            )
+    for name, expected in GENERIC_FUNCTIONS.items():
         rust_shape = rust_function_shape(rust_text, name)
         c_shape = c_function_shape(header_text, name)
         if rust_shape != expected or c_shape != expected or rust_shape != c_shape:
@@ -290,7 +427,7 @@ def main() -> int:
     missing_in_rust = sorted(header_symbols - rust_symbols)
     forbidden_in_rust = sorted(FORBIDDEN_DENSE_REDUCED_POSE_SYMBOLS & rust_symbols)
     forbidden_in_header = sorted(FORBIDDEN_DENSE_REDUCED_POSE_SYMBOLS & header_symbols)
-    shape_errors = check_unity_abi_shapes(rust_text, header_text)
+    shape_errors = check_abi_shapes(rust_text, header_text)
 
     if missing_in_header or missing_in_rust or forbidden_in_rust or forbidden_in_header or shape_errors:
         print("FFI header symbol mismatch detected.", file=sys.stderr)
@@ -307,7 +444,7 @@ def main() -> int:
             for symbol in sorted(set(forbidden_in_rust + forbidden_in_header)):
                 print(f"  - {symbol}", file=sys.stderr)
         if shape_errors:
-            print("\nUnity reduced-curve ABI shape drift:", file=sys.stderr)
+            print("\nTracked reduced-curve ABI shape drift:", file=sys.stderr)
             for error in shape_errors:
                 print(f"  - {error}", file=sys.stderr)
         return 1


### PR DESCRIPTION
## Summary

Prepare mmd-anim v0.3.2 from the changes since v0.3.1.

## What changed

- add runtime-neutral caller-owned C ABI enumeration for DCC cubic reduced bone and morph tracks
- split WASM vertex morph offsets from the non-geometry JSON payload through typed accessors
- preserve PMX morph panels across parse/export, JSON compatibility, FBX material split, and parts workflows
- reject invalid PMX parts morph panel labels instead of silently coercing them to `other`
- harden experimental C ABI boolean, pointer-range, aliasing, struct-size, stride, alignment, overflow, and output-buffer contracts
- enable the existing IK convergence break with the default `1e-4` tolerance
- bump workspace packages, README examples, Python version note, and CHANGELOG to 0.3.2
- remove the unreleased PMX profiling API and `web-time` dependency before publication

## Review

A full `origin/main..HEAD` Codex review found one actionable P2: invalid parts morph panel labels were silently serialized as `other`. Commit `eeee27b` adds fail-fast validation and a regression test. A focused follow-up review identified duplicated panel mapping; the fix now shares one checked mapping with serialization. No review findings remain open.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace` — 845 passed, 3 ignored
- `cargo doc --workspace --no-deps`
- `cargo check -p mmd-anim-wasm --target wasm32-unknown-unknown`
- `cargo build -p mmd-anim-ffi --release`
- `python tools/check_python_ffi_release.py` under the Visual Studio x64 developer environment — C static assertions plus 50 native Python tests passed
- `cargo check -p mmd-anim-physics-bullet --no-default-features`
- `cargo test -p mmd-anim-cli -p mmd-anim-ffi --no-default-features` — 252 passed, 1 ignored
- WASM harness `npm run build`
- package-content audit for `mmd-anim-runtime`, `mmd-anim-format`, `mmd-anim-physics-bullet`, `mmd-anim`, and `mmd-anim-cli`
- `cargo publish -p mmd-anim-runtime --dry-run`

## Release boundary

This draft PR is the release-preparation checkpoint. Merge, tag creation, GitHub Release creation, and crates.io publication are intentionally not performed here.