### PR TITLE
chore(release): update artifact actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,7 +146,7 @@ jobs:
           Compress-Archive -Path "staging\*" -DestinationPath "dist\${{ matrix.archive }}" -Force
 
       - name: Upload CLI artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: cli-${{ matrix.target }}
           path: dist/${{ matrix.archive }}
@@ -186,7 +186,7 @@ jobs:
           tar -C staging -czf "dist/mmd-anim-${{ github.ref_name }}-universal-apple-darwin.tar.gz" mmd-anim
 
       - name: Upload CLI artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: cli-universal-apple-darwin
           path: dist/mmd-anim-${{ github.ref_name }}-universal-apple-darwin.tar.gz
@@ -204,7 +204,7 @@ jobs:
         uses: actions/checkout@v7.0.1
 
       - name: Download CLI artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8.0.1
         with:
           path: dist
           merge-multiple: true


### PR DESCRIPTION
## Summary

- update upload-artifact to v7.0.1
- update download-artifact to v8.0.1
- remove the Node 20 deprecation warning observed in the v0.4.2 release run

## Evidence

Release run 32453659014 was cancelled before the crates.io publish or GitHub Release jobs started. No v0.4.2 crate or GitHub Release was published.

## Manual merge boundary

This PR must be merged manually by the maintainer. Automation and agents stop after CI verification.