### PR TITLE
chore(release): prepare v0.4.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7.0.1
 
       - name: Install Rust
         run: |
@@ -47,16 +47,28 @@ jobs:
         os: [ubuntu-latest, windows-latest]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7.0.1
 
       - name: Install Rust
         run: |
           rustup toolchain install stable --profile minimal
           rustup default stable
 
-      - name: Configure MSVC developer environment
-        if: runner.os == 'Windows'
-        uses: ilammy/msvc-dev-cmd@v1
-
-      - name: Run shared native Python/C ABI release gate
+      - name: Run shared native Python/C ABI release gate (Unix)
+        if: runner.os != 'Windows'
         run: python tools/check_python_ffi_release.py
+
+      - name: Run shared native Python/C ABI release gate (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $vswhere = Join-Path ${env:ProgramFiles(x86)} 'Microsoft Visual Studio\Installer\vswhere.exe'
+          $installPath = & $vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
+          if (-not $installPath) {
+            throw 'Visual Studio with the x64 C++ toolchain was not found.'
+          }
+          & (Join-Path $installPath 'Common7\Tools\Launch-VsDevShell.ps1') -Arch amd64 -HostArch amd64 -SkipAutomaticLocation
+          python tools/check_python_ffi_release.py
+          if ($LASTEXITCODE -ne 0) {
+            exit $LASTEXITCODE
+          }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,47 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7.0.1
+
+      - name: Verify release tag matches package versions
+        if: startsWith(github.ref, 'refs/tags/v')
+        shell: bash
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          import subprocess
+
+          expected = os.environ["GITHUB_REF_NAME"].removeprefix("v")
+          metadata = json.loads(
+              subprocess.check_output(
+                  ["cargo", "metadata", "--no-deps", "--format-version", "1"],
+                  text=True,
+              )
+          )
+          published = {
+              "mmd-anim-runtime",
+              "mmd-anim-format",
+              "mmd-anim-physics-bullet",
+              "mmd-anim",
+              "mmd-anim-cli",
+          }
+          versions = {
+              package["name"]: package["version"]
+              for package in metadata["packages"]
+              if package["name"] in published
+          }
+          mismatches = {
+              name: version
+              for name, version in versions.items()
+              if version != expected
+          }
+          if versions.keys() != published or mismatches:
+              raise SystemExit(
+                  f"release tag {expected!r} does not match package versions: "
+                  f"found={versions!r}, mismatches={mismatches!r}"
+              )
+          PY
 
       - name: Install Rust
         run: |
@@ -77,7 +117,7 @@ jobs:
             archive: mmd-anim-${{ github.ref_name }}-x86_64-pc-windows-msvc.zip
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7.0.1
 
       - name: Install Rust
         run: |
@@ -119,7 +159,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7.0.1
 
       - name: Install Rust
         run: |
@@ -161,7 +201,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7.0.1
 
       - name: Download CLI artifacts
         uses: actions/download-artifact@v4
@@ -211,14 +251,22 @@ jobs:
 
   publish:
     name: Publish crates.io packages
-    needs: checks
+    needs: [checks, build-cli, build-cli-macos-universal]
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.publish)
+    if: >-
+      always() &&
+      needs.checks.result == 'success' &&
+      (
+        (github.event_name == 'push' &&
+         needs.build-cli.result == 'success' &&
+         needs.build-cli-macos-universal.result == 'success') ||
+        (github.event_name == 'workflow_dispatch' && inputs.publish)
+      )
     env:
       CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7.0.1
 
       - name: Install Rust
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- Added the native `mmd_runtime_export_vmd_from_parts` C ABI. It validates
+  typed Bone/Morph SoA input and low-density metadata, then returns an owned
+  complete VMD 0002 buffer without performing file I/O.
+
 ## 0.4.1 - 2026-08-13
 
 Improved MMD knee IK parity and clip-switch physics reuse for native hosts.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,22 @@
 # Changelog
 
-## Unreleased
+## 0.4.2 - 2026-08-21
+
+Added native VMD export from typed Bone/Morph SoA data for Maya and other
+native hosts.
 
 ### Added
 
 - Added the native `mmd_runtime_export_vmd_from_parts` C ABI. It validates
   typed Bone/Morph SoA input and low-density metadata, then returns an owned
   complete VMD 0002 buffer without performing file I/O.
+
+### Known limitations
+
+- The native API materializes validated SoA data through the existing VMD
+  writer; streaming export and key reduction remain separate work.
+- The C ABI, WASM wrapper, PMM document conversion, and Python binding remain
+  experimental and may change before 1.0.
 
 ## 0.4.1 - 2026-08-13
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -372,7 +372,7 @@ checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "mmd-anim"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "mmd-anim-format",
  "mmd-anim-runtime",
