### PR TITLE
Expose compiled AnimationClip bone tracks over C ABI

### DIFF
--- a/crates/mmd-anim-ffi/include/mmd_runtime.h
+++ b/crates/mmd-anim-ffi/include/mmd_runtime.h
@@ -32,10 +32,12 @@ extern "C" {
    performed natively. Hosts that pre-apply Morph bone deltas must stop doing
    so before using that contract; bit 4
    (MMD_RUNTIME_FEATURE_REDUCED_POSE_GENERIC_CURVES) is set when runtime-neutral
-   reduced-pose sparse tracks are available.
-   Check the relevant bit before calling any
-   physics_world_* or evaluate_host_frame function; when the bit is unset
-   those functions return MMD_RUNTIME_STATUS_UNSUPPORTED.
+   reduced-pose sparse tracks are available; bit 5
+   (MMD_RUNTIME_FEATURE_CLIP_BONE_TRACK_INTROSPECTION) is set when compiled
+   authored local bone-track introspection is available.
+   Check the relevant bit before calling each optional surface; when a
+   surface's bit is unset, its status-returning functions return
+   MMD_RUNTIME_STATUS_UNSUPPORTED (and optional count functions return zero).
 
    Handle ownership
    ----------------
@@ -122,7 +124,11 @@ typedef struct mmd_runtime_reduced_pose_t mmd_runtime_reduced_pose_t;
 #define MMD_RUNTIME_FEATURE_MODEL_DESCRIPTOR         (1u << 2)
 #define MMD_RUNTIME_FEATURE_HOST_POSE_NATIVE_MORPHS  (1u << 3)
 #define MMD_RUNTIME_FEATURE_REDUCED_POSE_GENERIC_CURVES (1u << 4)
+#define MMD_RUNTIME_FEATURE_CLIP_BONE_TRACK_INTROSPECTION (1u << 5)
 #define MMD_RUNTIME_REDUCED_POSE_GENERIC_CURVE_ABI_VERSION_V1 1u
+#define MMD_RUNTIME_CLIP_BONE_TRACK_INTROSPECTION_ABI_VERSION_V1 1u
+#define MMD_RUNTIME_BONE_TRACK_CURVE_NONE 0u
+#define MMD_RUNTIME_BONE_TRACK_CURVE_CUBIC_BEZIER 1u
 #define MMD_RUNTIME_MODEL_DESCRIPTOR_VERSION_V1      1u
 #define MMD_RUNTIME_MODEL_DESCRIPTOR_FLAGS_NONE     0u
 
@@ -284,6 +290,41 @@ typedef struct mmd_runtime_ffi_bone_keyframe {
     float    position_xyz[3];
     float    rotation_xyzw[4];
 } mmd_runtime_ffi_bone_keyframe_t;
+
+/* Compiled/authored local clip introspection (fixed v1 layouts selected by
+   MMD_RUNTIME_CLIP_BONE_TRACK_INTROSPECTION_ABI_VERSION_V1).  A future
+   incompatible layout must use a new ABI/schema version or symbol.
+   Curve controls are normalized
+   cubic Bezier coordinates.  NONE has zero controls and means that the key
+   has no incoming segment; a later key's curves describe the segment from
+   the previous key to that key. */
+typedef struct mmd_runtime_ffi_bone_track_curve {
+    uint32_t kind;
+    float    x1;
+    float    y1;
+    float    x2;
+    float    y2;
+} mmd_runtime_ffi_bone_track_curve_t;
+
+typedef struct mmd_runtime_ffi_bone_track_descriptor {
+    uint32_t bone_index;
+    size_t   key_count;
+} mmd_runtime_ffi_bone_track_descriptor_t;
+
+/* Values are compiled/authored local translation/quaternion data and retain
+   transformations made by the clip construction path.  Registered VMD clips
+   include name resolution, fixed-axis projection, and registered
+   interpolation selection.  Values are not Append/IK-evaluated world poses. */
+typedef struct mmd_runtime_ffi_bone_track_key {
+    uint32_t bone_index;
+    uint32_t frame;
+    float    position_xyz[3];
+    float    rotation_xyzw[4];
+    mmd_runtime_ffi_bone_track_curve_t translation_x;
+    mmd_runtime_ffi_bone_track_curve_t translation_y;
+    mmd_runtime_ffi_bone_track_curve_t translation_z;
+    mmd_runtime_ffi_bone_track_curve_t rotation;
+} mmd_runtime_ffi_bone_track_key_t;
 
 typedef struct mmd_runtime_ffi_morph_track {
     uint32_t morph_index;
@@ -1492,6 +1533,34 @@ mmd_runtime_clip_t* mmd_runtime_clip_create(
     size_t                                  property_keyframe_count,
     const uint8_t*                          property_ik_enabled,
     size_t                                  property_ik_enabled_count);
+
+/* Read-only introspection of compiled/authored local bone tracks.  This is
+   valid for VMD-, PMM-, and programmatically-built AnimationClip data and
+   retains transformations made by the applicable construction path.  It does
+   not expose raw VMD bytes or solved Append/IK world poses. */
+size_t mmd_runtime_clip_bone_track_count(
+    const mmd_runtime_clip_t* clip);
+
+/* out_descriptor must not overlap the opaque clip handle. */
+mmd_runtime_status_t mmd_runtime_clip_bone_track_descriptor(
+    const mmd_runtime_clip_t*                         clip,
+    size_t                                            track_index,
+    mmd_runtime_ffi_bone_track_descriptor_t*          out_descriptor);
+size_t mmd_runtime_clip_bone_track_key_count(
+    const mmd_runtime_clip_t* clip,
+    size_t                        track_index);
+
+/* Output storage must not overlap the opaque clip handle, and out_keys must
+   not overlap out_written.  Copies all keys when out_key_capacity is
+   sufficient.  out_written is zero on every failure after all output storage
+   has been validated, including BUFFER_TOO_SMALL; short buffers are never
+   partially written. */
+mmd_runtime_status_t mmd_runtime_clip_copy_bone_track_keys(
+    const mmd_runtime_clip_t*              clip,
+    size_t                                  track_index,
+    mmd_runtime_ffi_bone_track_key_t*      out_keys,
+    size_t                                  out_key_capacity,
+    size_t*                                out_written);
 
 bool mmd_runtime_clip_frame_range(
     const mmd_runtime_clip_t* clip,

--- a/crates/mmd-anim-ffi/scripts/smoke.ps1
+++ b/crates/mmd-anim-ffi/scripts/smoke.ps1
@@ -85,6 +85,10 @@ $expectedExports = @(
     "mmd_runtime_instance_ik_enabled"
     "mmd_runtime_clip_create"
     "mmd_runtime_clip_create_from_vmd_bytes_for_model"
+    "mmd_runtime_clip_bone_track_count"
+    "mmd_runtime_clip_bone_track_descriptor"
+    "mmd_runtime_clip_bone_track_key_count"
+    "mmd_runtime_clip_copy_bone_track_keys"
     "mmd_runtime_clip_frame_range"
     "mmd_runtime_clip_free"
     "mmd_runtime_reduced_pose_create_from_dense"
@@ -92,9 +96,10 @@ $expectedExports = @(
     "mmd_runtime_reduced_pose_bone_count"
     "mmd_runtime_reduced_pose_morph_count"
     "mmd_runtime_reduced_pose_report"
-    "mmd_runtime_reduced_pose_unity_curve_count"
-    "mmd_runtime_reduced_pose_unity_curve_descriptor"
-    "mmd_runtime_reduced_pose_unity_curve_keys"
+    "mmd_runtime_reduced_pose_generic_curve_info"
+    "mmd_runtime_reduced_pose_generic_curve_count"
+    "mmd_runtime_reduced_pose_generic_curve_descriptor"
+    "mmd_runtime_reduced_pose_generic_curve_keys"
 )
 
 # Check each expected export name appears in the header

--- a/crates/mmd-anim-ffi/src/lib.rs
+++ b/crates/mmd-anim-ffi/src/lib.rs
@@ -17,14 +17,14 @@ use mmd_anim_runtime::{
     AnimationClip, AppendPrimitiveInput, BoneAnimationBinding, BoneIndex, DensePoseSequenceView,
     FlatAppendTransformInput, FlatBoneInput, FlatBoneMorphInput, FlatGroupMorphInput,
     FlatIkLinkInput, FlatIkSolverInput, HostPoseView, IkAngleLimit, IkChainDefinition,
-    IkChainLinkDefinition, IkChainPoseInput, IkChainSolver, IkSolveOptions, LocalAxis,
-    MorphAnimationBinding, MorphIndex, MorphInit, MorphKeyframe, MorphTrack, MovableBoneKeyframe,
-    MovableBoneTrack, PhysicsMode, PhysicsStepStats, PhysicsTickConfig, PoseReductionReport,
-    PropertyAnimationBinding, PropertyKeyframe, ReducedPoseSequence, ReductionTarget,
-    ReductionTolerances, RuntimeAppendTransformDescriptorV1, RuntimeBoneDescriptorV1,
-    RuntimeBoneMorphOffsetDescriptorV1, RuntimeGroupMorphOffsetDescriptorV1,
-    RuntimeIkLinkDescriptorV1, RuntimeIkSolverDescriptorV1, RuntimeInstance,
-    RuntimeModelDescriptorV1, RuntimeMorphDescriptorV1, SkeletonSnapshot,
+    IkChainLinkDefinition, IkChainPoseInput, IkChainSolver, IkSolveOptions, InterpolationScalar,
+    LocalAxis, MorphAnimationBinding, MorphIndex, MorphInit, MorphKeyframe, MorphTrack,
+    MovableBoneKeyframe, MovableBoneTrack, PhysicsMode, PhysicsStepStats, PhysicsTickConfig,
+    PoseReductionReport, PropertyAnimationBinding, PropertyKeyframe, ReducedPoseSequence,
+    ReductionTarget, ReductionTolerances, RuntimeAppendTransformDescriptorV1,
+    RuntimeBoneDescriptorV1, RuntimeBoneMorphOffsetDescriptorV1,
+    RuntimeGroupMorphOffsetDescriptorV1, RuntimeIkLinkDescriptorV1, RuntimeIkSolverDescriptorV1,
+    RuntimeInstance, RuntimeModelDescriptorV1, RuntimeMorphDescriptorV1, SkeletonSnapshot,
     build_append_transforms_from_flat_iter, build_bones_from_flat, build_ik_solvers_from_flat_iter,
     build_morph_init_from_flat_iter, compile_runtime_model_descriptor_v1, solve_append_transform,
 };
@@ -35,7 +35,11 @@ const FEATURE_PHYSICS_BULLET_NATIVE: u32 = 1 << 1;
 pub const MMD_RUNTIME_FEATURE_MODEL_DESCRIPTOR: u32 = 1 << 2;
 pub const MMD_RUNTIME_FEATURE_HOST_POSE_NATIVE_MORPHS: u32 = 1 << 3;
 pub const MMD_RUNTIME_FEATURE_REDUCED_POSE_GENERIC_CURVES: u32 = 1 << 4;
+pub const MMD_RUNTIME_FEATURE_CLIP_BONE_TRACK_INTROSPECTION: u32 = 1 << 5;
 pub const MMD_RUNTIME_REDUCED_POSE_GENERIC_CURVE_ABI_VERSION_V1: u32 = 1;
+pub const MMD_RUNTIME_CLIP_BONE_TRACK_INTROSPECTION_ABI_VERSION_V1: u32 = 1;
+pub const MMD_RUNTIME_BONE_TRACK_CURVE_NONE: u32 = 0;
+pub const MMD_RUNTIME_BONE_TRACK_CURVE_CUBIC_BEZIER: u32 = 1;
 pub const MMD_RUNTIME_REDUCTION_TARGET_DCC_CUBIC: u32 = 2;
 pub const MMD_RUNTIME_MODEL_DESCRIPTOR_VERSION_V1: u32 =
     mmd_anim_runtime::RUNTIME_MODEL_DESCRIPTOR_VERSION_V1;
@@ -43,6 +47,8 @@ pub const MMD_RUNTIME_MODEL_DESCRIPTOR_FLAGS_NONE: u32 = 0;
 const FEATURE_MODEL_DESCRIPTOR: u32 = MMD_RUNTIME_FEATURE_MODEL_DESCRIPTOR;
 const FEATURE_HOST_POSE_NATIVE_MORPHS: u32 = MMD_RUNTIME_FEATURE_HOST_POSE_NATIVE_MORPHS;
 const FEATURE_REDUCED_POSE_GENERIC_CURVES: u32 = MMD_RUNTIME_FEATURE_REDUCED_POSE_GENERIC_CURVES;
+const FEATURE_CLIP_BONE_TRACK_INTROSPECTION: u32 =
+    MMD_RUNTIME_FEATURE_CLIP_BONE_TRACK_INTROSPECTION;
 
 pub struct MmdRuntimeModel {
     model: Arc<ModelArena>,
@@ -250,6 +256,51 @@ pub struct MmdRuntimeFfiBoneKeyframe {
     pub frame: u32,
     pub position_xyz: [f32; 3],
     pub rotation_xyzw: [f32; 4],
+}
+
+/// Semantic interpolation metadata for one authored local bone channel.
+///
+/// `kind` is a raw integer so unknown future kinds remain ABI-safe to inspect.
+/// For the v1 kinds, the four controls are normalized to `[0, 1]` cubic
+/// Bezier coordinates. `MMD_RUNTIME_BONE_TRACK_CURVE_NONE` is represented by
+/// zero controls and denotes that the key has no incoming segment.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct MmdRuntimeFfiBoneTrackCurve {
+    pub kind: u32,
+    pub x1: f32,
+    pub y1: f32,
+    pub x2: f32,
+    pub y2: f32,
+}
+
+/// Descriptor for one authored local bone track in clip order.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct MmdRuntimeFfiBoneTrackDescriptor {
+    pub bone_index: u32,
+    pub key_count: usize,
+}
+
+/// One authored local bone key and its semantic incoming-segment curves.
+///
+/// This is compiled/authored local clip data and retains transformations made
+/// by the clip's construction path. Registered VMD clips therefore include
+/// name resolution, fixed-axis projection, and registered interpolation
+/// selection. It is not an Append/IK-evaluated world pose. For key `i > 0`,
+/// each curve stored on the key describes the segment from key `i - 1` to key
+/// `i`; the first key uses `NONE` curves.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct MmdRuntimeFfiBoneTrackKey {
+    pub bone_index: u32,
+    pub frame: u32,
+    pub position_xyz: [f32; 3],
+    pub rotation_xyzw: [f32; 4],
+    pub translation_x: MmdRuntimeFfiBoneTrackCurve,
+    pub translation_y: MmdRuntimeFfiBoneTrackCurve,
+    pub translation_z: MmdRuntimeFfiBoneTrackCurve,
+    pub rotation: MmdRuntimeFfiBoneTrackCurve,
 }
 
 #[repr(C)]
@@ -852,6 +903,7 @@ fn runtime_feature_flags() -> u32 {
         | FEATURE_MODEL_DESCRIPTOR
         | FEATURE_HOST_POSE_NATIVE_MORPHS
         | FEATURE_REDUCED_POSE_GENERIC_CURVES
+        | FEATURE_CLIP_BONE_TRACK_INTROSPECTION
         | if cfg!(feature = "physics-bullet-native") {
             FEATURE_PHYSICS_BULLET_NATIVE
         } else {
@@ -7223,6 +7275,269 @@ pub unsafe extern "C" fn mmd_runtime_clip_frame_range(
             *out_last_frame = last;
         }
         true
+    })
+}
+
+fn bone_track_curve(
+    interpolation: InterpolationScalar,
+    has_incoming_segment: bool,
+) -> MmdRuntimeFfiBoneTrackCurve {
+    if !has_incoming_segment {
+        return MmdRuntimeFfiBoneTrackCurve::default();
+    }
+    const SCALE: f32 = 1.0 / 127.0;
+    MmdRuntimeFfiBoneTrackCurve {
+        kind: MMD_RUNTIME_BONE_TRACK_CURVE_CUBIC_BEZIER,
+        x1: interpolation.x1 as f32 * SCALE,
+        y1: interpolation.y1 as f32 * SCALE,
+        x2: interpolation.x2 as f32 * SCALE,
+        y2: interpolation.y2 as f32 * SCALE,
+    }
+}
+
+fn bone_track_key(
+    bone_index: BoneIndex,
+    track: &MovableBoneTrack,
+    key_index: usize,
+) -> Result<MmdRuntimeFfiBoneTrackKey, MmdRuntimeStatus> {
+    let key = track.keyframe(key_index).ok_or_else(|| {
+        status_failure(
+            MmdRuntimeStatus::Error,
+            "bone track key index does not match the track",
+        )
+    })?;
+    let scalar_is_normalized = |interpolation: InterpolationScalar| {
+        interpolation.x1 <= 127
+            && interpolation.y1 <= 127
+            && interpolation.x2 <= 127
+            && interpolation.y2 <= 127
+    };
+    if key_index > 0
+        && (!scalar_is_normalized(key.position_interpolation.x)
+            || !scalar_is_normalized(key.position_interpolation.y)
+            || !scalar_is_normalized(key.position_interpolation.z)
+            || !scalar_is_normalized(key.rotation_interpolation))
+    {
+        return Err(status_failure(
+            MmdRuntimeStatus::InvalidInput,
+            "bone track interpolation control is outside the normalized VMD range",
+        ));
+    }
+    let rotation = key.rotation.normalize();
+    let result = MmdRuntimeFfiBoneTrackKey {
+        bone_index: bone_index.0,
+        frame: key.frame,
+        position_xyz: key.position.to_array(),
+        rotation_xyzw: rotation.to_array(),
+        translation_x: bone_track_curve(key.position_interpolation.x, key_index > 0),
+        translation_y: bone_track_curve(key.position_interpolation.y, key_index > 0),
+        translation_z: bone_track_curve(key.position_interpolation.z, key_index > 0),
+        rotation: bone_track_curve(key.rotation_interpolation, key_index > 0),
+    };
+    if !result.position_xyz.iter().all(|value| value.is_finite())
+        || !result.rotation_xyzw.iter().all(|value| value.is_finite())
+        || result
+            .rotation_xyzw
+            .iter()
+            .map(|value| value * value)
+            .sum::<f32>()
+            < 0.999_9
+        || result
+            .rotation_xyzw
+            .iter()
+            .map(|value| value * value)
+            .sum::<f32>()
+            > 1.000_1
+    {
+        return Err(status_failure(
+            MmdRuntimeStatus::InvalidInput,
+            "bone track key contains a non-finite or non-normalized value",
+        ));
+    }
+    Ok(result)
+}
+
+/// Returns the number of authored local bone tracks, or zero for a null clip.
+///
+/// Tracks are enumerated in the clip's authored binding order. This metadata
+/// retains transformations made by the clip's construction path; registered
+/// VMD clips include name resolution, fixed-axis projection, and registered
+/// interpolation selection. It is not a solved world pose.
+///
+/// # Safety
+///
+/// `clip` must be null or a live handle returned by a clip creation function.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn mmd_runtime_clip_bone_track_count(clip: *const MmdRuntimeClip) -> usize {
+    ffi_guard(0, || {
+        unsafe { clip.as_ref() }
+            .map(|clip| clip.clip.bone_track_count())
+            .unwrap_or(0)
+    })
+}
+
+/// Copies one authored local bone-track descriptor.
+///
+/// # Safety
+///
+/// `clip` must be null or a live clip handle. `out_descriptor` must point to
+/// writable, naturally aligned storage for one descriptor and must not overlap
+/// the opaque clip handle.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn mmd_runtime_clip_bone_track_descriptor(
+    clip: *const MmdRuntimeClip,
+    track_index: usize,
+    out_descriptor: *mut MmdRuntimeFfiBoneTrackDescriptor,
+) -> MmdRuntimeStatus {
+    ffi_guard(MmdRuntimeStatus::Error, || {
+        let Some(descriptor_range) = checked_pointer_range(out_descriptor, 1) else {
+            return status_failure(MmdRuntimeStatus::InvalidInput, FFI_ERR_INVALID_INPUT);
+        };
+        if !clip.is_null() {
+            let Some(range) = checked_pointer_range(clip, 1) else {
+                return status_failure(MmdRuntimeStatus::InvalidInput, FFI_ERR_INVALID_INPUT);
+            };
+            if pointer_ranges_overlap(descriptor_range, range) {
+                return status_failure(
+                    MmdRuntimeStatus::InvalidInput,
+                    "descriptor output must not alias the clip handle",
+                );
+            }
+        }
+        unsafe { ptr::write(out_descriptor, MmdRuntimeFfiBoneTrackDescriptor::default()) };
+        let Some(clip) = (unsafe { clip.as_ref() }) else {
+            return status_failure(MmdRuntimeStatus::InvalidInput, FFI_ERR_INVALID_INPUT);
+        };
+        let Some(binding) = clip.clip.bone_track(track_index) else {
+            return status_failure(
+                MmdRuntimeStatus::InvalidInput,
+                "bone track index out of range",
+            );
+        };
+        let descriptor = MmdRuntimeFfiBoneTrackDescriptor {
+            bone_index: binding.bone.0,
+            key_count: binding.track.keyframe_count(),
+        };
+        unsafe { ptr::write(out_descriptor, descriptor) };
+        MmdRuntimeStatus::Ok
+    })
+}
+
+/// Returns one authored local bone track's key count, or zero for null or an
+/// out-of-range track index.
+///
+/// # Safety
+///
+/// `clip` must be null or a live handle returned by a clip creation function.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn mmd_runtime_clip_bone_track_key_count(
+    clip: *const MmdRuntimeClip,
+    track_index: usize,
+) -> usize {
+    ffi_guard(0, || {
+        unsafe { clip.as_ref() }
+            .and_then(|clip| clip.clip.bone_track(track_index))
+            .map(|binding| binding.track.keyframe_count())
+            .unwrap_or(0)
+    })
+}
+
+/// Copies all keys from one authored local bone track into caller-owned
+/// contiguous storage. The first key has `NONE` curves with zero controls.
+/// For every later key, each curve describes the segment from the previous key
+/// to that key. After all output storage has been validated, `out_written` is
+/// set to zero before semantic validation and remains zero for every later
+/// failure; short buffers are never partially written.
+///
+/// # Safety
+///
+/// `clip` must be null or a live clip handle. `out_written` must point to one
+/// writable, naturally aligned `size_t`. When the track is non-empty,
+/// `out_keys` must be writable and naturally aligned for at least
+/// `out_key_capacity` keys. Neither output may overlap the opaque clip handle,
+/// and the output buffer must not overlap `out_written`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn mmd_runtime_clip_copy_bone_track_keys(
+    clip: *const MmdRuntimeClip,
+    track_index: usize,
+    out_keys: *mut MmdRuntimeFfiBoneTrackKey,
+    out_key_capacity: usize,
+    out_written: *mut usize,
+) -> MmdRuntimeStatus {
+    ffi_guard(MmdRuntimeStatus::Error, || {
+        let Some(count_range) = checked_pointer_range(out_written, 1) else {
+            return status_failure(MmdRuntimeStatus::InvalidInput, FFI_ERR_INVALID_INPUT);
+        };
+        let clip_range = if clip.is_null() {
+            None
+        } else {
+            let Some(range) = checked_pointer_range(clip, 1) else {
+                return status_failure(MmdRuntimeStatus::InvalidInput, FFI_ERR_INVALID_INPUT);
+            };
+            if pointer_ranges_overlap(count_range, range) {
+                return status_failure(
+                    MmdRuntimeStatus::InvalidInput,
+                    "out_written must not alias the clip handle",
+                );
+            }
+            Some(range)
+        };
+        let Some(output_range) = checked_pointer_range(out_keys, out_key_capacity) else {
+            return status_failure(MmdRuntimeStatus::InvalidInput, "invalid key buffer");
+        };
+        if pointer_ranges_overlap(output_range, count_range) {
+            return status_failure(
+                MmdRuntimeStatus::InvalidInput,
+                "key buffer must not alias out_written",
+            );
+        }
+        if clip_range.is_some_and(|range| pointer_ranges_overlap(output_range, range)) {
+            return status_failure(
+                MmdRuntimeStatus::InvalidInput,
+                "key buffer must not alias the clip handle",
+            );
+        }
+        unsafe { ptr::write(out_written, 0) };
+
+        let Some(clip) = (unsafe { clip.as_ref() }) else {
+            return status_failure(MmdRuntimeStatus::InvalidInput, FFI_ERR_INVALID_INPUT);
+        };
+        let Some(binding) = clip.clip.bone_track(track_index) else {
+            return status_failure(
+                MmdRuntimeStatus::InvalidInput,
+                "bone track index out of range",
+            );
+        };
+        let required = binding.track.keyframe_count();
+        if required == 0 {
+            return MmdRuntimeStatus::Ok;
+        }
+        if out_keys.is_null() {
+            return status_failure(MmdRuntimeStatus::InvalidInput, FFI_ERR_INVALID_INPUT);
+        }
+        if out_key_capacity < required {
+            return status_failure(MmdRuntimeStatus::BufferTooSmall, "output buffer too small");
+        }
+
+        let mut keys = Vec::new();
+        if keys.try_reserve_exact(required).is_err() {
+            return status_failure(
+                MmdRuntimeStatus::Error,
+                "failed to allocate the bone track key staging buffer",
+            );
+        }
+        for key_index in 0..required {
+            let key = match bone_track_key(binding.bone, &binding.track, key_index) {
+                Ok(key) => key,
+                Err(status) => return status,
+            };
+            keys.push(key);
+        }
+        unsafe {
+            slice::from_raw_parts_mut(out_keys, required).copy_from_slice(&keys);
+            ptr::write(out_written, required);
+        }
+        MmdRuntimeStatus::Ok
     })
 }
 

