### PR TITLE
chore(release): prepare v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## 0.4.1 - 2026-08-13
+
+Improved MMD knee IK parity and clip-switch physics reuse for native hosts.
+
+### Added
+
+- Added an experimental C ABI operation that rearms the next sequential
+  clip-bake sample from its evaluated pose without paying the reset-settle cost
+  when reusing a model-compatible Bullet physics world.
+
+### Fixed
+
+- Matched MMD's one-sided knee constraints by solving compatible knee links
+  around the raw local X axis and preserving the authored pose as the rollback
+  floor when a constrained IK candidate is worse.
+
+### Known limitations
+
+- Physics-world reuse requires the same compatible PMX model; hosts must rebuild
+  the world when model compatibility is not guaranteed.
+- The C ABI, WASM wrapper, PMM document conversion, and Python binding remain
+  experimental and may change before 1.0.
+
 ## 0.4.0 - 2026-08-03
 
 Expanded raw VMD diagnostics and versioned native-host ABI contracts.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -372,7 +372,7 @@ checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "mmd-anim"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "mmd-anim-format",
  "mmd-anim-runtime",
@@ -381,7 +381,7 @@ dependencies = [
 
 [[package]]
 name = "mmd-anim-cli"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -397,7 +397,7 @@ dependencies = [
 
 [[package]]
 name = "mmd-anim-ffi"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "glam",
  "mmd-anim-format",
@@ -409,7 +409,7 @@ dependencies = [
 
 [[package]]
 name = "mmd-anim-format"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "encoding_rs",
  "fbxcel",
@@ -422,7 +422,7 @@ dependencies = [
 
 [[package]]
 name = "mmd-anim-physics-bullet"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "cc",
  "glam",
@@ -434,7 +434,7 @@ dependencies = [
 
 [[package]]
 name = "mmd-anim-runtime"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "glam",
  "rayon",
@@ -443,7 +443,7 @@ dependencies = [
 
 [[package]]
 name = "mmd-anim-wasm"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "glam",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 rust-version = "1.87"
 license = "MIT"
@@ -30,6 +30,6 @@ serde_json = "1.0.145"
 wasm-bindgen = "0.2.105"
 js-sys = "0.3"
 encoding_rs = "0.8"
-mmd-anim-runtime = { path = "crates/mmd-anim-runtime", version = "0.4.0" }
-mmd-anim-format = { path = "crates/mmd-anim-format", version = "0.4.0" }
+mmd-anim-runtime = { path = "crates/mmd-anim-runtime", version = "0.4.1" }
+mmd-anim-format = { path = "crates/mmd-anim-format", version = "0.4.1" }
  

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Format support overview. "Loading" means parsing a file into structured data.
 
 ```toml
 [dependencies]
-mmd-anim = "0.4.0"
+mmd-anim = "0.4.1"
 ```
 
 ## Native Hosts (C ABI)

--- a/crates/mmd-anim-cli/Cargo.toml
+++ b/crates/mmd-anim-cli/Cargo.toml
@@ -26,8 +26,8 @@ clap = { version = "4", features = ["derive"] }
 clap_complete = "4"
 glam.workspace = true
 mmd-anim-runtime.workspace = true
-mmd-anim-format = { path = "../mmd-anim-format", version = "0.4.0", features = ["fbx"] }
-mmd-anim-physics-bullet = { path = "../mmd-anim-physics-bullet", version = "0.4.0", features = ["native", "pmx-format", "runtime"], optional = true }
+mmd-anim-format = { path = "../mmd-anim-format", version = "0.4.1", features = ["fbx"] }
+mmd-anim-physics-bullet = { path = "../mmd-anim-physics-bullet", version = "0.4.1", features = ["native", "pmx-format", "runtime"], optional = true }
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true

--- a/crates/mmd-anim-ffi/Cargo.toml
+++ b/crates/mmd-anim-ffi/Cargo.toml
@@ -18,8 +18,8 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 glam.workspace = true
 mmd-anim-runtime.workspace = true
-mmd-anim-format = { path = "../mmd-anim-format", version = "0.4.0", features = ["fbx"] }
-mmd-anim-physics-bullet = { path = "../mmd-anim-physics-bullet", version = "0.4.0", optional = true, features = ["native", "runtime", "pmx-format"] }
+mmd-anim-format = { path = "../mmd-anim-format", version = "0.4.1", features = ["fbx"] }
+mmd-anim-physics-bullet = { path = "../mmd-anim-physics-bullet", version = "0.4.1", optional = true, features = ["native", "runtime", "pmx-format"] }
 serde.workspace = true
 serde_json.workspace = true
 

--- a/crates/mmd-anim-ffi/include/mmd_runtime.h
+++ b/crates/mmd-anim-ffi/include/mmd_runtime.h
@@ -1579,6 +1579,11 @@ mmd_runtime_status_t mmd_runtime_physics_world_reset(
     mmd_runtime_instance_t*      instance,
     size_t*                      out_seeded_rigidbody_count);
 
+/* Arms the next sequential clip-bake sample to reseed from its evaluated pose
+   without running the reset settle. The world must remain model-compatible. */
+mmd_runtime_status_t mmd_runtime_physics_world_rearm_bake_seed(
+    mmd_runtime_physics_world_t* world);
+
 /* Forward steps feed static bodies only; DynamicBone bodies are seeded by
    reset and remain solver-owned. A successful explicit step disarms bake
    seed-only state so the next bake sample advances physics normally. */

--- a/crates/mmd-anim-ffi/src/lib.rs
+++ b/crates/mmd-anim-ffi/src/lib.rs
@@ -6019,6 +6019,22 @@ pub unsafe extern "C" fn mmd_runtime_physics_world_reset(
     })
 }
 
+/// Arms the next sequential clip-bake sample to reseed the existing Bullet
+/// world from that sample's evaluated pose without running the reset settle.
+/// This is intended for changing clips while retaining a compatible world.
+///
+/// # Safety
+///
+/// `world` must be a valid physics-world handle.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn mmd_runtime_physics_world_rearm_bake_seed(
+    world: *mut MmdRuntimePhysicsWorld,
+) -> MmdRuntimeStatus {
+    ffi_guard(MmdRuntimeStatus::Error, || {
+        physics_world_rearm_bake_seed_impl(world)
+    })
+}
+
 /// Steps a physics world using the runtime's fixed-step physics clock.
 ///
 /// This live-evaluation path feeds static bodies before the step. DynamicBone
@@ -6303,6 +6319,11 @@ fn physics_world_reset_impl(
     _instance: *mut MmdRuntimeInstance,
     _out_seeded_rigidbody_count: *mut usize,
 ) -> MmdRuntimeStatus {
+    status_failure(MmdRuntimeStatus::Unsupported, "physics backend unsupported")
+}
+
+#[cfg(not(feature = "physics-bullet-native"))]
+fn physics_world_rearm_bake_seed_impl(_world: *mut MmdRuntimePhysicsWorld) -> MmdRuntimeStatus {
     status_failure(MmdRuntimeStatus::Unsupported, "physics backend unsupported")
 }
 
@@ -6760,6 +6781,15 @@ fn physics_world_reset_impl(
         }
         Err(err) => status_failure(MmdRuntimeStatus::Error, err.to_string().as_str()),
     }
+}
+
+#[cfg(feature = "physics-bullet-native")]
+fn physics_world_rearm_bake_seed_impl(world: *mut MmdRuntimePhysicsWorld) -> MmdRuntimeStatus {
+    let Some(world) = (unsafe { world.as_mut() }) else {
+        return status_failure(MmdRuntimeStatus::InvalidInput, FFI_ERR_INVALID_INPUT);
+    };
+    world.next_bake_sample_is_seed_only = true;
+    MmdRuntimeStatus::Ok
 }
 
 #[cfg(feature = "physics-bullet-native")]

--- a/crates/mmd-anim-ffi/src/tests.rs
+++ b/crates/mmd-anim-ffi/src/tests.rs
@@ -3411,6 +3411,33 @@ fn physics_world_bake_clip_frames_seed_only_state_contract() {
         "continuation first sample must step physics: {report:?}"
     );
 
+    // A clip switch can re-arm seed-only without paying the reset settle.
+    assert_eq!(
+        unsafe { mmd_runtime_physics_world_rearm_bake_seed(world) },
+        MmdRuntimeStatus::Ok
+    );
+    report = zero_physics_step_report();
+    assert_eq!(
+        unsafe {
+            mmd_runtime_physics_world_bake_clip_frames(
+                world,
+                instance,
+                clip,
+                0.0,
+                15.0,
+                1.0 / 60.0,
+                1,
+                world_out.as_mut_ptr(),
+                world_out.len(),
+                morphs.as_mut_ptr(),
+                morphs.len(),
+                &mut report,
+            )
+        },
+        MmdRuntimeStatus::Ok
+    );
+    assert_zero_physics_step_report(&report);
+
     // Successful reset re-arms seed-only.
     assert_eq!(
         unsafe { mmd_runtime_physics_world_reset(world, instance, ptr::null_mut()) },

--- a/crates/mmd-anim-ffi/src/tests.rs
+++ b/crates/mmd-anim-ffi/src/tests.rs
@@ -9884,7 +9884,9 @@ fn model_descriptor_fixture_matches_pmx_model_arena_and_behavior() {
         },
         MmdRuntimeFfiBoneKeyframe {
             frame: 0,
-            position_xyz: [0.06, 0.0, 0.0],
+            // Keep the controller off the authored chain so property IK has
+            // an observable enabled-vs-disabled effect in this parity test.
+            position_xyz: [1.0, 0.0, 0.0],
             rotation_xyzw: controller_rotation,
         },
     ];
@@ -10009,11 +10011,28 @@ fn model_descriptor_fixture_matches_pmx_model_arena_and_behavior() {
             disabled_ik_world.len(),
         )
     });
