### PR TITLE
Fix direct PMM load and playback timeline

### DIFF
--- a/crates/mmd-anim-format/src/pmm.rs
+++ b/crates/mmd-anim-format/src/pmm.rs
@@ -2732,7 +2732,12 @@ fn write_pmm_scene(
     for _ in 0..4 {
         push_i32(&mut out, -1);
     }
-    out.push(0);
+    // PMM stores one expansion-state byte for each fixed display track.  MMD
+    // indexes this block after accepting the model-structure confirmation, so
+    // the count must agree with the fixed-track count even when every flag is
+    // false (the default state).
+    out.push(model_structure.fixed_tracks);
+    out.resize(out.len() + usize::from(model_structure.fixed_tracks), 0);
     push_i32(&mut out, 0);
     push_i32(&mut out, max_frame as i32);
 
@@ -5805,6 +5810,30 @@ mod tests {
         );
     }
 
+    fn assert_fixed_track_expansion_state(parsed: &PmmParsedManifest, expected_fixed_tracks: u8) {
+        let model = &parsed
+            .document_summary
+            .as_ref()
+            .expect("exported PMM must contain document summary")
+            .models[0];
+        let initial_bones_offset = model.sections.initial_bone_keyframes_offset;
+        let expansion_count_offset = initial_bones_offset
+            .checked_sub(9 + usize::from(expected_fixed_tracks))
+            .expect("initial bone section must follow expansion state");
+        assert_eq!(
+            parsed.source_bytes[expansion_count_offset], expected_fixed_tracks,
+            "fixed-track expansion count must match the model header"
+        );
+        let expansion_flags_start = expansion_count_offset + 1;
+        let expansion_flags_end = expansion_flags_start + usize::from(expected_fixed_tracks);
+        assert!(
+            parsed.source_bytes[expansion_flags_start..expansion_flags_end]
+                .iter()
+                .all(|flag| *flag == 0),
+            "exported fixed-track expansion flags must start disabled"
+        );
+    }
+
     #[test]
     fn exports_pmm_scene_header_timeline_fps_and_camera_fov() {
         let model =
@@ -5864,6 +5893,31 @@ mod tests {
             PmmDocumentKeyframeSummary::Camera { fov, .. } => assert_eq!(*fov, 42),
             other => panic!("unexpected camera keyframe summary: {other:?}"),
         }
+
+        assert_fixed_track_expansion_state(&reparsed, 2);
+    }
+
+    #[test]
+    fn exports_pmm_scene_without_fixed_tracks_has_no_expansion_flags() {
+        let model = crate::pmx::parse_pmx_model(include_bytes!(
+            "../fixtures/pmx/model_descriptor_parity.pmx"
+        ))
+        .unwrap();
+        let motion =
+            crate::vmd::parse_vmd_animation(include_bytes!("../fixtures/vmd/simple_camera.vmd"))
+                .unwrap();
+        let structure = pmm_export_model_structure_from_pmx(&model);
+        assert_eq!(structure.fixed_tracks, 0);
+
+        let report = export_pmm_scene_from_pmx_vmd(
+            &model,
+            &motion,
+            "UserFile/Model/model_descriptor_parity.pmx",
+            &PmmSceneExportOptions::default(),
+        );
+        let reparsed = parse_pmm_manifest(&report.bytes).unwrap();
+
+        assert_fixed_track_expansion_state(&reparsed, 0);
     }
 
     fn append_pmm_model_slot(data: &mut Vec<u8>, name: &[u8], english_name: &[u8], path: &[u8]) {

--- a/crates/mmd-anim-format/src/pmm.rs
+++ b/crates/mmd-anim-format/src/pmm.rs
@@ -2065,7 +2065,8 @@ pub fn parse_pmm_manifest(data: &[u8]) -> Result<PmmParsedManifest, ImportError>
     let audio_assets = scene_assets_by_kind(&asset_references, "audio");
     let image_assets = scene_assets_by_kind(&asset_references, "image");
     let video_assets = scene_assets_by_kind(&asset_references, "video");
-    let timeline = timeline_from_project_settings(&project_settings);
+    let timeline =
+        timeline_from_project_settings(&project_settings, document_global_summary.as_ref());
     let asset_summary = asset_summary(&asset_references);
     let diagnostics = pmm_diagnostics(
         &asset_references,
@@ -2692,7 +2693,7 @@ fn write_pmm_scene(
     out.resize(30, 0);
     push_u32(&mut out, options.screen_width);
     push_u32(&mut out, options.screen_height);
-    push_u32(&mut out, max_frame);
+    push_u32(&mut out, 480); // timeline panel width, not the animation end frame
     push_f32(&mut out, options.frame_rate);
     out.extend_from_slice(&[0, 1, 1, 1, 1, 1, 1]);
     out.push(0);
@@ -3094,14 +3095,14 @@ fn write_pmm_global_tail(out: &mut Vec<u8>, max_frame: u32, camera_fov: f32) {
 
     push_i32(out, 0);
     push_i32(out, 0);
+    push_i32(out, 0);
+    push_i32(out, 0);
+    out.push(0);
+    out.push(0);
+    out.push(0);
+    out.push(0);
+    push_i32(out, 0);
     push_i32(out, max_frame as i32);
-    push_i32(out, 0);
-    out.push(0);
-    out.push(0);
-    out.push(0);
-    out.push(0);
-    push_i32(out, 500);
-    push_i32(out, 0);
     out.push(0);
     push_empty_pmm_path(out);
     push_i32(out, 0);
@@ -3179,10 +3180,20 @@ fn push_pmm_sjis_string(out: &mut Vec<u8>, text: &str, original_bytes: Option<&[
     out.extend_from_slice(&encode_sjis(text));
 }
 
-fn timeline_from_project_settings(settings: &PmmProjectSettings) -> PmmTimeline {
-    let duration_seconds = settings
-        .timeline_frame_count
-        .zip(settings.frame_rate)
+fn timeline_from_project_settings(
+    settings: &PmmProjectSettings,
+    global: Option<&PmmDocumentGlobalSummary>,
+) -> PmmTimeline {
+    let (frame_count, frame_rate) = global
+        .map(|global| {
+            (
+                u32::try_from(global.settings.end_frame_index).ok(),
+                Some(global.settings.preferred_fps),
+            )
+        })
+        .unwrap_or((settings.timeline_frame_count, settings.frame_rate));
+    let duration_seconds = frame_count
+        .zip(frame_rate)
         .and_then(|(frame_count, frame_rate)| {
             if frame_rate > 0.0 {
                 Some(frame_count as f32 / frame_rate)
@@ -3191,10 +3202,10 @@ fn timeline_from_project_settings(settings: &PmmProjectSettings) -> PmmTimeline 
             }
         });
     PmmTimeline {
-        start_frame: settings.timeline_frame_count.map(|_| 0),
-        end_frame_exclusive: settings.timeline_frame_count,
-        frame_count: settings.timeline_frame_count,
-        frame_rate: settings.frame_rate,
+        start_frame: frame_count.map(|_| 0),
+        end_frame_exclusive: frame_count,
+        frame_count,
+        frame_rate,
         duration_seconds,
     }
 }
@@ -5886,14 +5897,19 @@ mod tests {
         assert_eq!(report.max_frame, 600);
         assert_eq!(reparsed.project_settings.screen_width, Some(800));
         assert_eq!(reparsed.project_settings.screen_height, Some(600));
-        assert_eq!(reparsed.project_settings.timeline_frame_count, Some(600));
+        assert_eq!(reparsed.project_settings.timeline_frame_count, Some(480));
         assert_eq!(reparsed.project_settings.frame_rate, Some(60.0));
+        assert_eq!(reparsed.timeline.frame_count, Some(600));
+        assert_eq!(reparsed.timeline.frame_rate, Some(60.0));
+        assert_eq!(reparsed.timeline.duration_seconds, Some(10.0));
         let global = reparsed.document_global_summary.as_ref().unwrap();
         match global.camera.initial_keyframe.as_ref().unwrap() {
             PmmDocumentKeyframeSummary::Camera { fov, .. } => assert_eq!(*fov, 42),
             other => panic!("unexpected camera keyframe summary: {other:?}"),
         }
-
+        assert_eq!(global.settings.horizontal_scroll_thumb, 0);
+        assert_eq!(global.settings.begin_frame_index, 0);
+        assert_eq!(global.settings.end_frame_index, 600);
         assert_fixed_track_expansion_state(&reparsed, 2);
     }
 


### PR DESCRIPTION
## Summary
- write one expansion-state byte for every declared fixed display track
- store the PMMv2 timeline panel width separately from the motion end frame
- write the playback range as `0..maxFrame` and derive the public timeline from document settings
- cover fixed-track and timeline field placement with focused regression assertions

## Root cause
`build-pmm` mixed three different PMMv2 concepts: the fixed-track expansion block, the timeline panel width in the header, and the document playback range. Long motions wrote `maxFrame` (6420 for the Kotora sample) as the UI panel width, while the actual playback range remained `500..0`. MMD either exited during load or stayed at frame 0 when playback was requested.

## Verification
- `cargo test -p mmd-anim-format`: 322 passed
- `cargo test -p mmd-anim-cli`: 183 passed, 1 ignored
- `cargo fmt --all -- --check`
- `cargo clippy -p mmd-anim-format -p mmd-anim-cli --all-targets -- -D warnings`
- independent review deletion pass: lean

## Real MMD host gate
Using `F:\Develop\MMDDev\MMDDumper\MikuMikuDance_v932x64` and its installed `mmd_oracle_plugin.dll`:

- generated a 3,017,731-byte PMM from Kotora PMX + Weekender Girl VMD (`maxFrame=6420`)
- MMD loaded it directly with the project title visible and remained responsive
- playback started through the MMDDumper runner
- 9 records accumulated from frame 0 through 59.8200023, including neighborhoods around frames 30 and 60
- no PMM/JSONL/dump artifact was retained after the run