--- a/crates/mmd-anim-ffi/src/tests.rs
+++ b/crates/mmd-anim-ffi/src/tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use mmd_anim_runtime::InterpolationVector3;
 use std::ffi::CStr;
 use std::mem::MaybeUninit;
 
@@ -278,6 +279,15 @@ fn assert_slice_near(actual: &[f32], expected: &[f32], tolerance: f32) {
             "index={index} actual={actual} expected={expected} tolerance={tolerance}"
         );
     }
+}
+
+fn misaligned_mut_ptr<T>(storage: &mut [u8]) -> *mut T {
+    let base = storage.as_mut_ptr();
+    let offset = (0..std::mem::align_of::<T>())
+        .find(|offset| !(base as usize + offset).is_multiple_of(std::mem::align_of::<T>()))
+        .expect("a type with alignment greater than one has a misaligned byte offset");
+    assert!(storage.len() >= offset + std::mem::size_of::<T>());
+    unsafe { base.add(offset).cast::<T>() }
 }
 
 fn reduced_pose_curve_fixture(target: u32) -> *mut MmdRuntimeReducedPose {
@@ -1728,6 +1738,401 @@ fn evaluates_clip_frame_through_c_abi() {
         mmd_runtime_instance_free(instance);
         mmd_runtime_model_free(model);
     }
+}
+
+#[test]
+fn clip_bone_track_introspection_is_authored_local_and_fail_closed() {
+    assert_eq!(
+        mmd_runtime_feature_flags() & MMD_RUNTIME_FEATURE_CLIP_BONE_TRACK_INTROSPECTION,
+        MMD_RUNTIME_FEATURE_CLIP_BONE_TRACK_INTROSPECTION
+    );
+    let clip = AnimationClip::new(vec![BoneAnimationBinding {
+        bone: BoneIndex(7),
+        track: MovableBoneTrack::from_keyframes(vec![
+            MovableBoneKeyframe {
+                frame: 10,
+                position: glam::Vec3A::new(1.0, 2.0, 3.0),
+                rotation: glam::Quat::from_xyzw(0.0, 0.0, 0.0, 2.0),
+                position_interpolation: InterpolationVector3 {
+                    x: InterpolationScalar {
+                        x1: 1,
+                        y1: 2,
+                        x2: 3,
+                        y2: 4,
+                    },
+                    y: InterpolationScalar::linear(),
+                    z: InterpolationScalar::linear(),
+                },
+                rotation_interpolation: InterpolationScalar::linear(),
+            },
+            MovableBoneKeyframe {
+                frame: 20,
+                position: glam::Vec3A::new(4.0, 5.0, 6.0),
+                rotation: glam::Quat::from_xyzw(0.0, 0.0, 1.0, 1.0),
+                position_interpolation: InterpolationVector3 {
+                    x: InterpolationScalar {
+                        x1: 32,
+                        y1: 64,
+                        x2: 96,
+                        y2: 127,
+                    },
+                    y: InterpolationScalar::linear(),
+                    z: InterpolationScalar::linear(),
+                },
+                rotation_interpolation: InterpolationScalar {
+                    x1: 16,
+                    y1: 32,
+                    x2: 80,
+                    y2: 112,
+                },
+            },
+        ]),
+    }]);
+    let handle = Box::into_raw(Box::new(MmdRuntimeClip { clip }));
+
+    assert_eq!(unsafe { mmd_runtime_clip_bone_track_count(handle) }, 1);
+    let key_count = unsafe { mmd_runtime_clip_bone_track_key_count(handle, 0) };
+    assert_eq!(key_count, 2);
+    assert_eq!(
+        unsafe { mmd_runtime_clip_bone_track_key_count(handle, 1) },
+        0
+    );
+
+    let mut descriptor = MmdRuntimeFfiBoneTrackDescriptor::default();
+    assert_eq!(
+        unsafe { mmd_runtime_clip_bone_track_descriptor(handle, 0, &mut descriptor) },
+        MmdRuntimeStatus::Ok
+    );
+    assert_eq!(descriptor.bone_index, 7);
+    assert_eq!(descriptor.key_count, key_count);
+    assert_eq!(
+        unsafe { mmd_runtime_clip_bone_track_descriptor(handle, 1, &mut descriptor) },
+        MmdRuntimeStatus::InvalidInput
+    );
+    assert_eq!(descriptor, MmdRuntimeFfiBoneTrackDescriptor::default());
+
+    let mut keys = [MmdRuntimeFfiBoneTrackKey::default(); 2];
+    let mut written = 99;
+    assert_eq!(
+        unsafe {
+            mmd_runtime_clip_copy_bone_track_keys(
+                handle,
+                0,
+                keys.as_mut_ptr(),
+                keys.len(),
+                &mut written,
+            )
+        },
+        MmdRuntimeStatus::Ok
+    );
+    assert_eq!(written, 2);
+    assert_eq!(keys[0].bone_index, 7);
+    assert_eq!(keys[0].frame, 10);
+    assert_eq!(keys[0].position_xyz, [1.0, 2.0, 3.0]);
+    assert_eq!(
+        keys[0].translation_x.kind,
+        MMD_RUNTIME_BONE_TRACK_CURVE_NONE
+    );
+    assert_eq!(keys[0].translation_x.x1, 0.0);
+    assert_eq!(keys[0].rotation.kind, MMD_RUNTIME_BONE_TRACK_CURVE_NONE);
+    assert_eq!(
+        keys[1].translation_x.kind,
+        MMD_RUNTIME_BONE_TRACK_CURVE_CUBIC_BEZIER
+    );
+    assert_eq!(keys[1].bone_index, 7);
+    assert_eq!(keys[1].translation_x.x1, 32.0 / 127.0);
+    assert_eq!(keys[1].translation_x.y2, 1.0);
+    assert_eq!(
+        keys[1].rotation.kind,
+        MMD_RUNTIME_BONE_TRACK_CURVE_CUBIC_BEZIER
+    );
+    let rotation_length = keys[1]
+        .rotation_xyzw
+        .iter()
+        .map(|value| value * value)
+        .sum::<f32>()
+        .sqrt();
+    assert!((rotation_length - 1.0).abs() < 1e-6);
+
+    let sentinel = MmdRuntimeFfiBoneTrackKey {
+        frame: 1234,
+        ..MmdRuntimeFfiBoneTrackKey::default()
+    };
+    let mut short = [sentinel];
+    written = 99;
+    assert_eq!(
+        unsafe {
+            mmd_runtime_clip_copy_bone_track_keys(
+                handle,
+                0,
+                short.as_mut_ptr(),
+                short.len(),
+                &mut written,
+            )
+        },
+        MmdRuntimeStatus::BufferTooSmall
+    );
+    assert_eq!(written, 0);
+    let alias_sentinel = MmdRuntimeFfiBoneTrackKey {
+        frame: 4321,
+        ..MmdRuntimeFfiBoneTrackKey::default()
+    };
+    let mut aliased_outputs = [alias_sentinel; 2];
+    assert_eq!(
+        unsafe {
+            mmd_runtime_clip_copy_bone_track_keys(
+                handle,
+                0,
+                aliased_outputs.as_mut_ptr(),
+                aliased_outputs.len(),
+                aliased_outputs.as_mut_ptr().cast::<usize>(),
+            )
+        },
+        MmdRuntimeStatus::InvalidInput
+    );
+    assert_eq!(aliased_outputs, [alias_sentinel; 2]);
+    assert_eq!(short[0], sentinel);
+
+    written = 99;
+    assert_eq!(
+        unsafe {
+            mmd_runtime_clip_copy_bone_track_keys(handle, 0, ptr::null_mut(), 0, &mut written)
+        },
+        MmdRuntimeStatus::InvalidInput
+    );
+    assert_eq!(written, 0);
+    assert_eq!(
+        unsafe {
+            mmd_runtime_clip_copy_bone_track_keys(
+                ptr::null(),
+                0,
+                keys.as_mut_ptr(),
+                keys.len(),
+                &mut written,
+            )
+        },
+        MmdRuntimeStatus::InvalidInput
+    );
+    assert_eq!(written, 0);
+
+    assert_eq!(
+        unsafe {
+            mmd_runtime_clip_bone_track_descriptor(
+                handle,
+                0,
+                handle.cast::<MmdRuntimeFfiBoneTrackDescriptor>(),
+            )
+        },
+        MmdRuntimeStatus::InvalidInput
+    );
+    written = 99;
+    assert_eq!(
+        unsafe {
+            mmd_runtime_clip_copy_bone_track_keys(
+                handle,
+                0,
+                handle.cast::<MmdRuntimeFfiBoneTrackKey>(),
+                keys.len(),
+                &mut written,
+            )
+        },
+        MmdRuntimeStatus::InvalidInput
+    );
+    assert_eq!(written, 99);
+    assert_eq!(
+        unsafe {
+            mmd_runtime_clip_copy_bone_track_keys(
+                handle,
+                0,
+                keys.as_mut_ptr(),
+                keys.len(),
+                handle.cast::<usize>(),
+            )
+        },
+        MmdRuntimeStatus::InvalidInput
+    );
+    assert_eq!(unsafe { mmd_runtime_clip_bone_track_count(handle) }, 1);
+
+    let mut misaligned_key_storage = [0u8; std::mem::size_of::<MmdRuntimeFfiBoneTrackKey>() + 8];
+    let misaligned_key =
+        misaligned_mut_ptr::<MmdRuntimeFfiBoneTrackKey>(&mut misaligned_key_storage);
+    written = 99;
+    assert_eq!(
+        unsafe {
+            mmd_runtime_clip_copy_bone_track_keys(handle, 0, misaligned_key, 1, &mut written)
+        },
+        MmdRuntimeStatus::InvalidInput
+    );
+    assert_eq!(written, 99);
+    let mut misaligned_descriptor_storage =
+        [0u8; std::mem::size_of::<MmdRuntimeFfiBoneTrackDescriptor>() + 8];
+    let misaligned_descriptor =
+        misaligned_mut_ptr::<MmdRuntimeFfiBoneTrackDescriptor>(&mut misaligned_descriptor_storage);
+    assert_eq!(
+        unsafe { mmd_runtime_clip_bone_track_descriptor(handle, 0, misaligned_descriptor) },
+        MmdRuntimeStatus::InvalidInput
+    );
+    let mut misaligned_count_storage = [0u8; std::mem::size_of::<usize>() + 8];
+    let misaligned_count = misaligned_mut_ptr::<usize>(&mut misaligned_count_storage);
+    assert_eq!(
+        unsafe {
+            mmd_runtime_clip_copy_bone_track_keys(
+                handle,
+                0,
+                keys.as_mut_ptr(),
+                keys.len(),
+                misaligned_count,
+            )
+        },
+        MmdRuntimeStatus::InvalidInput
+    );
+    written = 99;
+    let overflowing_capacity = usize::MAX / std::mem::size_of::<MmdRuntimeFfiBoneTrackKey>() + 1;
+    assert_eq!(
+        unsafe {
+            mmd_runtime_clip_copy_bone_track_keys(
+                handle,
+                0,
+                keys.as_mut_ptr(),
+                overflowing_capacity,
+                &mut written,
+            )
+        },
+        MmdRuntimeStatus::InvalidInput
+    );
+    assert_eq!(written, 99);
+    assert_eq!(unsafe { mmd_runtime_clip_bone_track_count(handle) }, 1);
+
+    unsafe { mmd_runtime_clip_free(handle) };
+}
+
+#[test]
+fn clip_bone_track_introspection_rejects_out_of_range_controls_without_writes() {
+    let clip = AnimationClip::new(vec![BoneAnimationBinding {
+        bone: BoneIndex(0),
+        track: MovableBoneTrack::from_keyframes(vec![
+            MovableBoneKeyframe::new(0, glam::Vec3A::ZERO, glam::Quat::IDENTITY),
+            MovableBoneKeyframe {
+                frame: 1,
+                position: glam::Vec3A::ZERO,
+                rotation: glam::Quat::IDENTITY,
+                position_interpolation: InterpolationVector3 {
+                    x: InterpolationScalar {
+                        x1: 200,
+                        y1: 0,
+                        x2: 127,
+                        y2: 127,
+                    },
+                    ..InterpolationVector3::linear()
+                },
+                rotation_interpolation: InterpolationScalar::linear(),
+            },
+        ]),
+    }]);
+    let handle = Box::into_raw(Box::new(MmdRuntimeClip { clip }));
+    let sentinel = MmdRuntimeFfiBoneTrackKey {
+        frame: 777,
+        ..MmdRuntimeFfiBoneTrackKey::default()
+    };
+    let mut output = [sentinel; 2];
+    let mut written = 99;
+    assert_eq!(
+        unsafe {
+            mmd_runtime_clip_copy_bone_track_keys(
+                handle,
+                0,
+                output.as_mut_ptr(),
+                output.len(),
+                &mut written,
+            )
+        },
+        MmdRuntimeStatus::InvalidInput
+    );
+    assert_eq!(written, 0);
+    assert_eq!(output, [sentinel; 2]);
+    unsafe { mmd_runtime_clip_free(handle) };
+}
+
+#[test]
+fn clip_bone_track_introspection_ignores_unused_first_key_controls() {
+    let clip = AnimationClip::new(vec![BoneAnimationBinding {
+        bone: BoneIndex(0),
+        track: MovableBoneTrack::from_keyframes(vec![
+            MovableBoneKeyframe {
+                frame: 0,
+                position: glam::Vec3A::ZERO,
+                rotation: glam::Quat::IDENTITY,
+                position_interpolation: InterpolationVector3 {
+                    x: InterpolationScalar {
+                        x1: 255,
+                        y1: 255,
+                        x2: 255,
+                        y2: 255,
+                    },
+                    ..InterpolationVector3::linear()
+                },
+                rotation_interpolation: InterpolationScalar {
+                    x1: 255,
+                    y1: 255,
+                    x2: 255,
+                    y2: 255,
+                },
+            },
+            MovableBoneKeyframe::new(1, glam::Vec3A::X, glam::Quat::IDENTITY),
+        ]),
+    }]);
+    let handle = Box::into_raw(Box::new(MmdRuntimeClip { clip }));
+    let mut output = [MmdRuntimeFfiBoneTrackKey::default(); 2];
+    let mut written = 0;
+    assert_eq!(
+        unsafe {
+            mmd_runtime_clip_copy_bone_track_keys(
+                handle,
+                0,
+                output.as_mut_ptr(),
+                output.len(),
+                &mut written,
+            )
+        },
+        MmdRuntimeStatus::Ok
+    );
+    assert_eq!(written, 2);
+    assert_eq!(
+        output[0].translation_x.kind,
+        MMD_RUNTIME_BONE_TRACK_CURVE_NONE
+    );
+    assert_eq!(output[0].rotation.kind, MMD_RUNTIME_BONE_TRACK_CURVE_NONE);
+    unsafe { mmd_runtime_clip_free(handle) };
+}
+
+#[test]
+fn clip_bone_track_introspection_layout_is_c_compatible() {
+    use std::mem::{align_of, offset_of, size_of};
+
+    assert_eq!(size_of::<MmdRuntimeFfiBoneTrackCurve>(), 20);
+    assert_eq!(align_of::<MmdRuntimeFfiBoneTrackCurve>(), 4);
+    assert_eq!(offset_of!(MmdRuntimeFfiBoneTrackCurve, kind), 0);
+    assert_eq!(offset_of!(MmdRuntimeFfiBoneTrackCurve, x1), 4);
+    assert_eq!(offset_of!(MmdRuntimeFfiBoneTrackCurve, y2), 16);
+
+    assert_eq!(size_of::<MmdRuntimeFfiBoneTrackDescriptor>(), 16);
+    assert_eq!(
+        align_of::<MmdRuntimeFfiBoneTrackDescriptor>(),
+        align_of::<usize>()
+    );
+    assert_eq!(offset_of!(MmdRuntimeFfiBoneTrackDescriptor, bone_index), 0);
+    assert_eq!(offset_of!(MmdRuntimeFfiBoneTrackDescriptor, key_count), 8);
+
+    assert_eq!(size_of::<MmdRuntimeFfiBoneTrackKey>(), 116);
+    assert_eq!(align_of::<MmdRuntimeFfiBoneTrackKey>(), 4);
+    assert_eq!(offset_of!(MmdRuntimeFfiBoneTrackKey, bone_index), 0);
+    assert_eq!(offset_of!(MmdRuntimeFfiBoneTrackKey, frame), 4);
+    assert_eq!(offset_of!(MmdRuntimeFfiBoneTrackKey, position_xyz), 8);
+    assert_eq!(offset_of!(MmdRuntimeFfiBoneTrackKey, rotation_xyzw), 20);
+    assert_eq!(offset_of!(MmdRuntimeFfiBoneTrackKey, translation_x), 36);
+    assert_eq!(offset_of!(MmdRuntimeFfiBoneTrackKey, translation_y), 56);
+    assert_eq!(offset_of!(MmdRuntimeFfiBoneTrackKey, translation_z), 76);
+    assert_eq!(offset_of!(MmdRuntimeFfiBoneTrackKey, rotation), 96);
 }
 
 #[test]