-    let ik_bone = fixture.ik_solvers[0].ik_bone_index as usize;
     assert_ne!(
-        &enabled_world[ik_bone * 16..ik_bone * 16 + 16],
-        &disabled_ik_world[ik_bone * 16..ik_bone * 16 + 16],
-        "IK enabled/disabled must change controller matrix"
+        enabled_world, disabled_ik_world,
+        "IK enabled must change at least one fixture bone matrix"
+    );
+    let ik_bone = fixture.ik_solvers[0].ik_bone_index as usize;
+    let target_bone = fixture.ik_solvers[0].target_bone_index as usize;
+    let matrix_translation = |world: &[f32], bone: usize| {
+        glam::Vec3A::new(
+            world[bone * 16 + 12],
+            world[bone * 16 + 13],
+            world[bone * 16 + 14],
+        )
+    };
+    let enabled_distance = (matrix_translation(&enabled_world, target_bone)
+        - matrix_translation(&enabled_world, ik_bone))
+    .length();
+    let disabled_distance = (matrix_translation(&disabled_ik_world, target_bone)
+        - matrix_translation(&disabled_ik_world, ik_bone))
+    .length();
+    assert!(
+        enabled_distance <= disabled_distance + 1.0e-5,
+        "IK enabled must not replace a better authored pose: enabled={enabled_distance} disabled={disabled_distance}"
     );
 
     let mut no_append_descriptor = fixture.descriptor();

