### PR TITLE
feat(ffi): rearm clip physics seed without reset

### DIFF
--- a/crates/mmd-anim-ffi/include/mmd_runtime.h
+++ b/crates/mmd-anim-ffi/include/mmd_runtime.h
@@ -1579,6 +1579,11 @@ mmd_runtime_status_t mmd_runtime_physics_world_reset(
     mmd_runtime_instance_t*      instance,
     size_t*                      out_seeded_rigidbody_count);
 
+/* Arms the next sequential clip-bake sample to reseed from its evaluated pose
+   without running the reset settle. The world must remain model-compatible. */
+mmd_runtime_status_t mmd_runtime_physics_world_rearm_bake_seed(
+    mmd_runtime_physics_world_t* world);
+
 /* Forward steps feed static bodies only; DynamicBone bodies are seeded by
    reset and remain solver-owned. A successful explicit step disarms bake
    seed-only state so the next bake sample advances physics normally. */

--- a/crates/mmd-anim-ffi/src/lib.rs
+++ b/crates/mmd-anim-ffi/src/lib.rs
@@ -6019,6 +6019,22 @@ pub unsafe extern "C" fn mmd_runtime_physics_world_reset(
     })
 }
 
+/// Arms the next sequential clip-bake sample to reseed the existing Bullet
+/// world from that sample's evaluated pose without running the reset settle.
+/// This is intended for changing clips while retaining a compatible world.
+///
+/// # Safety
+///
+/// `world` must be a valid physics-world handle.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn mmd_runtime_physics_world_rearm_bake_seed(
+    world: *mut MmdRuntimePhysicsWorld,
+) -> MmdRuntimeStatus {
+    ffi_guard(MmdRuntimeStatus::Error, || {
+        physics_world_rearm_bake_seed_impl(world)
+    })
+}
+
 /// Steps a physics world using the runtime's fixed-step physics clock.
 ///
 /// This live-evaluation path feeds static bodies before the step. DynamicBone
@@ -6303,6 +6319,11 @@ fn physics_world_reset_impl(
     _instance: *mut MmdRuntimeInstance,
     _out_seeded_rigidbody_count: *mut usize,
 ) -> MmdRuntimeStatus {
+    status_failure(MmdRuntimeStatus::Unsupported, "physics backend unsupported")
+}
+
+#[cfg(not(feature = "physics-bullet-native"))]
+fn physics_world_rearm_bake_seed_impl(_world: *mut MmdRuntimePhysicsWorld) -> MmdRuntimeStatus {
     status_failure(MmdRuntimeStatus::Unsupported, "physics backend unsupported")
 }
 
@@ -6760,6 +6781,15 @@ fn physics_world_reset_impl(
         }
         Err(err) => status_failure(MmdRuntimeStatus::Error, err.to_string().as_str()),
     }
+}
+
+#[cfg(feature = "physics-bullet-native")]
+fn physics_world_rearm_bake_seed_impl(world: *mut MmdRuntimePhysicsWorld) -> MmdRuntimeStatus {
+    let Some(world) = (unsafe { world.as_mut() }) else {
+        return status_failure(MmdRuntimeStatus::InvalidInput, FFI_ERR_INVALID_INPUT);
+    };
+    world.next_bake_sample_is_seed_only = true;
+    MmdRuntimeStatus::Ok
 }
 
 #[cfg(feature = "physics-bullet-native")]

--- a/crates/mmd-anim-ffi/src/tests.rs
+++ b/crates/mmd-anim-ffi/src/tests.rs
@@ -3411,6 +3411,33 @@ fn physics_world_bake_clip_frames_seed_only_state_contract() {
         "continuation first sample must step physics: {report:?}"
     );
 
+    // A clip switch can re-arm seed-only without paying the reset settle.
+    assert_eq!(
+        unsafe { mmd_runtime_physics_world_rearm_bake_seed(world) },
+        MmdRuntimeStatus::Ok
+    );
+    report = zero_physics_step_report();
+    assert_eq!(
+        unsafe {
+            mmd_runtime_physics_world_bake_clip_frames(
+                world,
+                instance,
+                clip,
+                0.0,
+                15.0,
+                1.0 / 60.0,
+                1,
+                world_out.as_mut_ptr(),
+                world_out.len(),
+                morphs.as_mut_ptr(),
+                morphs.len(),
+                &mut report,
+            )
+        },
+        MmdRuntimeStatus::Ok
+    );
+    assert_zero_physics_step_report(&report);
+
     // Successful reset re-arms seed-only.
     assert_eq!(
         unsafe { mmd_runtime_physics_world_reset(world, instance, ptr::null_mut()) },


### PR DESCRIPTION
## What changed

- Add `mmd_runtime_physics_world_rearm_bake_seed` to the public C ABI.
- Re-arm the next compatible clip-bake sample as seed-only without running reset settle.
- Return `Unsupported` when the Bullet backend is disabled.
- Add regression coverage for clip switching on a retained physics world.

## Why

Unity Timeline reuses a compatible same-PMX physics world across clips. It needs to seed the first sample of the new clip without paying the expensive reset-settle path.

## Impact

Hosts can retain a compatible Bullet world at clip boundaries while preserving the existing reset API and feature-disabled behavior.

## Validation

- `cargo test -p mmd-anim-ffi physics_world_bake_clip_frames_seed_only_state_contract`
- `cargo check -p mmd-anim-ffi --no-default-features`
- `cargo fmt --all -- --check`
- Codex Review: no findings