@@ -381,7 +381,7 @@ dependencies = [
 
 [[package]]
 name = "mmd-anim-cli"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -397,7 +397,7 @@ dependencies = [
 
 [[package]]
 name = "mmd-anim-ffi"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "glam",
  "mmd-anim-format",
@@ -409,7 +409,7 @@ dependencies = [
 
 [[package]]
 name = "mmd-anim-format"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "encoding_rs",
  "fbxcel",
@@ -422,7 +422,7 @@ dependencies = [
 
 [[package]]
 name = "mmd-anim-physics-bullet"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "cc",
  "glam",
@@ -434,7 +434,7 @@ dependencies = [
 
 [[package]]
 name = "mmd-anim-runtime"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "glam",
  "rayon",
@@ -443,7 +443,7 @@ dependencies = [
 
 [[package]]
 name = "mmd-anim-wasm"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "glam",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.4.1"
+version = "0.4.2"
 edition = "2024"
 rust-version = "1.87"
 license = "MIT"
@@ -30,6 +30,6 @@ serde_json = "1.0.145"
 wasm-bindgen = "0.2.105"
 js-sys = "0.3"
 encoding_rs = "0.8"
-mmd-anim-runtime = { path = "crates/mmd-anim-runtime", version = "0.4.1" }
-mmd-anim-format = { path = "crates/mmd-anim-format", version = "0.4.1" }
+mmd-anim-runtime = { path = "crates/mmd-anim-runtime", version = "0.4.2" }
+mmd-anim-format = { path = "crates/mmd-anim-format", version = "0.4.2" }
  

--- a/README.md
+++ b/README.md
@@ -91,6 +91,13 @@ It is not tied to a specific engine; any host that can call a C ABI can use it
 (Unity is one example).
 The header is [crates/mmd-anim-ffi/include/mmd_runtime.h](crates/mmd-anim-ffi/include/mmd_runtime.h).
 
+For native VMD export, `mmd_runtime_export_vmd_from_parts` accepts typed
+Bone/Morph SoA arrays plus JSON metadata for names and low-density camera,
+light, self-shadow, and property/IK sections. The function performs no file
+I/O and returns an owned VMD 0002 byte buffer; release it with
+`mmd_runtime_byte_buffer_free`. High-density key values are not expanded into
+the metadata JSON.
+
 ```c
 // 1. Create a model from PMX bytes
 mmd_runtime_model_t* model =

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Format support overview. "Loading" means parsing a file into structured data.
 
 ```toml
 [dependencies]
-mmd-anim = "0.4.1"
+mmd-anim = "0.4.2"
 ```
 
 ## Native Hosts (C ABI)

--- a/crates/mmd-anim-cli/Cargo.toml
+++ b/crates/mmd-anim-cli/Cargo.toml
@@ -26,8 +26,8 @@ clap = { version = "4", features = ["derive"] }
 clap_complete = "4"
 glam.workspace = true
 mmd-anim-runtime.workspace = true
-mmd-anim-format = { path = "../mmd-anim-format", version = "0.4.1", features = ["fbx"] }
-mmd-anim-physics-bullet = { path = "../mmd-anim-physics-bullet", version = "0.4.1", features = ["native", "pmx-format", "runtime"], optional = true }
+mmd-anim-format = { path = "../mmd-anim-format", version = "0.4.2", features = ["fbx"] }
+mmd-anim-physics-bullet = { path = "../mmd-anim-physics-bullet", version = "0.4.2", features = ["native", "pmx-format", "runtime"], optional = true }
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true

--- a/crates/mmd-anim-ffi/Cargo.toml
+++ b/crates/mmd-anim-ffi/Cargo.toml
@@ -18,8 +18,8 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 glam.workspace = true
 mmd-anim-runtime.workspace = true
-mmd-anim-format = { path = "../mmd-anim-format", version = "0.4.1", features = ["fbx"] }
-mmd-anim-physics-bullet = { path = "../mmd-anim-physics-bullet", version = "0.4.1", optional = true, features = ["native", "runtime", "pmx-format"] }
+mmd-anim-format = { path = "../mmd-anim-format", version = "0.4.2", features = ["fbx"] }
+mmd-anim-physics-bullet = { path = "../mmd-anim-physics-bullet", version = "0.4.2", optional = true, features = ["native", "runtime", "pmx-format"] }
 serde.workspace = true
 serde_json.workspace = true
 

--- a/crates/mmd-anim-ffi/include/mmd_runtime.h
+++ b/crates/mmd-anim-ffi/include/mmd_runtime.h
@@ -1409,6 +1409,31 @@ mmd_runtime_ffi_byte_buffer_t mmd_runtime_export_pmx_from_parts(
     const float*   skin_weights,
     const float*   edge_scale);
 
+/* Builds a complete VMD 0002 byte stream from low-density metadata and
+   caller-owned typed Bone/Morph SoA arrays. No file I/O is performed and the
+   returned Rust-owned buffer must be freed with mmd_runtime_byte_buffer_free.
+   Every pointer is nullable only when its paired length is zero; all lengths
+   are explicit so hosts can validate their SoA layout before the call. */
+mmd_runtime_ffi_byte_buffer_t mmd_runtime_export_vmd_from_parts(
+    const uint8_t* metadata_json,
+    size_t         metadata_json_len,
+    const uint32_t* bone_name_indices,
+    size_t         bone_name_index_count,
+    const uint32_t* bone_frames,
+    size_t         bone_frame_count,
+    const float*   bone_translations_xyz,
+    size_t         bone_translation_f32_len,
+    const float*   bone_rotations_xyzw,
+    size_t         bone_rotation_f32_len,
+    const uint8_t* bone_interpolations,
+    size_t         bone_interpolation_u8_len,
+    const uint32_t* morph_name_indices,
+    size_t         morph_name_index_count,
+    const uint32_t* morph_frames,
+    size_t         morph_frame_count,
+    const float*   morph_weights,
+    size_t         morph_weight_count);
+
 /* The PMX-paired constructor resolves names through the imported model and
    applies MMD registration semantics, including fixed-axis projection and
    the registered 64-byte VMD interpolation layout. */

--- a/crates/mmd-anim-ffi/src/lib.rs
+++ b/crates/mmd-anim-ffi/src/lib.rs
@@ -1036,6 +1036,7 @@ const FFI_ERR_PMX_IMPORT_FAILED: &str = "pmx import failed";
 const FFI_ERR_VMD_IMPORT_FAILED: &str = "vmd import failed";
 const FFI_ERR_CLIP_CREATE_FAILED: &str = "clip create failed";
 const FFI_ERR_PMX_EXPORT_FAILED: &str = "pmx export failed";
+const FFI_ERR_VMD_EXPORT_FAILED: &str = "vmd export failed";
 const FFI_ERR_JSON_ENCODE_FAILED: &str = "json encode failed";
 const FFI_ERR_WORKER_PANIC: &str = "worker panic";
 
@@ -4683,6 +4684,175 @@ pub unsafe extern "C" fn mmd_runtime_export_pmx_from_parts(
             };
         byte_buffer_from_vec(mmd_anim_format::export_pmx_model(&model))
     })
+}
+
+/// Exports a VMD from converted typed SoA channels and low-density metadata.
+///
+/// # Safety
+///
+/// Each non-null pointer must reference the number of readable elements given
+/// by its paired length for the duration of this call, and must be aligned for
+/// its element type. A pointer may be null only when its length is zero. The
+/// returned buffer is owned by the caller and must be released with
+/// `mmd_runtime_byte_buffer_free`; no input pointer is retained.
+#[unsafe(no_mangle)]
+#[allow(clippy::too_many_arguments)]
+pub unsafe extern "C" fn mmd_runtime_export_vmd_from_parts(
+    metadata_json: *const u8,
+    metadata_json_len: usize,
+    bone_name_indices: *const u32,
+    bone_name_index_count: usize,
+    bone_frames: *const u32,
+    bone_frame_count: usize,
+    bone_translations_xyz: *const f32,
+    bone_translation_f32_len: usize,
+    bone_rotations_xyzw: *const f32,
+    bone_rotation_f32_len: usize,
+    bone_interpolations: *const u8,
+    bone_interpolation_u8_len: usize,
+    morph_name_indices: *const u32,
+    morph_name_index_count: usize,
+    morph_frames: *const u32,
+    morph_frame_count: usize,
+    morph_weights: *const f32,
+    morph_weight_count: usize,
+) -> MmdRuntimeFfiByteBuffer {
+    ffi_guard(empty_byte_buffer(), || {
+        if metadata_json.is_null() || metadata_json_len == 0 {
+            return empty_byte_buffer_failure(FFI_ERR_INVALID_INPUT);
+        }
+        if bone_frame_count != bone_name_index_count || morph_frame_count != morph_name_index_count
+        {
+            return empty_byte_buffer_failure(FFI_ERR_INVALID_INPUT);
+        }
+        let Some(expected_translation_len) = bone_name_index_count.checked_mul(3) else {
+            return empty_byte_buffer_failure(FFI_ERR_INVALID_INPUT);
+        };
+        let Some(expected_rotation_len) = bone_name_index_count.checked_mul(4) else {
+            return empty_byte_buffer_failure(FFI_ERR_INVALID_INPUT);
+        };
+        let Some(expected_interpolation_len) = bone_name_index_count.checked_mul(64) else {
+            return empty_byte_buffer_failure(FFI_ERR_INVALID_INPUT);
+        };
+        if bone_translation_f32_len != expected_translation_len
+            || bone_rotation_f32_len != expected_rotation_len
+            || bone_interpolation_u8_len != expected_interpolation_len
+            || morph_weight_count != morph_name_index_count
+            || bone_name_index_count > u32::MAX as usize
+            || morph_name_index_count > u32::MAX as usize
+        {
+            return empty_byte_buffer_failure(FFI_ERR_INVALID_INPUT);
+        }
+
+        // Validate every pointer's nullability, alignment, and slice
+        // addressability before creating any slice. Readability of the
+        // pointed-to allocation remains the caller's documented C contract.
+        if !ffi_slice_valid(metadata_json, metadata_json_len)
+            || !ffi_slice_valid(bone_name_indices, bone_name_index_count)
+            || !ffi_slice_valid(bone_frames, bone_frame_count)
+            || !ffi_slice_valid(bone_translations_xyz, bone_translation_f32_len)
+            || !ffi_slice_valid(bone_rotations_xyzw, bone_rotation_f32_len)
+            || !ffi_slice_valid(bone_interpolations, bone_interpolation_u8_len)
+            || !ffi_slice_valid(morph_name_indices, morph_name_index_count)
+            || !ffi_slice_valid(morph_frames, morph_frame_count)
+            || !ffi_slice_valid(morph_weights, morph_weight_count)
+        {
+            return empty_byte_buffer_failure(FFI_ERR_INVALID_INPUT);
+        }
+        let Some(metadata_bytes) = (unsafe { ffi_checked_slice(metadata_json, metadata_json_len) })
+        else {
+            return empty_byte_buffer_failure(FFI_ERR_INVALID_INPUT);
+        };
+        let Some(bone_name_indices) =
+            (unsafe { ffi_checked_slice(bone_name_indices, bone_name_index_count) })
+        else {
+            return empty_byte_buffer_failure(FFI_ERR_INVALID_INPUT);
+        };
+        let Some(bone_frames) = (unsafe { ffi_checked_slice(bone_frames, bone_frame_count) })
+        else {
+            return empty_byte_buffer_failure(FFI_ERR_INVALID_INPUT);
+        };
+        let Some(bone_translations_xyz) =
+            (unsafe { ffi_checked_slice(bone_translations_xyz, bone_translation_f32_len) })
+        else {
+            return empty_byte_buffer_failure(FFI_ERR_INVALID_INPUT);
+        };
+        let Some(bone_rotations_xyzw) =
+            (unsafe { ffi_checked_slice(bone_rotations_xyzw, bone_rotation_f32_len) })
+        else {
+            return empty_byte_buffer_failure(FFI_ERR_INVALID_INPUT);
+        };
+        let Some(bone_interpolations) =
+            (unsafe { ffi_checked_slice(bone_interpolations, bone_interpolation_u8_len) })
+        else {
+            return empty_byte_buffer_failure(FFI_ERR_INVALID_INPUT);
+        };
+        let Some(morph_name_indices) =
+            (unsafe { ffi_checked_slice(morph_name_indices, morph_name_index_count) })
+        else {
+            return empty_byte_buffer_failure(FFI_ERR_INVALID_INPUT);
+        };
+        let Some(morph_frames) = (unsafe { ffi_checked_slice(morph_frames, morph_frame_count) })
+        else {
+            return empty_byte_buffer_failure(FFI_ERR_INVALID_INPUT);
+        };
+        let Some(morph_weights) = (unsafe { ffi_checked_slice(morph_weights, morph_weight_count) })
+        else {
+            return empty_byte_buffer_failure(FFI_ERR_INVALID_INPUT);
+        };
+
+        let metadata_json = match str::from_utf8(metadata_bytes) {
+            Ok(json) => json,
+            Err(_) => return empty_byte_buffer_failure(FFI_ERR_INVALID_INPUT),
+        };
+        let descriptor: mmd_anim_format::VmdPartsDescriptor =
+            match serde_json::from_str(metadata_json) {
+                Ok(descriptor) => descriptor,
+                Err(_) => return empty_byte_buffer_failure(FFI_ERR_INVALID_INPUT),
+            };
+        if descriptor.schema != "mmd-anim-vmd-parts" || descriptor.version != 1 {
+            return empty_byte_buffer_failure(FFI_ERR_INVALID_INPUT);
+        }
+        let animation =
+            match mmd_anim_format::build_vmd_animation_from_parts(mmd_anim_format::VmdPartsInput {
+                descriptor,
+                bone_name_indices,
+                bone_frames,
+                bone_translations_xyz,
+                bone_rotations_xyzw,
+                bone_interpolations,
+                morph_name_indices,
+                morph_frames,
+                morph_weights,
+            }) {
+                Ok(animation) => animation,
+                Err(_) => return empty_byte_buffer_failure(FFI_ERR_VMD_EXPORT_FAILED),
+            };
+        byte_buffer_from_vec(mmd_anim_format::export_vmd_animation(&animation))
+    })
+}
+
+unsafe fn ffi_checked_slice<'a, T>(ptr: *const T, len: usize) -> Option<&'a [T]> {
+    if len == 0 {
+        return Some(&[]);
+    }
+    if ptr.is_null()
+        || !(ptr as usize).is_multiple_of(std::mem::align_of::<T>())
+        || len > isize::MAX as usize / std::mem::size_of::<T>()
+    {
+        return None;
+    }
+    // SAFETY: the caller's C contract guarantees that this pointer is live and
+    // readable for `len` elements; the checks above establish null, alignment,
+    // and addressable-slice preconditions before constructing the borrow.
+    Some(unsafe { slice::from_raw_parts(ptr, len) })
+}
+
+fn ffi_slice_valid<T>(ptr: *const T, len: usize) -> bool {
+    len == 0
+        || (!ptr.is_null()
+            && (ptr as usize).is_multiple_of(std::mem::align_of::<T>())
+            && len <= isize::MAX as usize / std::mem::size_of::<T>())
 }
 
 macro_rules! create_runtime_model_ffi {

--- a/crates/mmd-anim-ffi/src/tests.rs
+++ b/crates/mmd-anim-ffi/src/tests.rs
@@ -34,6 +34,446 @@ fn last_error_message_survives_read_without_clearing() {
 }
 
 #[test]
+fn vmd_from_parts_returns_owned_buffer_and_rejects_schema_mismatch() {
+    let metadata = r#"{
+        "schema":"mmd-anim-vmd-parts",
+        "version":1,
+        "modelName":"parts",
+        "modelNameBytes":[],
+        "boneNames":[{"name":"センター","nameBytes":[]}],
+        "morphNames":[{"name":"笑い","nameBytes":[]}],
+        "cameraFrames":[{"frame":12,"distance":4.5,"position":[1.0,2.0,3.0],"rotation":[0.1,0.2,0.3],"interpolation":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24],"fov":45,"perspective":false}],
+        "lightFrames":[{"frame":13,"color":[0.1,0.2,0.3],"direction":[0.0,1.0,0.0]}],
+        "selfShadowFrames":[{"frame":14,"mode":1,"distance":0.25}],
+        "propertyFrames":[{"frame":15,"visible":true,"ikStates":[{"boneName":"IK","boneNameBytes":[73,75],"enabled":false}]}]
+    }"#;
+    let bone_names = [0u32];
+    let bone_frames = [7u32];
+    let translations = [1.0f32, 2.0, 3.0];
+    let rotations = [0.0f32, 0.0, 0.0, 1.0];
+    let interpolation = [0x5au8; 64];
+    let morph_names = [0u32];
+    let morph_frames = [9u32];
+    let weights = [0.75f32];
+    let buffer = unsafe {
+        mmd_runtime_export_vmd_from_parts(
+            metadata.as_ptr(),
+            metadata.len(),
+            bone_names.as_ptr(),
+            bone_names.len(),
+            bone_frames.as_ptr(),
+            bone_frames.len(),
+            translations.as_ptr(),
+            translations.len(),
+            rotations.as_ptr(),
+            rotations.len(),
+            interpolation.as_ptr(),
+            interpolation.len(),
+            morph_names.as_ptr(),
+            morph_names.len(),
+            morph_frames.as_ptr(),
+            morph_frames.len(),
+            weights.as_ptr(),
+            weights.len(),
+        )
+    };
+    assert!(!buffer.data.is_null());
+    assert!(buffer.len > 50);
+    let bytes = unsafe { std::slice::from_raw_parts(buffer.data, buffer.len) };
+    let parsed = mmd_anim_format::parse_vmd_animation(bytes).expect("valid VMD output");
+    assert_eq!(parsed.bone_frames[0].frame, 7);
+    assert_eq!(parsed.bone_frames[0].interpolation, interpolation.to_vec());
+    assert_eq!(parsed.morph_frames[0].frame, 9);
+    assert_eq!(parsed.morph_frames[0].weight, 0.75);
+    assert_eq!(parsed.camera_frames[0].frame, 12);
+    assert_eq!(
+        parsed.camera_frames[0].interpolation,
+        [
+            1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24
+        ]
+    );
+    assert!(!parsed.camera_frames[0].perspective);
+    assert_eq!(parsed.light_frames[0].color, [0.1, 0.2, 0.3]);
+    assert_eq!(parsed.self_shadow_frames[0].distance, 0.25);
+    assert!(parsed.property_frames[0].visible);
+    assert!(!parsed.property_frames[0].ik_states[0].enabled);
+    unsafe { mmd_runtime_byte_buffer_free(buffer) };
+
+    let bad_metadata = r#"{
+        "schema":"wrong", "version":1, "modelName":"parts", "modelNameBytes":[],
+        "boneNames":[], "morphNames":[], "cameraFrames":[], "lightFrames":[],
+        "selfShadowFrames":[], "propertyFrames":[]
+    }"#;
+    let empty = unsafe {
+        mmd_runtime_export_vmd_from_parts(
+            bad_metadata.as_ptr(),
+            bad_metadata.len(),
+            std::ptr::null(),
+            0,
+            std::ptr::null(),
+            0,
+            std::ptr::null(),
+            0,
+            std::ptr::null(),
+            0,
+            std::ptr::null(),
+            0,
+            std::ptr::null(),
+            0,
+            std::ptr::null(),
+            0,
+            std::ptr::null(),
+            0,
+        )
+    };
+    assert!(empty.data.is_null());
+    assert_eq!(empty.len, 0);
+    assert_eq!(
+        last_error_cstr().unwrap().to_bytes(),
+        FFI_ERR_INVALID_INPUT.as_bytes()
+    );
+    unsafe { mmd_runtime_byte_buffer_free(empty) };
+
+    let empty_metadata = br#"{"schema":"mmd-anim-vmd-parts","version":1,"modelName":"empty","modelNameBytes":[],"boneNames":[],"morphNames":[],"cameraFrames":[],"lightFrames":[],"selfShadowFrames":[],"propertyFrames":[]}"#;
+    let empty_animation = unsafe {
+        mmd_runtime_export_vmd_from_parts(
+            empty_metadata.as_ptr(),
+            empty_metadata.len(),
+            std::ptr::null(),
+            0,
+            std::ptr::null(),
+            0,
+            std::ptr::null(),
+            0,
+            std::ptr::null(),
+            0,
+            std::ptr::null(),
+            0,
+            std::ptr::null(),
+            0,
+            std::ptr::null(),
+            0,
+            std::ptr::null(),
+            0,
+        )
+    };
+    assert!(!empty_animation.data.is_null());
+    let empty_bytes =
+        unsafe { std::slice::from_raw_parts(empty_animation.data, empty_animation.len) };
+    let empty_parsed = mmd_anim_format::parse_vmd_animation(empty_bytes).unwrap();
+    assert!(empty_parsed.bone_frames.is_empty());
+    assert!(empty_parsed.morph_frames.is_empty());
+    assert!(empty_parsed.camera_frames.is_empty());
+    assert!(empty_parsed.light_frames.is_empty());
+    assert!(empty_parsed.self_shadow_frames.is_empty());
+    assert!(empty_parsed.property_frames.is_empty());
+    unsafe { mmd_runtime_byte_buffer_free(empty_animation) };
+}
+
+#[test]
+fn vmd_from_parts_rejects_null_mismatch_nonfinite_and_bad_index() {
+    let metadata = br#"{"schema":"mmd-anim-vmd-parts","version":1,"modelName":"x","modelNameBytes":[],"boneNames":[{"name":"x","nameBytes":[]}],"morphNames":[],"cameraFrames":[],"lightFrames":[],"selfShadowFrames":[],"propertyFrames":[]}"#;
+    for invalid_metadata in [
+        br#"{"schema":"mmd-anim-vmd-parts","version":1,"modelName":"x","modelNameBytes":[],"boneNames":[],"morphNames":[],"cameraFrames":[],"lightFrames":[],"selfShadowFrames":[],"propertyFrames":[],"unknown":1}"#.as_slice(),
+        br#"not json"#.as_slice(),
+    ] {
+        let failed = unsafe {
+            mmd_runtime_export_vmd_from_parts(
+                invalid_metadata.as_ptr(),
+                invalid_metadata.len(),
+                std::ptr::null(),
+                0,
+                std::ptr::null(),
+                0,
+                std::ptr::null(),
+                0,
+                std::ptr::null(),
+                0,
+                std::ptr::null(),
+                0,
+                std::ptr::null(),
+                0,
+                std::ptr::null(),
+                0,
+                std::ptr::null(),
+                0,
+            )
+        };
+        assert!(failed.data.is_null());
+        assert_eq!(last_error_cstr().unwrap().to_bytes(), FFI_ERR_INVALID_INPUT.as_bytes());
+        unsafe { mmd_runtime_byte_buffer_free(failed) };
+    }
+    let empty = unsafe {
+        mmd_runtime_export_vmd_from_parts(
+            std::ptr::null(),
+            metadata.len(),
+            std::ptr::null(),
+            0,
+            std::ptr::null(),
+            0,
+            std::ptr::null(),
+            0,
+            std::ptr::null(),
+            0,
+            std::ptr::null(),
+            0,
+            std::ptr::null(),
+            0,
+            std::ptr::null(),
+            0,
+            std::ptr::null(),
+            0,
+        )
+    };
+    assert!(empty.data.is_null());
+    assert_eq!(
+        last_error_cstr().unwrap().to_bytes(),
+        FFI_ERR_INVALID_INPUT.as_bytes()
+    );
+    unsafe { mmd_runtime_byte_buffer_free(empty) };
+
+    let names = [0u32];
+    let frames = [1u32];
+    let translations = [0.0f32, 0.0, 0.0];
+    let rotations = [0.0f32, 0.0, 0.0, 1.0];
+    let interpolation = [0u8; 64];
+    let mismatch = unsafe {
+        mmd_runtime_export_vmd_from_parts(
+            metadata.as_ptr(),
+            metadata.len(),
+            names.as_ptr(),
+            1,
+            frames.as_ptr(),
+            1,
+            translations.as_ptr(),
+            2,
+            rotations.as_ptr(),
+            rotations.len(),
+            interpolation.as_ptr(),
+            interpolation.len(),
+            std::ptr::null(),
+            0,
+            std::ptr::null(),
+            0,
+            std::ptr::null(),
+            0,
+        )
+    };
+    assert!(mismatch.data.is_null());
+    assert_eq!(
+        last_error_cstr().unwrap().to_bytes(),
+        FFI_ERR_INVALID_INPUT.as_bytes()
+    );
+    let null_typed = unsafe {
+        mmd_runtime_export_vmd_from_parts(
+            metadata.as_ptr(),
+            metadata.len(),
+            names.as_ptr(),
+            1,
+            frames.as_ptr(),
+            1,
+            std::ptr::null(),
+            3,
+            rotations.as_ptr(),
+            rotations.len(),
+            interpolation.as_ptr(),
+            interpolation.len(),
+            std::ptr::null(),
+            0,
+            std::ptr::null(),
+            0,
+            std::ptr::null(),
+            0,
+        )
+    };
+    assert!(null_typed.data.is_null());
+    assert_eq!(
+        last_error_cstr().unwrap().to_bytes(),
+        FFI_ERR_INVALID_INPUT.as_bytes()
+    );
+    unsafe { mmd_runtime_byte_buffer_free(null_typed) };
+
+    let mut misaligned_storage = [0u8; 16];
+    let misaligned_f32 = unsafe { misaligned_storage.as_mut_ptr().add(1) as *const f32 };
+    let misaligned = unsafe {
+        mmd_runtime_export_vmd_from_parts(
+            metadata.as_ptr(),
+            metadata.len(),
+            names.as_ptr(),
+            1,
+            frames.as_ptr(),
+            1,
+            misaligned_f32,
+            3,
+            rotations.as_ptr(),
+            rotations.len(),
+            interpolation.as_ptr(),
+            interpolation.len(),
+            std::ptr::null(),
+            0,
+            std::ptr::null(),
+            0,
+            std::ptr::null(),
+            0,
+        )
+    };
+    assert!(misaligned.data.is_null());
+    assert_eq!(
+        last_error_cstr().unwrap().to_bytes(),
+        FFI_ERR_INVALID_INPUT.as_bytes()
+    );
+    unsafe { mmd_runtime_byte_buffer_free(misaligned) };
+
+    let overflow = unsafe {
+        mmd_runtime_export_vmd_from_parts(
+            metadata.as_ptr(),
+            metadata.len(),
+            std::ptr::null(),
+            usize::MAX,
+            std::ptr::null(),
+            usize::MAX,
+            std::ptr::null(),
+            0,
+            std::ptr::null(),
+            0,
+            std::ptr::null(),
+            0,
+            std::ptr::null(),
+            0,
+            std::ptr::null(),
+            0,
+            std::ptr::null(),
+            0,
+        )
+    };
+    assert!(overflow.data.is_null());
+    assert_eq!(
+        last_error_cstr().unwrap().to_bytes(),
+        FFI_ERR_INVALID_INPUT.as_bytes()
+    );
+    unsafe { mmd_runtime_byte_buffer_free(overflow) };
+
+    let nan = [f32::NAN, 0.0, 0.0];
+    let failed = unsafe {
+        mmd_runtime_export_vmd_from_parts(
+            metadata.as_ptr(),
+            metadata.len(),
+            names.as_ptr(),
+            1,
+            frames.as_ptr(),
+            1,
+            nan.as_ptr(),
+            nan.len(),
+            rotations.as_ptr(),
+            rotations.len(),
+            interpolation.as_ptr(),
+            interpolation.len(),
+            std::ptr::null(),
+            0,
+            std::ptr::null(),
+            0,
+            std::ptr::null(),
+            0,
+        )
+    };
+    assert!(failed.data.is_null());
+    assert_eq!(
+        last_error_cstr().unwrap().to_bytes(),
+        FFI_ERR_VMD_EXPORT_FAILED.as_bytes()
+    );
+
+    let infinite_rotation = [f32::INFINITY, 0.0, 0.0, 1.0];
+    let failed = unsafe {
+        mmd_runtime_export_vmd_from_parts(
+            metadata.as_ptr(),
+            metadata.len(),
+            names.as_ptr(),
+            1,
+            frames.as_ptr(),
+            1,
+            translations.as_ptr(),
+            translations.len(),
+            infinite_rotation.as_ptr(),
+            infinite_rotation.len(),
+            interpolation.as_ptr(),
+            interpolation.len(),
+            std::ptr::null(),
+            0,
+            std::ptr::null(),
+            0,
+            std::ptr::null(),
+            0,
+        )
+    };
+    assert!(failed.data.is_null());
+    assert_eq!(
+        last_error_cstr().unwrap().to_bytes(),
+        FFI_ERR_VMD_EXPORT_FAILED.as_bytes()
+    );
+
+    let morph_names = [0u32];
+    let morph_frames = [2u32];
+    let infinite_weight = [f32::INFINITY];
+    let morph_metadata = br#"{"schema":"mmd-anim-vmd-parts","version":1,"modelName":"x","modelNameBytes":[],"boneNames":[],"morphNames":[{"name":"m","nameBytes":[]}],"cameraFrames":[],"lightFrames":[],"selfShadowFrames":[],"propertyFrames":[]}"#;
+    let failed = unsafe {
+        mmd_runtime_export_vmd_from_parts(
+            morph_metadata.as_ptr(),
+            morph_metadata.len(),
+            std::ptr::null(),
+            0,
+            std::ptr::null(),
+            0,
+            std::ptr::null(),
+            0,
+            std::ptr::null(),
+            0,
+            std::ptr::null(),
+            0,
+            morph_names.as_ptr(),
+            morph_names.len(),
+            morph_frames.as_ptr(),
+            morph_frames.len(),
+            infinite_weight.as_ptr(),
+            infinite_weight.len(),
+        )
+    };
+    assert!(failed.data.is_null());
+    assert_eq!(
+        last_error_cstr().unwrap().to_bytes(),
+        FFI_ERR_VMD_EXPORT_FAILED.as_bytes()
+    );
+
+    let bad_index = [1u32];
+    let failed = unsafe {
+        mmd_runtime_export_vmd_from_parts(
+            metadata.as_ptr(),
+            metadata.len(),
+            bad_index.as_ptr(),
+            1,
+            frames.as_ptr(),
+            1,
+            translations.as_ptr(),
+            translations.len(),
+            rotations.as_ptr(),
+            rotations.len(),
+            interpolation.as_ptr(),
+            interpolation.len(),
+            std::ptr::null(),
+            0,
+            std::ptr::null(),
+            0,
+            std::ptr::null(),
+            0,
+        )
+    };
+    assert!(failed.data.is_null());
+    assert_eq!(
+        last_error_cstr().unwrap().to_bytes(),
+        FFI_ERR_VMD_EXPORT_FAILED.as_bytes()
+    );
+}
+
+#[test]
 fn failing_ffi_parse_sets_last_error_message() {
     let garbage = [0u8; 16];
     let buf = unsafe { mmd_runtime_parse_vmd_json(garbage.as_ptr(), garbage.len()) };

--- a/crates/mmd-anim-format/src/lib.rs
+++ b/crates/mmd-anim-format/src/lib.rs
@@ -45,11 +45,12 @@ pub use pmx::{
 };
 pub use vmd::{
     VmdCameraState, VmdClipBuildError, VmdClipBuildOptions, VmdExportMorphKind, VmdExportName,
-    VmdIkEntry, VmdImportResult, VmdLightState, VmdParsedAnimation, VmdPoseExport,
-    VmdPoseExportBindings, VmdPoseExportError, VmdPoseExportReport, VmdPropertyIkFrame,
-    VmdSelfShadowState, build_clip_from_import, build_mmd_registered_pair_clip,
-    build_mmd_registered_pair_clip_with_options, build_pair_clip, build_pair_clip_with_options,
-    build_property_binding_with_ik_resolver, export_reduced_pose_to_vmd, export_vmd_animation,
+    VmdIkEntry, VmdImportResult, VmdLightState, VmdParsedAnimation, VmdPartsDescriptor,
+    VmdPartsInput, VmdPartsNameEntry, VmdPoseExport, VmdPoseExportBindings, VmdPoseExportError,
+    VmdPoseExportReport, VmdPropertyIkFrame, VmdSelfShadowState, build_clip_from_import,
+    build_mmd_registered_pair_clip, build_mmd_registered_pair_clip_with_options, build_pair_clip,
+    build_pair_clip_with_options, build_property_binding_with_ik_resolver,
+    build_vmd_animation_from_parts, export_reduced_pose_to_vmd, export_vmd_animation,
     import_vmd_motion, parse_vmd_animation, sample_vmd_camera_frames, sample_vmd_light_frames,
     sample_vmd_self_shadow_frames,
 };

--- a/crates/mmd-anim-format/src/vmd/mod.rs
+++ b/crates/mmd-anim-format/src/vmd/mod.rs
@@ -1,3 +1,4 @@
+use encoding_rs::SHIFT_JIS;
 use glam::{Quat, Vec3A};
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
@@ -304,6 +305,288 @@ pub struct VmdParsedAnimation {
     pub light_frames: Vec<VmdParsedLightFrame>,
     pub self_shadow_frames: Vec<VmdParsedSelfShadowFrame>,
     pub property_frames: Vec<VmdParsedPropertyFrame>,
+}
+
+/// Metadata for the native VMD from-parts exporter.
+///
+/// Bone and morph key values intentionally do not occur in this JSON object:
+/// callers pass those high-density channels as typed SoA slices through the
+/// FFI.  The `deny_unknown_fields` contract prevents a host from accidentally
+/// falling back to a dense JSON representation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct VmdPartsDescriptor {
+    pub schema: String,
+    pub version: u32,
+    pub model_name: String,
+    pub model_name_bytes: Vec<u8>,
+    pub bone_names: Vec<VmdPartsNameEntry>,
+    pub morph_names: Vec<VmdPartsNameEntry>,
+    pub camera_frames: Vec<VmdParsedCameraFrame>,
+    pub light_frames: Vec<VmdParsedLightFrame>,
+    pub self_shadow_frames: Vec<VmdParsedSelfShadowFrame>,
+    pub property_frames: Vec<VmdParsedPropertyFrame>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct VmdPartsNameEntry {
+    pub name: String,
+    pub name_bytes: Vec<u8>,
+}
+
+/// Typed SoA channels consumed by [`build_vmd_animation_from_parts`].
+#[derive(Debug, Clone)]
+pub struct VmdPartsInput<'a> {
+    pub descriptor: VmdPartsDescriptor,
+    pub bone_name_indices: &'a [u32],
+    pub bone_frames: &'a [u32],
+    pub bone_translations_xyz: &'a [f32],
+    pub bone_rotations_xyzw: &'a [f32],
+    pub bone_interpolations: &'a [u8],
+    pub morph_name_indices: &'a [u32],
+    pub morph_frames: &'a [u32],
+    pub morph_weights: &'a [f32],
+}
+
+/// Validates and materializes typed VMD SoA channels into the existing parsed
+/// animation representation.  The binary writer remains
+/// [`export_vmd_animation`]; this helper only performs validation and the
+/// unavoidable typed record construction needed by that writer.
+pub fn build_vmd_animation_from_parts(
+    input: VmdPartsInput<'_>,
+) -> Result<VmdParsedAnimation, String> {
+    let descriptor = input.descriptor;
+    if descriptor.schema != "mmd-anim-vmd-parts" || descriptor.version != 1 {
+        return Err("unsupported VMD parts schema".to_owned());
+    }
+    validate_vmd_parts_name(&descriptor.model_name_bytes, 20, "model name")?;
+    for entry in &descriptor.bone_names {
+        validate_vmd_parts_name(&entry.name_bytes, 15, "bone name")?;
+    }
+    for entry in &descriptor.morph_names {
+        validate_vmd_parts_name(&entry.name_bytes, 15, "morph name")?;
+    }
+    for frame in &descriptor.camera_frames {
+        validate_vmd_parts_camera(frame)?;
+    }
+    for frame in &descriptor.light_frames {
+        validate_vmd_parts_light(frame)?;
+    }
+    for frame in &descriptor.self_shadow_frames {
+        if !frame.distance.is_finite() || frame.mode > 2 {
+            return Err("invalid self-shadow frame".to_owned());
+        }
+    }
+    for frame in &descriptor.property_frames {
+        validate_vmd_parts_count(frame.ik_states.len(), "IK")?;
+        for state in &frame.ik_states {
+            validate_vmd_parts_name(&state.bone_name_bytes, 20, "IK bone name")?;
+        }
+    }
+
+    let bone_count = input.bone_name_indices.len();
+    let morph_count = input.morph_name_indices.len();
+    let bone_translation_len = bone_count
+        .checked_mul(3)
+        .ok_or_else(|| "bone translation length overflow".to_owned())?;
+    let bone_rotation_len = bone_count
+        .checked_mul(4)
+        .ok_or_else(|| "bone rotation length overflow".to_owned())?;
+    let bone_interpolation_len = bone_count
+        .checked_mul(64)
+        .ok_or_else(|| "bone interpolation length overflow".to_owned())?;
+    if input.bone_frames.len() != bone_count
+        || input.bone_translations_xyz.len() != bone_translation_len
+        || input.bone_rotations_xyzw.len() != bone_rotation_len
+        || input.bone_interpolations.len() != bone_interpolation_len
+    {
+        return Err("bone SoA lengths do not match".to_owned());
+    }
+    let morph_weight_len = morph_count;
+    if input.morph_frames.len() != morph_count || input.morph_weights.len() != morph_weight_len {
+        return Err("morph SoA lengths do not match".to_owned());
+    }
+    validate_vmd_parts_count(bone_count, "bone")?;
+    validate_vmd_parts_count(morph_count, "morph")?;
+    validate_vmd_parts_count(descriptor.camera_frames.len(), "camera")?;
+    validate_vmd_parts_count(descriptor.light_frames.len(), "light")?;
+    validate_vmd_parts_count(descriptor.self_shadow_frames.len(), "self-shadow")?;
+    validate_vmd_parts_count(descriptor.property_frames.len(), "property")?;
+
+    for (index, _frame) in input.bone_frames.iter().enumerate() {
+        let name_index = input.bone_name_indices[index] as usize;
+        if name_index >= descriptor.bone_names.len() {
+            return Err("bone name index out of range".to_owned());
+        }
+        if !input.bone_translations_xyz[index * 3..index * 3 + 3]
+            .iter()
+            .all(|value| value.is_finite())
+            || !input.bone_rotations_xyzw[index * 4..index * 4 + 4]
+                .iter()
+                .all(|value| value.is_finite())
+        {
+            return Err("bone value is not finite".to_owned());
+        }
+    }
+    for (index, _frame) in input.morph_frames.iter().enumerate() {
+        let name_index = input.morph_name_indices[index] as usize;
+        if name_index >= descriptor.morph_names.len() {
+            return Err("morph name index out of range".to_owned());
+        }
+        if !input.morph_weights[index].is_finite() {
+            return Err("morph weight is not finite".to_owned());
+        }
+    }
+
+    let mut max_frame = 0u32;
+    for &frame in input.bone_frames {
+        max_frame = max_frame.max(frame);
+    }
+    for &frame in input.morph_frames {
+        max_frame = max_frame.max(frame);
+    }
+    for frame in &descriptor.camera_frames {
+        max_frame = max_frame.max(frame.frame);
+    }
+    for frame in &descriptor.light_frames {
+        max_frame = max_frame.max(frame.frame);
+    }
+    for frame in &descriptor.self_shadow_frames {
+        max_frame = max_frame.max(frame.frame);
+    }
+    for frame in &descriptor.property_frames {
+        max_frame = max_frame.max(frame.frame);
+    }
+
+    // Check all writer arithmetic before allocating/materializing records.
+    let mut output_size = 50usize;
+    output_size = checked_vmd_parts_size(output_size, bone_count, 111)?;
+    output_size = checked_vmd_parts_size(output_size, morph_count, 23)?;
+    output_size = checked_vmd_parts_size(output_size, descriptor.camera_frames.len(), 61)?;
+    output_size = checked_vmd_parts_size(output_size, descriptor.light_frames.len(), 28)?;
+    output_size = checked_vmd_parts_size(output_size, descriptor.self_shadow_frames.len(), 9)?;
+    output_size = output_size
+        .checked_add(4)
+        .ok_or_else(|| "VMD output size overflow".to_owned())?;
+    for frame in &descriptor.property_frames {
+        output_size = output_size
+            .checked_add(9)
+            .ok_or_else(|| "VMD output size overflow".to_owned())?;
+        for _ in &frame.ik_states {
+            output_size = output_size
+                .checked_add(21)
+                .ok_or_else(|| "VMD output size overflow".to_owned())?;
+        }
+    }
+    if output_size > isize::MAX as usize {
+        return Err("VMD output size exceeds addressable range".to_owned());
+    }
+
+    let bone_frames = input
+        .bone_frames
+        .iter()
+        .enumerate()
+        .map(|(index, &frame)| {
+            let name = &descriptor.bone_names[input.bone_name_indices[index] as usize];
+            Ok(VmdParsedBoneFrame {
+                bone_name: name.name.clone(),
+                bone_name_bytes: name.name_bytes.clone(),
+                frame,
+                translation: input.bone_translations_xyz[index * 3..index * 3 + 3]
+                    .try_into()
+                    .expect("validated translation stride"),
+                rotation: input.bone_rotations_xyzw[index * 4..index * 4 + 4]
+                    .try_into()
+                    .expect("validated rotation stride"),
+                interpolation: input.bone_interpolations[index * 64..index * 64 + 64].to_vec(),
+            })
+        })
+        .collect::<Result<Vec<_>, String>>()?;
+    let morph_frames: Vec<VmdParsedMorphFrame> = input
+        .morph_frames
+        .iter()
+        .enumerate()
+        .map(|(index, &frame)| {
+            let name = &descriptor.morph_names[input.morph_name_indices[index] as usize];
+            VmdParsedMorphFrame {
+                morph_name: name.name.clone(),
+                morph_name_bytes: name.name_bytes.clone(),
+                frame,
+                weight: input.morph_weights[index],
+            }
+        })
+        .collect();
+    Ok(VmdParsedAnimation {
+        kind: "vmd",
+        metadata: VmdParsedMetadata {
+            format: "vmd",
+            model_name: descriptor.model_name,
+            model_name_bytes: descriptor.model_name_bytes,
+            counts: VmdParsedCounts {
+                bones: bone_frames.len(),
+                morphs: morph_frames.len(),
+                cameras: descriptor.camera_frames.len(),
+                lights: descriptor.light_frames.len(),
+                self_shadows: descriptor.self_shadow_frames.len(),
+                properties: descriptor.property_frames.len(),
+            },
+            max_frame,
+        },
+        bone_frames,
+        morph_frames,
+        camera_frames: descriptor.camera_frames,
+        light_frames: descriptor.light_frames,
+        self_shadow_frames: descriptor.self_shadow_frames,
+        property_frames: descriptor.property_frames,
+    })
+}
+
+fn validate_vmd_parts_count(count: usize, section: &str) -> Result<(), String> {
+    if count > u32::MAX as usize {
+        Err(format!("{section} section count exceeds u32"))
+    } else {
+        Ok(())
+    }
+}
+
+fn checked_vmd_parts_size(size: usize, count: usize, stride: usize) -> Result<usize, String> {
+    size.checked_add(4)
+        .and_then(|size| {
+            count
+                .checked_mul(stride)
+                .and_then(|bytes| size.checked_add(bytes))
+        })
+        .ok_or_else(|| "VMD output size overflow".to_owned())
+}
+
+fn validate_vmd_parts_name(bytes: &[u8], width: usize, field: &str) -> Result<(), String> {
+    if bytes.len() > width || bytes.contains(&0) {
+        return Err(format!("invalid {field} raw bytes"));
+    }
+    if !bytes.is_empty() && SHIFT_JIS.decode(bytes).2 {
+        return Err(format!("invalid {field} CP932 bytes"));
+    }
+    Ok(())
+}
+
+fn validate_vmd_parts_camera(frame: &VmdParsedCameraFrame) -> Result<(), String> {
+    if !frame.distance.is_finite()
+        || !frame.position.iter().all(|value| value.is_finite())
+        || !frame.rotation.iter().all(|value| value.is_finite())
+    {
+        return Err("camera value is not finite".to_owned());
+    }
+    Ok(())
+}
+
+fn validate_vmd_parts_light(frame: &VmdParsedLightFrame) -> Result<(), String> {
+    if !frame.color.iter().all(|value| value.is_finite())
+        || !frame.direction.iter().all(|value| value.is_finite())
+    {
+        return Err("light value is not finite".to_owned());
+    }
+    Ok(())
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1775,6 +2058,437 @@ mod tests {
     use super::*;
     #[allow(unused_imports)]
     use serde_json;
+
+    #[test]
+    fn vmd_parts_preserves_soa_order_interpolation_and_all_sections() {
+        let descriptor = VmdPartsDescriptor {
+            schema: "mmd-anim-vmd-parts".to_owned(),
+            version: 1,
+            model_name: "parts".to_owned(),
+            model_name_bytes: vec![0x82, 0xa0],
+            bone_names: vec![VmdPartsNameEntry {
+                name: "あ".to_owned(),
+                name_bytes: vec![0x82, 0xa0],
+            }],
+            morph_names: vec![VmdPartsNameEntry {
+                name: "い".to_owned(),
+                name_bytes: vec![0x82, 0xa2],
+            }],
+            camera_frames: vec![VmdParsedCameraFrame {
+                frame: 20,
+                distance: 30.0,
+                position: [1.0, 2.0, 3.0],
+                rotation: [0.1, 0.2, 0.3],
+                interpolation: [0x31; 24],
+                fov: 45,
+                perspective: true,
+            }],
+            light_frames: vec![VmdParsedLightFrame {
+                frame: 21,
+                color: [0.1, 0.2, 0.3],
+                direction: [0.0, 1.0, 0.0],
+            }],
+            self_shadow_frames: vec![VmdParsedSelfShadowFrame {
+                frame: 22,
+                mode: 1,
+                distance: 0.5,
+            }],
+            property_frames: vec![VmdParsedPropertyFrame {
+                frame: 23,
+                visible: true,
+                ik_states: vec![VmdParsedIkState {
+                    bone_name: "IK".to_owned(),
+                    bone_name_bytes: b"IK".to_vec(),
+                    enabled: false,
+                }],
+            }],
+        };
+        let metadata_json = serde_json::to_string(&descriptor).unwrap();
+        let metadata_value: serde_json::Value = serde_json::from_str(&metadata_json).unwrap();
+        assert!(metadata_value.get("boneFrames").is_none());
+        assert!(metadata_value.get("morphFrames").is_none());
+        let input = VmdPartsInput {
+            descriptor,
+            bone_name_indices: &[0, 0],
+            bone_frames: &[10, 5],
+            bone_translations_xyz: &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+            bone_rotations_xyzw: &[0.0, 0.0, 0.0, 1.0, 0.1, 0.2, 0.3, 0.9],
+            bone_interpolations: &[0x11; 64 * 2],
+            morph_name_indices: &[0],
+            morph_frames: &[11],
+            morph_weights: &[0.75],
+        };
+        let animation = build_vmd_animation_from_parts(input).unwrap();
+        let first = export_vmd_animation(&animation);
+        let second = export_vmd_animation(&animation);
+        assert_eq!(first, second);
+        let parsed = parse_vmd_animation(&first).unwrap();
+        assert_eq!(parsed.bone_frames.len(), 2);
+        assert_eq!(parsed.bone_frames[0].frame, 10);
+        assert_eq!(parsed.bone_frames[1].frame, 5);
+        assert_eq!(parsed.bone_frames[0].bone_name_bytes, vec![0x82, 0xa0]);
+        assert_eq!(parsed.bone_frames[0].translation, [1.0, 2.0, 3.0]);
+        assert_eq!(parsed.bone_frames[1].rotation, [0.1, 0.2, 0.3, 0.9]);
+        assert_eq!(parsed.bone_frames[0].interpolation, vec![0x11; 64]);
+        assert_eq!(parsed.morph_frames[0].morph_name_bytes, vec![0x82, 0xa2]);
+        assert_eq!(parsed.morph_frames[0].weight, 0.75);
+        assert_eq!(parsed.camera_frames[0].interpolation, [0x31; 24]);
+        assert_eq!(parsed.camera_frames[0].distance, 30.0);
+        assert_eq!(parsed.camera_frames[0].position, [1.0, 2.0, 3.0]);
+        assert_eq!(parsed.camera_frames[0].rotation, [0.1, 0.2, 0.3]);
+        assert_eq!(parsed.camera_frames[0].fov, 45);
+        assert!(parsed.camera_frames[0].perspective);
+        assert_eq!(parsed.light_frames.len(), 1);
+        assert_eq!(parsed.light_frames[0].color, [0.1, 0.2, 0.3]);
+        assert_eq!(parsed.light_frames[0].direction, [0.0, 1.0, 0.0]);
+        assert_eq!(parsed.self_shadow_frames.len(), 1);
+        assert_eq!(parsed.self_shadow_frames[0].mode, 1);
+        assert_eq!(parsed.self_shadow_frames[0].distance, 0.5);
+        assert!(parsed.property_frames[0].visible);
+        assert_eq!(parsed.property_frames[0].ik_states[0].bone_name, "IK");
+        assert_eq!(
+            parsed.property_frames[0].ik_states[0].bone_name_bytes,
+            b"IK".to_vec()
+        );
+        assert!(!parsed.property_frames[0].ik_states[0].enabled);
+        assert_eq!(parsed.metadata.model_name_bytes, vec![0x82, 0xa0]);
+        assert_eq!(parsed.metadata.max_frame, 23);
+    }
+
+    fn minimal_vmd_parts_descriptor() -> VmdPartsDescriptor {
+        VmdPartsDescriptor {
+            schema: "mmd-anim-vmd-parts".to_owned(),
+            version: 1,
+            model_name: "model".to_owned(),
+            model_name_bytes: Vec::new(),
+            bone_names: vec![VmdPartsNameEntry {
+                name: "bone".to_owned(),
+                name_bytes: Vec::new(),
+            }],
+            morph_names: vec![VmdPartsNameEntry {
+                name: "morph".to_owned(),
+                name_bytes: Vec::new(),
+            }],
+            camera_frames: Vec::new(),
+            light_frames: Vec::new(),
+            self_shadow_frames: Vec::new(),
+            property_frames: Vec::new(),
+        }
+    }
+
+    fn one_key_vmd_parts<'a>(
+        descriptor: VmdPartsDescriptor,
+        translation: &'a [f32],
+        rotation: &'a [f32],
+        weight: &'a [f32],
+    ) -> VmdPartsInput<'a> {
+        VmdPartsInput {
+            descriptor,
+            bone_name_indices: &[0],
+            bone_frames: &[1],
+            bone_translations_xyz: translation,
+            bone_rotations_xyzw: rotation,
+            bone_interpolations: &[0; 64],
+            morph_name_indices: &[0],
+            morph_frames: &[2],
+            morph_weights: weight,
+        }
+    }
+
+    #[test]
+    fn vmd_parts_accepts_exact_raw_widths_and_rejects_invalid_raw_names() {
+        let mut descriptor = minimal_vmd_parts_descriptor();
+        descriptor.model_name_bytes = vec![b'M'; 20];
+        descriptor.bone_names[0].name_bytes = vec![b'B'; 15];
+        descriptor.morph_names[0].name_bytes = vec![b'R'; 15];
+        let animation = build_vmd_animation_from_parts(one_key_vmd_parts(
+            descriptor.clone(),
+            &[1.0, 2.0, 3.0],
+            &[0.0, 0.0, 0.0, 1.0],
+            &[0.5],
+        ))
+        .unwrap();
+        let parsed = parse_vmd_animation(&export_vmd_animation(&animation)).unwrap();
+        assert_eq!(parsed.metadata.model_name_bytes, vec![b'M'; 20]);
+        assert_eq!(parsed.bone_frames[0].bone_name_bytes, vec![b'B'; 15]);
+        assert_eq!(parsed.morph_frames[0].morph_name_bytes, vec![b'R'; 15]);
+
+        for (field, bytes) in [
+            ("model", vec![b'M'; 21]),
+            ("bone", vec![b'B'; 16]),
+            ("morph", vec![b'R'; 16]),
+        ] {
+            let mut invalid = descriptor.clone();
+            match field {
+                "model" => invalid.model_name_bytes = bytes,
+                "bone" => invalid.bone_names[0].name_bytes = bytes,
+                _ => invalid.morph_names[0].name_bytes = bytes,
+            }
+            assert!(
+                build_vmd_animation_from_parts(one_key_vmd_parts(
+                    invalid,
+                    &[1.0, 2.0, 3.0],
+                    &[0.0, 0.0, 0.0, 1.0],
+                    &[0.5],
+                ))
+                .is_err()
+            );
+        }
+
+        for (field, bytes) in [
+            ("model", vec![b'M', 0]),
+            ("bone", vec![b'B', 0]),
+            ("morph", vec![b'R', 0]),
+            ("model", vec![0x82]),
+        ] {
+            let mut invalid = descriptor.clone();
+            match field {
+                "model" => invalid.model_name_bytes = bytes,
+                "bone" => invalid.bone_names[0].name_bytes = bytes,
+                _ => invalid.morph_names[0].name_bytes = bytes,
+            }
+            assert!(
+                build_vmd_animation_from_parts(one_key_vmd_parts(
+                    invalid,
+                    &[1.0, 2.0, 3.0],
+                    &[0.0, 0.0, 0.0, 1.0],
+                    &[0.5],
+                ))
+                .is_err()
+            );
+        }
+    }
+
+    #[test]
+    fn vmd_parts_rejects_soa_mismatch_indices_nonfinite_and_low_density_floats() {
+        let descriptor = minimal_vmd_parts_descriptor();
+        let mut mismatch = one_key_vmd_parts(
+            descriptor.clone(),
+            &[1.0, 2.0, 3.0],
+            &[0.0, 0.0, 0.0, 1.0],
+            &[0.5],
+        );
+        mismatch.bone_translations_xyz = &[1.0, 2.0];
+        assert!(build_vmd_animation_from_parts(mismatch).is_err());
+        let short_rotation = one_key_vmd_parts(
+            descriptor.clone(),
+            &[1.0, 2.0, 3.0],
+            &[0.0, 0.0, 1.0],
+            &[0.5],
+        );
+        assert!(build_vmd_animation_from_parts(short_rotation).is_err());
+        let mut short_interpolation = one_key_vmd_parts(
+            descriptor.clone(),
+            &[1.0, 2.0, 3.0],
+            &[0.0, 0.0, 0.0, 1.0],
+            &[0.5],
+        );
+        short_interpolation.bone_interpolations = &[0; 63];
+        assert!(build_vmd_animation_from_parts(short_interpolation).is_err());
+        let mut morph_mismatch = one_key_vmd_parts(
+            descriptor.clone(),
+            &[1.0, 2.0, 3.0],
+            &[0.0, 0.0, 0.0, 1.0],
+            &[0.5],
+        );
+        morph_mismatch.morph_frames = &[];
+        assert!(build_vmd_animation_from_parts(morph_mismatch).is_err());
+        let mut bad_index = one_key_vmd_parts(
+            descriptor.clone(),
+            &[1.0, 2.0, 3.0],
+            &[0.0, 0.0, 0.0, 1.0],
+            &[0.5],
+        );
+        bad_index.bone_name_indices = &[1];
+        assert!(build_vmd_animation_from_parts(bad_index).is_err());
+        let mut bad_morph_index = one_key_vmd_parts(
+            descriptor.clone(),
+            &[1.0, 2.0, 3.0],
+            &[0.0, 0.0, 0.0, 1.0],
+            &[0.5],
+        );
+        bad_morph_index.morph_name_indices = &[1];
+        assert!(build_vmd_animation_from_parts(bad_morph_index).is_err());
+
+        let camera_with_short_interpolation = serde_json::json!({
+            "schema": "mmd-anim-vmd-parts",
+            "version": 1,
+            "modelName": "model",
+            "modelNameBytes": [],
+            "boneNames": [],
+            "morphNames": [],
+            "cameraFrames": [{
+                "frame": 0,
+                "distance": 0.0,
+                "position": [0.0, 0.0, 0.0],
+                "rotation": [0.0, 0.0, 0.0],
+                "interpolation": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                "fov": 30,
+                "perspective": true
+            }],
+            "lightFrames": [],
+            "selfShadowFrames": [],
+            "propertyFrames": []
+        });
+        assert!(
+            serde_json::from_value::<VmdPartsDescriptor>(camera_with_short_interpolation).is_err()
+        );
+
+        for (translation, rotation, weight) in [
+            (
+                &[f32::NAN, 0.0, 0.0][..],
+                &[0.0, 0.0, 0.0, 1.0][..],
+                &[0.5][..],
+            ),
+            (
+                &[0.0, 0.0, 0.0][..],
+                &[f32::INFINITY, 0.0, 0.0, 1.0][..],
+                &[0.5][..],
+            ),
+            (
+                &[0.0, 0.0, 0.0][..],
+                &[0.0, 0.0, 0.0, 1.0][..],
+                &[f32::INFINITY][..],
+            ),
+        ] {
+            assert!(
+                build_vmd_animation_from_parts(one_key_vmd_parts(
+                    descriptor.clone(),
+                    translation,
+                    rotation,
+                    weight,
+                ))
+                .is_err()
+            );
+        }
+
+        let mut camera = descriptor.clone();
+        camera.camera_frames.push(VmdParsedCameraFrame {
+            frame: 1,
+            distance: f32::NAN,
+            position: [0.0; 3],
+            rotation: [0.0; 3],
+            interpolation: [0; 24],
+            fov: 30,
+            perspective: false,
+        });
+        assert!(
+            build_vmd_animation_from_parts(one_key_vmd_parts(
+                camera,
+                &[0.0, 0.0, 0.0],
+                &[0.0, 0.0, 0.0, 1.0],
+                &[0.5],
+            ))
+            .is_err()
+        );
+        let mut light = descriptor.clone();
+        light.light_frames.push(VmdParsedLightFrame {
+            frame: 1,
+            color: [f32::INFINITY, 0.0, 0.0],
+            direction: [0.0; 3],
+        });
+        assert!(
+            build_vmd_animation_from_parts(one_key_vmd_parts(
+                light,
+                &[0.0, 0.0, 0.0],
+                &[0.0, 0.0, 0.0, 1.0],
+                &[0.5],
+            ))
+            .is_err()
+        );
+        let mut self_shadow = descriptor;
+        self_shadow
+            .self_shadow_frames
+            .push(VmdParsedSelfShadowFrame {
+                frame: 1,
+                mode: 1,
+                distance: f32::NAN,
+            });
+        assert!(
+            build_vmd_animation_from_parts(one_key_vmd_parts(
+                self_shadow,
+                &[0.0, 0.0, 0.0],
+                &[0.0, 0.0, 0.0, 1.0],
+                &[0.5],
+            ))
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn vmd_parts_checked_helpers_reject_overflow() {
+        assert!(checked_vmd_parts_size(usize::MAX, 1, 1).is_err());
+        assert!(checked_vmd_parts_size(0, usize::MAX, 2).is_err());
+        if usize::BITS > 32 {
+            assert!(validate_vmd_parts_count(u32::MAX as usize + 1, "test").is_err());
+        }
+    }
+
+    #[test]
+    fn vmd_parts_empty_animation_reparses_six_empty_sections() {
+        let animation = build_vmd_animation_from_parts(VmdPartsInput {
+            descriptor: minimal_vmd_parts_descriptor(),
+            bone_name_indices: &[],
+            bone_frames: &[],
+            bone_translations_xyz: &[],
+            bone_rotations_xyzw: &[],
+            bone_interpolations: &[],
+            morph_name_indices: &[],
+            morph_frames: &[],
+            morph_weights: &[],
+        })
+        .unwrap();
+        let parsed = parse_vmd_animation(&export_vmd_animation(&animation)).unwrap();
+        assert!(parsed.bone_frames.is_empty());
+        assert!(parsed.morph_frames.is_empty());
+        assert!(parsed.camera_frames.is_empty());
+        assert!(parsed.light_frames.is_empty());
+        assert!(parsed.self_shadow_frames.is_empty());
+        assert!(parsed.property_frames.is_empty());
+        assert_eq!(parsed.metadata.counts.bones, 0);
+        assert_eq!(parsed.metadata.counts.morphs, 0);
+        assert_eq!(parsed.metadata.counts.cameras, 0);
+        assert_eq!(parsed.metadata.counts.lights, 0);
+        assert_eq!(parsed.metadata.counts.self_shadows, 0);
+        assert_eq!(parsed.metadata.counts.properties, 0);
+    }
+
+    #[test]
+    fn vmd_parts_large_key_metadata_stays_sparse_and_output_size_is_checked() {
+        let key_count = 3_000usize;
+        let descriptor = minimal_vmd_parts_descriptor();
+        let metadata_json = serde_json::to_string(&descriptor).unwrap();
+        assert!(metadata_json.len() < 1_024);
+        assert!(!metadata_json.contains("boneFrames"));
+        assert!(!metadata_json.contains("morphFrames"));
+        let bone_name_indices = vec![0u32; key_count];
+        let bone_frames: Vec<u32> = (0..key_count as u32).collect();
+        let translations = vec![0.0f32; key_count * 3];
+        let rotations = vec![0.0f32; key_count * 4];
+        let interpolations = vec![0u8; key_count * 64];
+        let morph_name_indices = vec![0u32; key_count];
+        let morph_frames: Vec<u32> = (0..key_count as u32).collect();
+        let weights = vec![0.25f32; key_count];
+        let animation = build_vmd_animation_from_parts(VmdPartsInput {
+            descriptor,
+            bone_name_indices: &bone_name_indices,
+            bone_frames: &bone_frames,
+            bone_translations_xyz: &translations,
+            bone_rotations_xyzw: &rotations,
+            bone_interpolations: &interpolations,
+            morph_name_indices: &morph_name_indices,
+            morph_frames: &morph_frames,
+            morph_weights: &weights,
+        })
+        .unwrap();
+        let bytes = export_vmd_animation(&animation);
+        let expected = 74 + key_count * 111 + key_count * 23;
+        assert_eq!(bytes.len(), expected);
+        let parsed = parse_vmd_animation(&bytes).unwrap();
+        assert_eq!(parsed.metadata.counts.bones, key_count);
+        assert_eq!(parsed.metadata.counts.morphs, key_count);
+    }
 
     fn build_vmd_header_bytes() -> Vec<u8> {
         let mut buf = Vec::new();

--- a/crates/mmd-anim-runtime/src/reduce/mod.rs
+++ b/crates/mmd-anim-runtime/src/reduce/mod.rs
@@ -477,7 +477,7 @@ struct DirtyRanges {
 
 impl DirtyRanges {
     fn full(frame_count: usize, bone_count: usize, morph_count: usize) -> Self {
-        let range = || vec![0..=frame_count.saturating_sub(1)];
+        let range = || Vec::from([0..=frame_count.saturating_sub(1)]);
         Self {
             bone_local: (0..bone_count).map(|_| range()).collect(),
             morph: (0..morph_count).map(|_| range()).collect(),

--- a/crates/mmd-anim-runtime/src/reduce/mod.rs
+++ b/crates/mmd-anim-runtime/src/reduce/mod.rs
@@ -477,7 +477,7 @@ struct DirtyRanges {
 
 impl DirtyRanges {
     fn full(frame_count: usize, bone_count: usize, morph_count: usize) -> Self {
-        let range = || Vec::from([0..=frame_count.saturating_sub(1)]);
+        let range = || std::iter::once(0..=frame_count.saturating_sub(1)).collect();
         Self {
             bone_local: (0..bone_count).map(|_| range()).collect(),
             morph: (0..morph_count).map(|_| range()).collect(),

--- a/crates/mmd-anim-wasm/Cargo.toml
+++ b/crates/mmd-anim-wasm/Cargo.toml
@@ -17,7 +17,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 glam.workspace = true
 mmd-anim-runtime.workspace = true
-mmd-anim-format = { path = "../mmd-anim-format", version = "0.4.1" }
+mmd-anim-format = { path = "../mmd-anim-format", version = "0.4.2" }
 wasm-bindgen.workspace = true
 js-sys.workspace = true
 serde.workspace = true

--- a/crates/mmd-anim-wasm/LICENSE
+++ b/crates/mmd-anim-wasm/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Yohawing
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/crates/mmd-anim-wasm/src/lib.rs
+++ b/crates/mmd-anim-wasm/src/lib.rs
@@ -2380,6 +2380,41 @@ mod tests {
     }
 
     #[test]
+    fn vmd_from_parts_matches_wasm_json_export_at_parse_level() {
+        let descriptor: mmd_anim_format::VmdPartsDescriptor =
+            serde_json::from_value(serde_json::json!({
+                "schema": "mmd-anim-vmd-parts",
+                "version": 1,
+                "modelName": "wasm_parts",
+                "modelNameBytes": [],
+                "boneNames": [{"name": "センター", "nameBytes": []}],
+                "morphNames": [],
+                "cameraFrames": [],
+                "lightFrames": [],
+                "selfShadowFrames": [],
+                "propertyFrames": []
+            }))
+            .unwrap();
+        let animation =
+            mmd_anim_format::build_vmd_animation_from_parts(mmd_anim_format::VmdPartsInput {
+                descriptor,
+                bone_name_indices: &[0],
+                bone_frames: &[3],
+                bone_translations_xyz: &[1.0, 2.0, 3.0],
+                bone_rotations_xyzw: &[0.0, 0.0, 0.0, 1.0],
+                bone_interpolations: &[0x2a; 64],
+                morph_name_indices: &[],
+                morph_frames: &[],
+                morph_weights: &[],
+            })
+            .unwrap();
+        let parts_bytes = mmd_anim_format::export_vmd_animation(&animation);
+        let json = serde_json::to_string(&animation).unwrap();
+        let json_bytes = export_vmd_animation_json_bytes(&json).unwrap();
+        assert_eq!(parts_bytes, json_bytes);
+    }
+
+    #[test]
     fn samples_vmd_camera_array_layout() {
         let bytes: &[u8] = include_bytes!("../../mmd-anim-format/fixtures/vmd/simple_camera.vmd");
         let parsed = mmd_anim_format::parse_vmd_animation(bytes).unwrap();

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -74,7 +74,7 @@ Rust API、C ABI、WASM wrapper を通じて、他のホストや製品にも同
 
 ```toml
 [dependencies]
-mmd-anim = "0.3.2"
+mmd-anim = "0.4.2"
 ```
 
 ## ネイティブ (C ABI) から使う

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -84,6 +84,12 @@ mmd-anim = "0.3.2"
 （Unity はその一例です）。
 ヘッダーは [crates/mmd-anim-ffi/include/mmd_runtime.h](../crates/mmd-anim-ffi/include/mmd_runtime.h) です。
 
+ネイティブ VMD 書き出しでは、`mmd_runtime_export_vmd_from_parts` に型付き
+Bone/Morph SoA 配列と、名前および低密度のカメラ・ライト・セルフシャドウ・
+Property/IK セクションを含む JSON メタデータを渡せます。ファイル I/O は行わず、
+所有権を移した VMD 0002 バイト列を返します。返却バッファは
+`mmd_runtime_byte_buffer_free` で解放してください。高密度のキー値は JSON に展開しません。
+
 ```c
 // 1. PMX のバイト列からモデルを作成
 mmd_runtime_model_t* model =

--- a/tools/check_ffi_header_symbols.py
+++ b/tools/check_ffi_header_symbols.py
@@ -563,6 +563,32 @@ PHYSICS_PARAM_FUNCTIONS = {
     ),
 }
 
+VMD_FROM_PARTS_FUNCTIONS = {
+    "mmd_runtime_export_vmd_from_parts": (
+        "ffi_byte_buffer",
+        [
+            ("metadata_json", "const_u8_ptr"),
+            ("metadata_json_len", "usize"),
+            ("bone_name_indices", "const_u32_ptr"),
+            ("bone_name_index_count", "usize"),
+            ("bone_frames", "const_u32_ptr"),
+            ("bone_frame_count", "usize"),
+            ("bone_translations_xyz", "const_f32_ptr"),
+            ("bone_translation_f32_len", "usize"),
+            ("bone_rotations_xyzw", "const_f32_ptr"),
+            ("bone_rotation_f32_len", "usize"),
+            ("bone_interpolations", "const_u8_ptr"),
+            ("bone_interpolation_u8_len", "usize"),
+            ("morph_name_indices", "const_u32_ptr"),
+            ("morph_name_index_count", "usize"),
+            ("morph_frames", "const_u32_ptr"),
+            ("morph_frame_count", "usize"),
+            ("morph_weights", "const_f32_ptr"),
+            ("morph_weight_count", "usize"),
+        ],
+    ),
+}
+
 
 def rust_exported_symbols(text: str) -> set[str]:
     lines = text.splitlines()
@@ -631,6 +657,8 @@ def canonical_rust_type(type_name: str) -> str:
         "*const MmdRuntimePhysicsWorld": "const_physics_world_ptr",
         "*mut MmdRuntimePhysicsWorld": "physics_world_ptr",
         "*const u8": "const_u8_ptr",
+        "*const u32": "const_u32_ptr",
+        "*const f32": "const_f32_ptr",
         "*mut u8": "mut_u8_ptr",
         "*mut usize": "usize_ptr",
         "*mut MmdRuntimeFfiGenericCurveInfo": "generic_info_ptr",
@@ -679,6 +707,8 @@ def canonical_c_type(type_name: str) -> str:
         "const mmd_runtime_physics_world_t*": "const_physics_world_ptr",
         "mmd_runtime_physics_world_t*": "physics_world_ptr",
         "const uint8_t*": "const_u8_ptr",
+        "const uint32_t*": "const_u32_ptr",
+        "const float*": "const_f32_ptr",
         "uint8_t*": "mut_u8_ptr",
         "size_t*": "usize_ptr",
         "mmd_runtime_ffi_generic_curve_info_t*": "generic_info_ptr",
@@ -852,6 +882,13 @@ def check_abi_shapes(rust_text: str, header_text: str) -> list[str]:
                 f"function {name}: Rust={rust_shape}, header={c_shape}, expected={expected}"
             )
     for name, expected in PHYSICS_PARAM_FUNCTIONS.items():
+        rust_shape = rust_function_shape(rust_text, name)
+        c_shape = c_function_shape(header_text, name)
+        if rust_shape != expected or c_shape != expected or rust_shape != c_shape:
+            errors.append(
+                f"function {name}: Rust={rust_shape}, header={c_shape}, expected={expected}"
+            )
+    for name, expected in VMD_FROM_PARTS_FUNCTIONS.items():
         rust_shape = rust_function_shape(rust_text, name)
         c_shape = c_function_shape(header_text, name)
         if rust_shape != expected or c_shape != expected or rust_shape != c_shape:


### PR DESCRIPTION
## Summary

- add the native VMD from-parts C ABI for typed Bone/Morph SoA export
- preserve the existing VMD writer and owned byte-buffer contract
- harden release publication ordering and tag/package version validation
- bump workspace packages and documentation to v0.4.2

## Verification

- Rust 1.98 fmt, workspace clippy, tests (918 passed; 3 documented local-asset tests ignored), and docs
- WASM target check and harness build
- no-default-feature checks/tests
- C header/ABI checks, release cdylib build, and 50 native Python binding tests
- package content audit and mmd-anim-runtime publish dry-run
- develop CI run 32452960633: all jobs passed with zero annotations

## Release

After merge, an annotated v0.4.2 tag will be created on the main merge commit. The tag workflow will build CLI assets and publish crates only after release checks and all CLI builds pass.