--- a/crates/mmd-anim-runtime/src/ik_primitive.rs
+++ b/crates/mmd-anim-runtime/src/ik_primitive.rs
@@ -120,8 +120,14 @@ impl IkChainSolver {
         self.apply_link_rotations();
         self.update_world_matrices(input);
 
-        let mut final_distance = f32::MAX;
-        let mut best_distance = f32::MAX;
+        // The input local pose is the rollback floor. A constrained IK
+        // candidate can be worse than the authored pose, so it must not become
+        // the best pose merely because it is the first finite distance seen.
+        let mut final_distance = {
+            let eff_pos = translation(self.world_matrices[self.definition.target_slot]);
+            (eff_pos - input.goal_position).length()
+        };
+        let mut best_distance = final_distance;
         let mut executed_iterations = 0u32;
         let mut link_steps = 0u32;
 
@@ -846,13 +852,44 @@ pub(crate) fn solve_plane_link_step(input: PlaneLinkStepInput<'_>) {
         1 => Vec3A::new(0.0, 1.0, 0.0),
         _ => Vec3A::new(0.0, 0.0, 1.0),
     };
-    let (q_b, q_b_inv) = match input.local_axis_basis {
-        Some(basis) if basis.is_finite() => (basis.normalize(), basis.normalize().inverse()),
-        _ => (Quat::IDENTITY, Quat::IDENTITY),
+    let (lower, upper) = limit_axis_bounds(input.limits, input.axis_index);
+    // MMD-compatible knee links are one-sided rotations around the raw local
+    // X axis. PMX localAxis is a manipulator frame and must not become the
+    // knee pole/rotation axis here. On the first pass, measure the target
+    // against the authored (pre-IK) link orientation so the resulting angle
+    // is an absolute knee angle; later passes continue from planeModeAngle.
+    let axis_aligned_with_bone = match input.local_axis_basis {
+        Some(basis) if basis.is_finite() && basis.length_squared() > f32::EPSILON => {
+            basis
+                .normalize()
+                .mul_vec3a(Vec3A::X)
+                .dot(input.local_effector.normalize())
+                .abs()
+                > 0.95
+        }
+        _ => true,
     };
-    // Solve the plane limit in local-axis space, then conjugate back.
+    let mmd_knee_plane = input.axis_index == 0
+        && axis_aligned_with_bone
+        && ((lower < 0.0 && upper <= 0.0) || (lower >= 0.0 && upper > 0.0));
+    let (q_b, q_b_inv) = if mmd_knee_plane {
+        (Quat::IDENTITY, Quat::IDENTITY)
+    } else {
+        match input.local_axis_basis {
+            Some(basis) if basis.is_finite() => (basis.normalize(), basis.normalize().inverse()),
+            _ => (Quat::IDENTITY, Quat::IDENTITY),
+        }
+    };
+    let base = input.base_rotations[input.link_index];
+    let local_target = if mmd_knee_plane && input.iteration == 0 {
+        (input.ik_rotations[input.link_index] * base)
+            .normalize()
+            .mul_vec3a(*input.local_target)
+    } else {
+        *input.local_target
+    };
     let local_eff_n = q_b_inv.mul_vec3a(*input.local_effector).normalize();
-    let local_tgt_n = q_b_inv.mul_vec3a(*input.local_target).normalize();
+    let local_tgt_n = q_b_inv.mul_vec3a(local_target).normalize();
 
     let dot = local_eff_n.dot(local_tgt_n).clamp(-1.0, 1.0);
     let raw_angle = dot.acos();
@@ -874,12 +911,6 @@ pub(crate) fn solve_plane_link_step(input: PlaneLinkStepInput<'_>) {
 
     let state = &mut input.chain_states[input.link_index];
     let mut next_angle = state.plane_mode_angle + signed_angle;
-    let (lower, upper) = match input.axis_index {
-        0 => (input.limits.min.x, input.limits.max.x),
-        1 => (input.limits.min.y, input.limits.max.y),
-        _ => (input.limits.min.z, input.limits.max.z),
-    };
-    let base = input.base_rotations[input.link_index];
 
     if input.iteration == 0 && (next_angle < lower || next_angle > upper) {
         if -next_angle > lower && -next_angle < upper {

--- a/crates/mmd-anim-runtime/src/runtime/ik.rs
+++ b/crates/mmd-anim-runtime/src/runtime/ik.rs
@@ -63,8 +63,16 @@ impl RuntimeInstance {
             self.update_world_matrices_after_ik_link_change(ik_index);
 
             let mut broke_early = false;
-            let mut final_distance = f32::MAX;
-            let mut best_distance = f32::MAX;
+            // The current local pose is the rollback floor. A constrained IK
+            // candidate can be worse than the authored FK pose, so the first
+            // full link pass must not become the best pose merely because it
+            // is the first finite distance observed.
+            let mut final_distance = {
+                let eff = translation(self.pose.world_matrices()[target_bone.as_usize()]);
+                let ik = translation(self.pose.world_matrices()[ik_bone.as_usize()]);
+                (eff - ik).length()
+            };
+            let mut best_distance = final_distance;
             for _iteration in 0..iteration_count {
                 let eff_pos = translation(self.pose.world_matrices()[target_bone.as_usize()]);
                 let ik_pos = translation(self.pose.world_matrices()[ik_bone.as_usize()]);

--- a/crates/mmd-anim-runtime/src/runtime/tests.rs
+++ b/crates/mmd-anim-runtime/src/runtime/tests.rs
@@ -411,6 +411,57 @@ fn solves_one_link_ik_toward_controller_bone() {
 }
 
 #[test]
+fn ik_rollback_preserves_better_fk_pose_than_limited_candidate() {
+    // The authored FK pose is intentionally outside the narrow IK angle box.
+    // Its effector is already almost at the controller, so clamping it toward
+    // the IK limits would be a worse candidate and must be rolled back.
+    let base_rotation = Quat::from_rotation_z(1.0);
+    let target_position = base_rotation.mul_vec3a(Vec3A::X) + Vec3A::new(0.01, 0.0, 0.0);
+    let angle_limit = IkAngleLimit::new(Vec3A::splat(-0.1), Vec3A::splat(0.1));
+    let model = Arc::new(
+        ModelArena::new_with_ik(
+            vec![
+                BoneInit::new(None, Vec3A::ZERO),
+                BoneInit::new(Some(BoneIndex(0)), Vec3A::X),
+                BoneInit::new(None, target_position),
+            ],
+            vec![IkSolverInit {
+                ik_bone: BoneIndex(2),
+                target_bone: BoneIndex(1),
+                links: vec![IkLinkInit::new(BoneIndex(0)).with_angle_limit(angle_limit)],
+                iteration_count: 1,
+                limit_angle: 0.0,
+            }],
+        )
+        .unwrap(),
+    );
+
+    let mut baseline = RuntimeInstance::new(Arc::clone(&model));
+    baseline
+        .pose_mut()
+        .set_local_rotation(BoneIndex(0), base_rotation);
+    baseline.evaluate_current_pose_without_ik();
+    let baseline_distance = (translation(baseline.world_matrices()[1])
+        - translation(baseline.world_matrices()[2]))
+    .length();
+
+    let mut solved = RuntimeInstance::new(model);
+    solved
+        .pose_mut()
+        .set_local_rotation(BoneIndex(0), base_rotation);
+    solved.evaluate_current_pose();
+    let solved_distance = (translation(solved.world_matrices()[1])
+        - translation(solved.world_matrices()[2]))
+    .length();
+
+    assert!(
+        solved_distance <= baseline_distance + 1.0e-5,
+        "IK must not replace a better FK pose: baseline={baseline_distance} solved={solved_distance}"
+    );
+    assert_eq!(solved.ik_runtime_stats()[0].rollback_breaks, 1);
+}
+
+#[test]
 fn skips_disabled_ik_solver() {
     let model = Arc::new(
         ModelArena::new_with_ik(
@@ -2404,6 +2455,39 @@ fn plane_link_step_matches_saba_total_axis_rotation() {
         Quat::from_rotation_z(std::f32::consts::FRAC_PI_2).mul_vec3a(Vec3A::X),
     );
     assert_vec3a_near(effective.mul_vec3a(Vec3A::Z), Vec3A::Z);
+}
+
+#[test]
+fn one_sided_x_plane_uses_authored_frame_not_pmx_local_axis() {
+    let base = Quat::from_rotation_x(-0.8);
+    let expected = Quat::from_rotation_x(-0.7);
+    let local_effector = Vec3A::new(0.0, -1.0, 0.0);
+    let parent_target = expected.mul_vec3a(local_effector);
+    let local_target = base.inverse().mul_vec3a(parent_target);
+    let base_rotations = vec![base];
+    let mut ik_rotations = vec![Quat::IDENTITY];
+    let mut chain_states = vec![super::ChainLinkState::default()];
+
+    super::solve_plane_link_step(super::PlaneLinkStepInput {
+        local_effector: &local_effector,
+        local_target: &local_target,
+        link_index: 0,
+        base_rotations: &base_rotations,
+        ik_rotations: &mut ik_rotations,
+        chain_states: &mut chain_states,
+        axis_index: 0,
+        limits: IkAngleLimit::new(
+            Vec3A::new(-std::f32::consts::PI, 0.0, 0.0),
+            Vec3A::new(-0.01, 0.0, 0.0),
+        ),
+        iteration: 0,
+        limit_angle: 0.0,
+        local_axis_basis: Some(Quat::from_rotation_z(std::f32::consts::FRAC_PI_2)),
+    });
+
+    let effective = (ik_rotations[0] * base).normalize();
+    assert_vec3a_near(effective.mul_vec3a(local_effector), parent_target);
+    assert_near(chain_states[0].plane_mode_angle, -0.7);
 }
 
 #[test]

--- a/crates/mmd-anim-wasm/Cargo.toml
+++ b/crates/mmd-anim-wasm/Cargo.toml
@@ -17,7 +17,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 glam.workspace = true
 mmd-anim-runtime.workspace = true
-mmd-anim-format = { path = "../mmd-anim-format", version = "0.4.0" }
+mmd-anim-format = { path = "../mmd-anim-format", version = "0.4.1" }
 wasm-bindgen.workspace = true
 js-sys.workspace = true
 serde.workspace = true


### PR DESCRIPTION
## Summary

- bump the workspace and internal dependency versions to `0.4.1`
- document the MMD one-sided knee IK parity fix
- document the experimental native physics-world bake-seed rearm API

## Why

`v0.4.0` does not contain the knee constraint correction or the native clip-switch rearm operation required by the Unity Timeline physics-world reuse path. This patch release publishes those already-merged fixes from `develop` and makes the native commit reachable to fresh submodule checkouts.

## Impact

- compatible one-sided knee links follow MMD's raw local-X constraint behavior and retain the authored pose as the rollback floor
- native hosts can reuse a model-compatible Bullet world across clips without paying the reset-settle path
- hosts must still rebuild the physics world when PMX compatibility is not guaranteed

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace` — 909 passed, 3 ignored
- `cargo doc --workspace --no-deps`
- `cargo check -p mmd-anim-wasm --target wasm32-unknown-unknown`
- `cargo build -p mmd-anim-ffi --release`
- `python tools/check_python_ffi_release.py` in VS x64 environment — C static assertions and 50 native Python tests passed
- `cargo check -p mmd-anim-physics-bullet --no-default-features`
- `cargo test -p mmd-anim-cli -p mmd-anim-ffi --no-default-features` — 273 passed, 1 ignored
- WASM harness `npm run build`
- package-content audit for all five published crates
- `cargo publish -p mmd-anim-runtime --dry-run`
- independent Codex review — no findings; simplicity neutral

Dependent crate publish dry-runs remain intentionally deferred until `mmd-anim-runtime 0.4.1` is visible in the crates.io index, matching the release checklist.