@@ -4920,10 +5325,180 @@ fn imported_model_vmd_clip_uses_mmd_registration_semantics() {
         "registered path must decode the registered interpolation block"
     );
 
-    unsafe {
-        mmd_runtime_clip_free(clip);
-        mmd_runtime_model_free(model);
+    unsafe { mmd_runtime_model_free(model) };
+    assert_eq!(
+        unsafe { mmd_runtime_clip_bone_track_count(clip) },
+        registered.bone_track_count()
+    );
+    let assert_curve = |actual: MmdRuntimeFfiBoneTrackCurve, expected: InterpolationScalar| {
+        assert_eq!(actual.kind, MMD_RUNTIME_BONE_TRACK_CURVE_CUBIC_BEZIER);
+        assert_near(actual.x1, expected.x1 as f32 / 127.0, 1.0e-7);
+        assert_near(actual.y1, expected.y1 as f32 / 127.0, 1.0e-7);
+        assert_near(actual.x2, expected.x2 as f32 / 127.0, 1.0e-7);
+        assert_near(actual.y2, expected.y2 as f32 / 127.0, 1.0e-7);
+    };
+    for (track_index, expected_binding) in registered.bone_tracks().iter().enumerate() {
+        let mut descriptor = MmdRuntimeFfiBoneTrackDescriptor::default();
+        assert_eq!(
+            unsafe { mmd_runtime_clip_bone_track_descriptor(clip, track_index, &mut descriptor) },
+            MmdRuntimeStatus::Ok
+        );
+        assert_eq!(descriptor.bone_index, expected_binding.bone.0);
+        assert_eq!(
+            descriptor.key_count,
+            expected_binding.track.keyframe_count()
+        );
+        let mut keys = vec![MmdRuntimeFfiBoneTrackKey::default(); descriptor.key_count];
+        let mut written = 0;
+        assert_eq!(
+            unsafe {
+                mmd_runtime_clip_copy_bone_track_keys(
+                    clip,
+                    track_index,
+                    keys.as_mut_ptr(),
+                    keys.len(),
+                    &mut written,
+                )
+            },
+            MmdRuntimeStatus::Ok
+        );
+        assert_eq!(written, descriptor.key_count);
+        for (key_index, actual_key) in keys.iter().enumerate() {
+            let expected_key = expected_binding
+                .track
+                .keyframe(key_index)
+                .expect("registered key");
+            assert_eq!(actual_key.bone_index, expected_binding.bone.0);
+            assert_eq!(actual_key.frame, expected_key.frame);
+            assert_slice_near(
+                &actual_key.position_xyz,
+                &expected_key.position.to_array(),
+                1.0e-7,
+            );
+            assert_slice_near(
+                &actual_key.rotation_xyzw,
+                &expected_key.rotation.to_array(),
+                1.0e-6,
+            );
+            if key_index == 0 {
+                assert_eq!(
+                    actual_key.translation_x,
+                    MmdRuntimeFfiBoneTrackCurve::default()
+                );
+                assert_eq!(
+                    actual_key.translation_y,
+                    MmdRuntimeFfiBoneTrackCurve::default()
+                );
+                assert_eq!(
+                    actual_key.translation_z,
+                    MmdRuntimeFfiBoneTrackCurve::default()
+                );
+                assert_eq!(actual_key.rotation, MmdRuntimeFfiBoneTrackCurve::default());
+            } else {
+                assert_curve(
+                    actual_key.translation_x,
+                    expected_key.position_interpolation.x,
+                );
+                assert_curve(
+                    actual_key.translation_y,
+                    expected_key.position_interpolation.y,
+                );
+                assert_curve(
+                    actual_key.translation_z,
+                    expected_key.position_interpolation.z,
+                );
+                assert_curve(actual_key.rotation, expected_key.rotation_interpolation);
+            }
+        }
     }
+    unsafe { mmd_runtime_clip_free(clip) };
+}
+
+#[test]
+fn pmm_document_clip_uses_the_same_bone_track_introspection_surface() {
+    let bytes = include_bytes!("../../mmd-anim-format/fixtures/pmm/ik_multi_bone_from_pmx_vmd.pmm");
+    let parsed = mmd_anim_format::parse_pmm_manifest(bytes).expect("PMM fixture");
+    let mut model = parsed
+        .document_summary
+        .expect("PMM document summary")
+        .models
+        .remove(0);
+    let semantic_curves = [1, 2, 3, 4, 11, 12, 13, 14, 21, 22, 23, 24, 31, 32, 33, 34];
+    for key in &mut model.bone_keyframe_summaries {
+        key.interpolation = semantic_curves;
+    }
+    let expected =
+        mmd_anim_format::build_pmm_document_model_clip(&model).expect("PMM document clip");
+    let track_index = expected
+        .bone_tracks()
+        .iter()
+        .position(|binding| binding.track.keyframe_count() > 1)
+        .expect("PMM fixture has a keyed bone track");
+    let expected_binding = &expected.bone_tracks()[track_index];
+    let handle = Box::into_raw(Box::new(MmdRuntimeClip {
+        clip: expected.clone(),
+    }));
+
+    let mut descriptor = MmdRuntimeFfiBoneTrackDescriptor::default();
+    assert_eq!(
+        unsafe { mmd_runtime_clip_bone_track_descriptor(handle, track_index, &mut descriptor) },
+        MmdRuntimeStatus::Ok
+    );
+    assert_eq!(descriptor.bone_index, expected_binding.bone.0);
+    assert_eq!(
+        descriptor.key_count,
+        expected_binding.track.keyframe_count()
+    );
+    let mut keys = vec![MmdRuntimeFfiBoneTrackKey::default(); descriptor.key_count];
+    let mut written = 0;
+    assert_eq!(
+        unsafe {
+            mmd_runtime_clip_copy_bone_track_keys(
+                handle,
+                track_index,
+                keys.as_mut_ptr(),
+                keys.len(),
+                &mut written,
+            )
+        },
+        MmdRuntimeStatus::Ok
+    );
+    assert_eq!(written, descriptor.key_count);
+    assert_eq!(
+        keys[0].translation_x,
+        MmdRuntimeFfiBoneTrackCurve::default()
+    );
+    let expected_key = expected_binding
+        .track
+        .keyframe(1)
+        .expect("PMM authored second key");
+    assert_eq!(keys[1].frame, expected_key.frame);
+    assert_eq!(
+        keys[1].translation_x.kind,
+        MMD_RUNTIME_BONE_TRACK_CURVE_CUBIC_BEZIER
+    );
+    assert_near(
+        keys[1].translation_x.x1,
+        expected_key.position_interpolation.x.x1 as f32 / 127.0,
+        1.0e-7,
+    );
+    assert_near(
+        keys[1].translation_y.x1,
+        expected_key.position_interpolation.y.x1 as f32 / 127.0,
+        1.0e-7,
+    );
+    assert_near(
+        keys[1].translation_z.x1,
+        expected_key.position_interpolation.z.x1 as f32 / 127.0,
+        1.0e-7,
+    );
+    assert_near(
+        keys[1].rotation.x1,
+        expected_key.rotation_interpolation.x1 as f32 / 127.0,
+        1.0e-7,
+    );
+
+    unsafe { mmd_runtime_clip_free(handle) };
 }
 
 // -----------------------------------------------------------------------

--- a/crates/mmd-anim-runtime/src/animation.rs
+++ b/crates/mmd-anim-runtime/src/animation.rs
@@ -134,6 +134,22 @@ impl MovableBoneTrack {
         self.frame_numbers.len()
     }
 
+    /// Returns an owned view of one authored keyframe.
+    ///
+    /// The interpolation fields on the returned keyframe retain the clip's
+    /// incoming-segment convention: for key `i > 0` they describe the segment
+    /// from key `i - 1` to key `i`.  Callers that expose the first key should
+    /// treat its interpolation as having no incoming segment.
+    pub fn keyframe(&self, index: usize) -> Option<MovableBoneKeyframe> {
+        Some(MovableBoneKeyframe {
+            frame: *self.frame_numbers.get(index)?,
+            position: *self.positions.get(index)?,
+            rotation: *self.rotations.get(index)?,
+            position_interpolation: *self.position_interpolations.get(index)?,
+            rotation_interpolation: *self.rotation_interpolations.get(index)?,
+        })
+    }
+
     pub fn sample(&self, frame: f32) -> Option<(Vec3A, Quat)> {
         match self.frame_numbers.len() {
             0 => None,
@@ -543,6 +559,11 @@ impl AnimationClip {
 
     pub fn bone_track_count(&self) -> usize {
         self.bone_tracks.len()
+    }
+
+    /// Returns one authored local bone track by clip order.
+    pub fn bone_track(&self, index: usize) -> Option<&BoneAnimationBinding> {
+        self.bone_tracks.get(index)
     }
 
     pub fn morph_track_count(&self) -> usize {

--- a/tools/check_ffi_header_symbols.py
+++ b/tools/check_ffi_header_symbols.py
@@ -36,6 +36,16 @@ GENERIC_CONSTANTS = {
     "MMD_RUNTIME_GENERIC_ROTATION_BASIS_EULER_XYZ_RADIANS_PER_FRAME": 2,
 }
 
+CLIP_TRACK_CONSTANTS = {
+    "MMD_RUNTIME_CLIP_BONE_TRACK_INTROSPECTION_ABI_VERSION_V1": 1,
+    "MMD_RUNTIME_BONE_TRACK_CURVE_NONE": 0,
+    "MMD_RUNTIME_BONE_TRACK_CURVE_CUBIC_BEZIER": 1,
+}
+
+CLIP_TRACK_FEATURE_BITS = {
+    "MMD_RUNTIME_FEATURE_CLIP_BONE_TRACK_INTROSPECTION": 5,
+}
+
 GENERIC_STRUCTS = {
     "MmdRuntimeFfiGenericCurveInfo": (
         "mmd_runtime_ffi_generic_curve_info_t",
@@ -90,6 +100,36 @@ GENERIC_STRUCTS = {
     ),
 }
 
+CLIP_TRACK_STRUCTS = {
+    "MmdRuntimeFfiBoneTrackCurve": (
+        "mmd_runtime_ffi_bone_track_curve_t",
+        [
+            ("kind", "u32"),
+            ("x1", "f32"),
+            ("y1", "f32"),
+            ("x2", "f32"),
+            ("y2", "f32"),
+        ],
+    ),
+    "MmdRuntimeFfiBoneTrackDescriptor": (
+        "mmd_runtime_ffi_bone_track_descriptor_t",
+        [("bone_index", "u32"), ("key_count", "usize")],
+    ),
+    "MmdRuntimeFfiBoneTrackKey": (
+        "mmd_runtime_ffi_bone_track_key_t",
+        [
+            ("bone_index", "u32"),
+            ("frame", "u32"),
+            ("position_xyz", "f32[3]"),
+            ("rotation_xyzw", "f32[4]"),
+            ("translation_x", "bone_track_curve"),
+            ("translation_y", "bone_track_curve"),
+            ("translation_z", "bone_track_curve"),
+            ("rotation", "bone_track_curve"),
+        ],
+    ),
+}
+
 GENERIC_FUNCTIONS = {
     "mmd_runtime_reduced_pose_generic_curve_info": (
         "status",
@@ -116,6 +156,35 @@ GENERIC_FUNCTIONS = {
             ("out_key_capacity", "usize"),
             ("key_stride_bytes", "usize"),
             ("out_required_count", "usize_ptr"),
+        ],
+    ),
+}
+
+CLIP_TRACK_FUNCTIONS = {
+    "mmd_runtime_clip_bone_track_count": (
+        "usize",
+        [("clip", "const_clip_ptr")],
+    ),
+    "mmd_runtime_clip_bone_track_descriptor": (
+        "status",
+        [
+            ("clip", "const_clip_ptr"),
+            ("track_index", "usize"),
+            ("out_descriptor", "bone_track_descriptor_ptr"),
+        ],
+    ),
+    "mmd_runtime_clip_bone_track_key_count": (
+        "usize",
+        [("clip", "const_clip_ptr"), ("track_index", "usize")],
+    ),
+    "mmd_runtime_clip_copy_bone_track_keys": (
+        "status",
+        [
+            ("clip", "const_clip_ptr"),
+            ("track_index", "usize"),
+            ("out_keys", "bone_track_key_ptr"),
+            ("out_key_capacity", "usize"),
+            ("out_written", "usize_ptr"),
         ],
     ),
 }
@@ -192,6 +261,7 @@ def canonical_rust_type(type_name: str) -> str:
         "MmdRuntimeStatus": "status",
         "MmdRuntimeFfiByteBuffer": "ffi_byte_buffer",
         "*const MmdRuntimeReducedPose": "const_reduced_pose_ptr",
+        "*const MmdRuntimeClip": "const_clip_ptr",
         "*const MmdRuntimePhysicsWorld": "const_physics_world_ptr",
         "*mut MmdRuntimePhysicsWorld": "physics_world_ptr",
         "*const u8": "const_u8_ptr",
@@ -199,6 +269,9 @@ def canonical_rust_type(type_name: str) -> str:
         "*mut MmdRuntimeFfiGenericCurveInfo": "generic_info_ptr",
         "*mut MmdRuntimeFfiGenericCurveDescriptor": "generic_descriptor_ptr",
         "*mut MmdRuntimeFfiGenericCurveKey": "generic_key_ptr",
+        "MmdRuntimeFfiBoneTrackCurve": "bone_track_curve",
+        "*mut MmdRuntimeFfiBoneTrackDescriptor": "bone_track_descriptor_ptr",
+        "*mut MmdRuntimeFfiBoneTrackKey": "bone_track_key_ptr",
     }.get(compact, compact)
 
 
@@ -215,6 +288,7 @@ def canonical_c_type(type_name: str) -> str:
         "mmd_runtime_status_t": "status",
         "mmd_runtime_ffi_byte_buffer_t": "ffi_byte_buffer",
         "const mmd_runtime_reduced_pose_t*": "const_reduced_pose_ptr",
+        "const mmd_runtime_clip_t*": "const_clip_ptr",
         "const mmd_runtime_physics_world_t*": "const_physics_world_ptr",
         "mmd_runtime_physics_world_t*": "physics_world_ptr",
         "const uint8_t*": "const_u8_ptr",
@@ -222,6 +296,9 @@ def canonical_c_type(type_name: str) -> str:
         "mmd_runtime_ffi_generic_curve_info_t*": "generic_info_ptr",
         "mmd_runtime_ffi_generic_curve_descriptor_t*": "generic_descriptor_ptr",
         "mmd_runtime_ffi_generic_curve_key_t*": "generic_key_ptr",
+        "mmd_runtime_ffi_bone_track_descriptor_t*": "bone_track_descriptor_ptr",
+        "mmd_runtime_ffi_bone_track_key_t*": "bone_track_key_ptr",
+        "mmd_runtime_ffi_bone_track_curve_t": "bone_track_curve",
     }.get(compact, compact)
 
 
@@ -303,6 +380,28 @@ def check_abi_shapes(rust_text: str, header_text: str) -> list[str]:
             errors.append(
                 f"constant {name}: Rust={rust_value}, header={header_value}, expected={expected}"
             )
+    for name, expected in CLIP_TRACK_CONSTANTS.items():
+        rust_match = re.search(rf"pub const {name}: u32 = (\d+);", rust_text)
+        header_match = re.search(rf"\b{name}(?:\s+|\s*=\s*)(\d+)(?:u)?\b", header_text)
+        rust_value = int(rust_match.group(1)) if rust_match else None
+        header_value = int(header_match.group(1)) if header_match else None
+        if rust_value != expected or header_value != expected or rust_value != header_value:
+            errors.append(
+                f"constant {name}: Rust={rust_value}, header={header_value}, expected={expected}"
+            )
+    for name, expected_bit in CLIP_TRACK_FEATURE_BITS.items():
+        rust_match = re.search(
+            rf"pub const {name}: u32 = 1\s*<<\s*(\d+);", rust_text
+        )
+        header_match = re.search(
+            rf"#define\s+{name}\s+\(1u\s*<<\s*(\d+)\)", header_text
+        )
+        rust_bit = int(rust_match.group(1)) if rust_match else None
+        header_bit = int(header_match.group(1)) if header_match else None
+        if rust_bit != expected_bit or header_bit != expected_bit or rust_bit != header_bit:
+            errors.append(
+                f"feature {name}: Rust bit={rust_bit}, header bit={header_bit}, expected={expected_bit}"
+            )
     for rust_name, (c_alias, expected) in GENERIC_STRUCTS.items():
         rust_fields = rust_struct_fields(rust_text, rust_name)
         c_fields = c_struct_fields(header_text, c_alias)
@@ -310,7 +409,21 @@ def check_abi_shapes(rust_text: str, header_text: str) -> list[str]:
             errors.append(
                 f"struct {rust_name}/{c_alias}: Rust={rust_fields}, header={c_fields}, expected={expected}"
             )
+    for rust_name, (c_alias, expected) in CLIP_TRACK_STRUCTS.items():
+        rust_fields = rust_struct_fields(rust_text, rust_name)
+        c_fields = c_struct_fields(header_text, c_alias)
+        if rust_fields != expected or c_fields != expected or rust_fields != c_fields:
+            errors.append(
+                f"struct {rust_name}/{c_alias}: Rust={rust_fields}, header={c_fields}, expected={expected}"
+            )
     for name, expected in GENERIC_FUNCTIONS.items():
+        rust_shape = rust_function_shape(rust_text, name)
+        c_shape = c_function_shape(header_text, name)
+        if rust_shape != expected or c_shape != expected or rust_shape != c_shape:
+            errors.append(
+                f"function {name}: Rust={rust_shape}, header={c_shape}, expected={expected}"
+            )
+    for name, expected in CLIP_TRACK_FUNCTIONS.items():
         rust_shape = rust_function_shape(rust_text, name)
         c_shape = c_function_shape(header_text, name)
         if rust_shape != expected or c_shape != expected or rust_shape != c_shape:


### PR DESCRIPTION
## Summary
- add a format-neutral, read-only compiled AnimationClip bone-track introspection ABI
- expose caller-owned descriptor/key copies with normalized local quaternions and semantic X/Y/Z/rotation Bezier curves
- define first-key NONE and previous-key-to-current-key segment ownership
- validate null/range/alignment/capacity/aliasing inputs without partial writes
- cover programmatic, registered VMD, and PMM document clips

## Boundary
- stacked on #39 because registered VMD construction semantics are supplied there
- does not add or replace a Runtime Bake/Live creation API
- does not expose raw VMD bytes, Maya tangents, internal Rust slices, or solved Append/IK world poses

## Verification
- cargo test --workspace: 877 passed, 3 ignored
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo doc --workspace --no-deps
- python tools/check_ffi_header_symbols.py: 172 symbols/shapes matched
- crates/mmd-anim-ffi/scripts/smoke.ps1: PASS (49 expected exports in header; dumpbin unavailable)
- independent correctness and Rust/C FFI safety re-reviews: approve, no findings

## Local-only docs
The Sour evidence and Maya handoff/TODO documents remain ignored local files and are not included in this PR.