### PR TITLE
feat(ffi): expose VPD JSON codec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -399,6 +399,7 @@ dependencies = [
 name = "mmd-anim-ffi"
 version = "0.4.2"
 dependencies = [
+ "encoding_rs",
  "glam",
  "mmd-anim-format",
  "mmd-anim-physics-bullet",

--- a/crates/mmd-anim-ffi/Cargo.toml
+++ b/crates/mmd-anim-ffi/Cargo.toml
@@ -16,6 +16,7 @@ name = "mmd_runtime_ffi"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
+encoding_rs.workspace = true
 glam.workspace = true
 mmd-anim-runtime.workspace = true
 mmd-anim-format = { path = "../mmd-anim-format", version = "0.4.2", features = ["fbx"] }

--- a/crates/mmd-anim-ffi/include/mmd_runtime.h
+++ b/crates/mmd-anim-ffi/include/mmd_runtime.h
@@ -759,6 +759,24 @@ mmd_runtime_ffi_byte_buffer_t mmd_runtime_parse_vmd_json(
     const uint8_t* data,
     size_t         len);
 
+/* Converts a camelCase VpdParsedPose UTF-8 JSON DTO to Shift-JIS VPD bytes.
+   The input is borrowed only for the call. Invalid input, malformed JSON, or
+   text that cannot be represented in Shift-JIS returns an empty buffer and
+   sets the thread-local last error. The caller owns a non-empty returned
+   buffer and must free it with mmd_runtime_byte_buffer_free. */
+mmd_runtime_ffi_byte_buffer_t mmd_runtime_export_vpd_pose_json(
+    const uint8_t* json,
+    size_t         json_len);
+
+/* Converts Shift-JIS VPD bytes to a UTF-8 VpdParsedPose JSON DTO. The input is
+   borrowed only for the call. Invalid input, malformed VPD, or invalid
+   Shift-JIS returns an empty buffer and sets the thread-local last error. The
+   caller owns a non-empty returned buffer and must free it with
+   mmd_runtime_byte_buffer_free. */
+mmd_runtime_ffi_byte_buffer_t mmd_runtime_parse_vpd_pose_json(
+    const uint8_t* data,
+    size_t         len);
+
 /* Opt-in shared VMD context. The constructor parses the bytes once and owns
    all retained channels. Clips made from it own independent compiled tracks
    and remain valid after the context is freed. */

--- a/crates/mmd-anim-ffi/src/lib.rs
+++ b/crates/mmd-anim-ffi/src/lib.rs
@@ -1031,12 +1031,15 @@ const RIG_BONE_FIXED_AXIS: u32 = 1;
 const FFI_PANIC_ERROR_MESSAGE: &str = "internal panic in mmd-anim-ffi";
 const FFI_ERR_INVALID_INPUT: &str = "invalid input";
 const FFI_ERR_VMD_PARSE_FAILED: &str = "vmd parse failed";
+const FFI_ERR_VPD_PARSE_FAILED: &str = "vpd parse failed";
 const FFI_ERR_PMX_PARSE_FAILED: &str = "pmx parse failed";
 const FFI_ERR_PMX_IMPORT_FAILED: &str = "pmx import failed";
 const FFI_ERR_VMD_IMPORT_FAILED: &str = "vmd import failed";
 const FFI_ERR_CLIP_CREATE_FAILED: &str = "clip create failed";
 const FFI_ERR_PMX_EXPORT_FAILED: &str = "pmx export failed";
 const FFI_ERR_VMD_EXPORT_FAILED: &str = "vmd export failed";
+const FFI_ERR_VPD_EXPORT_FAILED: &str = "vpd export failed";
+const FFI_ERR_JSON_DECODE_FAILED: &str = "json decode failed";
 const FFI_ERR_JSON_ENCODE_FAILED: &str = "json encode failed";
 const FFI_ERR_WORKER_PANIC: &str = "worker panic";
 
@@ -1567,6 +1570,113 @@ pub unsafe extern "C" fn mmd_runtime_parse_vmd_json(
             Ok(parsed) => parsed,
             Err(_) => return empty_byte_buffer_failure(FFI_ERR_VMD_PARSE_FAILED),
         };
+
+        match serde_json::to_vec(&parsed) {
+            Ok(json) => byte_buffer_from_vec(json),
+            Err(_) => empty_byte_buffer_failure(FFI_ERR_JSON_ENCODE_FAILED),
+        }
+    })
+}
+
+fn is_valid_shift_jis(bytes: &[u8]) -> bool {
+    let (_, _, had_errors) = encoding_rs::SHIFT_JIS.decode(bytes);
+    !had_errors
+}
+
+fn is_shift_jis_encodable(text: &str) -> bool {
+    let (_, _, had_errors) = encoding_rs::SHIFT_JIS.encode(text);
+    !had_errors
+}
+
+fn vpd_export_preserves_pose(source: &mmd_anim_format::VpdParsedPose, exported: &[u8]) -> bool {
+    let Ok(reparsed) = mmd_anim_format::parse_vpd_pose(exported) else {
+        return false;
+    };
+    source.model_file == reparsed.model_file
+        && source.bone_count == reparsed.bone_count
+        && source.bones.iter().zip(&reparsed.bones).all(|(a, b)| {
+            a.name == b.name
+                && a.translation
+                    .iter()
+                    .zip(b.translation)
+                    .all(|(a, b)| (a - b).abs() <= 1.0e-6)
+                && a.rotation
+                    .iter()
+                    .zip(b.rotation)
+                    .all(|(a, b)| (a - b).abs() <= 1.0e-6)
+        })
+}
+
+/// Exports a camelCase `VpdParsedPose` JSON DTO as Shift-JIS VPD bytes.
+///
+/// The input is borrowed only for this call. The returned buffer is owned by
+/// the caller and must be freed with `mmd_runtime_byte_buffer_free`.
+///
+/// # Safety
+///
+/// `json` must point to `json_len` readable bytes when `json_len` is non-zero.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn mmd_runtime_export_vpd_pose_json(
+    json: *const u8,
+    json_len: usize,
+) -> MmdRuntimeFfiByteBuffer {
+    ffi_guard(empty_byte_buffer(), || {
+        if json.is_null() || json_len == 0 {
+            return empty_byte_buffer_failure(FFI_ERR_INVALID_INPUT);
+        }
+
+        let json = unsafe { slice::from_raw_parts(json, json_len) };
+        let pose: mmd_anim_format::VpdParsedPose = match serde_json::from_slice(json) {
+            Ok(pose) => pose,
+            Err(_) => return empty_byte_buffer_failure(FFI_ERR_JSON_DECODE_FAILED),
+        };
+        if pose.bone_count != pose.bones.len()
+            || !is_shift_jis_encodable(&pose.model_file)
+            || pose
+                .bones
+                .iter()
+                .any(|bone| !is_shift_jis_encodable(&bone.name))
+        {
+            return empty_byte_buffer_failure(FFI_ERR_VPD_EXPORT_FAILED);
+        }
+
+        let exported = mmd_anim_format::export_vpd_pose(&pose);
+        if !vpd_export_preserves_pose(&pose, &exported) {
+            return empty_byte_buffer_failure(FFI_ERR_VPD_EXPORT_FAILED);
+        }
+        byte_buffer_from_vec(exported)
+    })
+}
+
+/// Parses Shift-JIS VPD bytes and returns UTF-8 `VpdParsedPose` JSON.
+///
+/// The input is borrowed only for this call. The returned buffer is owned by
+/// the caller and must be freed with `mmd_runtime_byte_buffer_free`.
+///
+/// # Safety
+///
+/// `data` must point to `len` readable bytes when `len` is non-zero.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn mmd_runtime_parse_vpd_pose_json(
+    data: *const u8,
+    len: usize,
+) -> MmdRuntimeFfiByteBuffer {
+    ffi_guard(empty_byte_buffer(), || {
+        if data.is_null() || len == 0 {
+            return empty_byte_buffer_failure(FFI_ERR_INVALID_INPUT);
+        }
+
+        let bytes = unsafe { slice::from_raw_parts(data, len) };
+        if !is_valid_shift_jis(bytes) {
+            return empty_byte_buffer_failure(FFI_ERR_VPD_PARSE_FAILED);
+        }
+        let parsed = match mmd_anim_format::parse_vpd_pose(bytes) {
+            Ok(parsed) => parsed,
+            Err(_) => return empty_byte_buffer_failure(FFI_ERR_VPD_PARSE_FAILED),
+        };
+        if !parsed.diagnostics.is_empty() {
+            return empty_byte_buffer_failure(FFI_ERR_VPD_PARSE_FAILED);
+        }
 
         match serde_json::to_vec(&parsed) {
             Ok(json) => byte_buffer_from_vec(json),

--- a/crates/mmd-anim-ffi/src/tests.rs
+++ b/crates/mmd-anim-ffi/src/tests.rs
@@ -6242,6 +6242,172 @@ fn vmd_json_rejects_null_empty_invalid() {
     assert_eq!(invalid.len, 0);
 }
 
+fn vpd_json_fixture() -> Vec<u8> {
+    serde_json::to_vec(&serde_json::json!({
+        "modelFile": "model.pmx",
+        "boneCount": 2,
+        "bones": [
+            {
+                "name": "左腕",
+                "translation": [1.1234564, 2.0, -3.25],
+                "rotation": [0.1, 0.2, 0.3, 0.9238794]
+            },
+            {
+                "name": "右腕",
+                "translation": [-4.5, 5.25, 6.0],
+                "rotation": [0.0, 0.0, 0.0, 1.0]
+            }
+        ]
+    }))
+    .unwrap()
+}
+
+fn assert_f32_slice_near(actual: &[f32], expected: &[f32], epsilon: f32) {
+    assert_eq!(actual.len(), expected.len());
+    for (index, (&actual, &expected)) in actual.iter().zip(expected).enumerate() {
+        assert!(
+            (actual - expected).abs() <= epsilon,
+            "value {index}: actual={actual}, expected={expected}, epsilon={epsilon}"
+        );
+    }
+}
+
+fn assert_vpd_pose_matches_fixture(pose: &mmd_anim_format::VpdParsedPose) {
+    assert_eq!(pose.model_file, "model.pmx");
+    assert_eq!(pose.bone_count, 2);
+    assert_eq!(
+        pose.bones
+            .iter()
+            .map(|bone| bone.name.as_str())
+            .collect::<Vec<_>>(),
+        ["左腕", "右腕"]
+    );
+    assert_f32_slice_near(&pose.bones[0].translation, &[1.1234564, 2.0, -3.25], 1.0e-6);
+    assert_f32_slice_near(&pose.bones[0].rotation, &[0.1, 0.2, 0.3, 0.9238794], 1.0e-6);
+}
+
+#[test]
+fn vpd_json_ffi_exports_and_parses_owned_roundtrip_buffers() {
+    let source_json = vpd_json_fixture();
+    let vpd_buffer =
+        unsafe { mmd_runtime_export_vpd_pose_json(source_json.as_ptr(), source_json.len()) };
+    assert!(!vpd_buffer.data.is_null());
+    assert!(vpd_buffer.len > 0);
+    let vpd = ffi_buffer_to_vec(vpd_buffer);
+    assert!(vpd.starts_with(b"Vocaloid Pose Data file"));
+
+    let parsed_by_codec = mmd_anim_format::parse_vpd_pose(&vpd).unwrap();
+    assert_vpd_pose_matches_fixture(&parsed_by_codec);
+
+    let json_buffer = unsafe { mmd_runtime_parse_vpd_pose_json(vpd.as_ptr(), vpd.len()) };
+    assert!(!json_buffer.data.is_null());
+    assert!(json_buffer.len > 0);
+    let parsed_json = ffi_buffer_to_vec(json_buffer);
+    let reparsed: mmd_anim_format::VpdParsedPose = serde_json::from_slice(&parsed_json).unwrap();
+    assert_vpd_pose_matches_fixture(&reparsed);
+}
+
+#[test]
+fn vpd_json_ffi_fails_closed_and_sets_last_error() {
+    let dummy = 0u8;
+    for buffer in [
+        unsafe { mmd_runtime_export_vpd_pose_json(ptr::null(), 1) },
+        unsafe { mmd_runtime_export_vpd_pose_json(&dummy, 0) },
+        unsafe { mmd_runtime_parse_vpd_pose_json(ptr::null(), 1) },
+        unsafe { mmd_runtime_parse_vpd_pose_json(&dummy, 0) },
+    ] {
+        assert_empty_ffi_buffer(buffer, "null or empty VPD JSON FFI input");
+        assert_eq!(
+            last_error_cstr().unwrap().to_bytes(),
+            FFI_ERR_INVALID_INPUT.as_bytes()
+        );
+    }
+
+    let malformed_json = br#"{"modelFile":"model.pmx""#;
+    let buffer =
+        unsafe { mmd_runtime_export_vpd_pose_json(malformed_json.as_ptr(), malformed_json.len()) };
+    assert_empty_ffi_buffer(buffer, "malformed VPD JSON");
+    assert_eq!(
+        last_error_cstr().unwrap().to_bytes(),
+        FFI_ERR_JSON_DECODE_FAILED.as_bytes()
+    );
+
+    let unencodable = serde_json::to_vec(&serde_json::json!({
+        "modelFile": "model.pmx",
+        "boneCount": 1,
+        "bones": [{
+            "name": "腕😀",
+            "translation": [0.0, 0.0, 0.0],
+            "rotation": [0.0, 0.0, 0.0, 1.0]
+        }]
+    }))
+    .unwrap();
+    let buffer =
+        unsafe { mmd_runtime_export_vpd_pose_json(unencodable.as_ptr(), unencodable.len()) };
+    assert_empty_ffi_buffer(buffer, "unencodable VPD JSON text");
+    assert_eq!(
+        last_error_cstr().unwrap().to_bytes(),
+        FFI_ERR_VPD_EXPORT_FAILED.as_bytes()
+    );
+
+    let lossy_model_file = serde_json::to_vec(&serde_json::json!({
+        "modelFile": "folder//model.pmx",
+        "boneCount": 0,
+        "bones": []
+    }))
+    .unwrap();
+    let buffer = unsafe {
+        mmd_runtime_export_vpd_pose_json(lossy_model_file.as_ptr(), lossy_model_file.len())
+    };
+    assert_empty_ffi_buffer(buffer, "lossy VPD grammar characters");
+    assert_eq!(
+        last_error_cstr().unwrap().to_bytes(),
+        FFI_ERR_VPD_EXPORT_FAILED.as_bytes()
+    );
+
+    let invalid_magic = b"not a VPD";
+    let buffer =
+        unsafe { mmd_runtime_parse_vpd_pose_json(invalid_magic.as_ptr(), invalid_magic.len()) };
+    assert_empty_ffi_buffer(buffer, "invalid VPD magic");
+    assert_eq!(
+        last_error_cstr().unwrap().to_bytes(),
+        FFI_ERR_VPD_PARSE_FAILED.as_bytes()
+    );
+
+    let truncated = b"Vocaloid Pose Data file\r\n";
+    let buffer = unsafe { mmd_runtime_parse_vpd_pose_json(truncated.as_ptr(), truncated.len()) };
+    assert_empty_ffi_buffer(buffer, "truncated VPD");
+    assert_eq!(
+        last_error_cstr().unwrap().to_bytes(),
+        FFI_ERR_VPD_PARSE_FAILED.as_bytes()
+    );
+
+    let invalid_shift_jis = b"Vocaloid Pose Data file\r\n\r\nmodel\x81;\r\n0;\r\n";
+    let buffer = unsafe {
+        mmd_runtime_parse_vpd_pose_json(invalid_shift_jis.as_ptr(), invalid_shift_jis.len())
+    };
+    assert_empty_ffi_buffer(buffer, "invalid Shift-JIS VPD");
+    assert_eq!(
+        last_error_cstr().unwrap().to_bytes(),
+        FFI_ERR_VPD_PARSE_FAILED.as_bytes()
+    );
+}
+
+#[test]
+fn vpd_json_header_declarations_match_rust_exports() {
+    type VpdJsonFn = unsafe extern "C" fn(*const u8, usize) -> MmdRuntimeFfiByteBuffer;
+    let _: VpdJsonFn = mmd_runtime_export_vpd_pose_json;
+    let _: VpdJsonFn = mmd_runtime_parse_vpd_pose_json;
+
+    let header = include_str!("../include/mmd_runtime.h");
+    assert!(header.contains(
+        "mmd_runtime_ffi_byte_buffer_t mmd_runtime_export_vpd_pose_json(\n    const uint8_t* json,\n    size_t         json_len);"
+    ));
+    assert!(header.contains(
+        "mmd_runtime_ffi_byte_buffer_t mmd_runtime_parse_vpd_pose_json(\n    const uint8_t* data,\n    size_t         len);"
+    ));
+}
+
 #[test]
 fn vmd_json_serializes_camera_fixture() {
     let bytes: &[u8] = include_bytes!("../../mmd-anim-format/fixtures/vmd/simple_camera.vmd");

--- a/crates/mmd-anim-format/src/vpd.rs
+++ b/crates/mmd-anim-format/src/vpd.rs
@@ -41,15 +41,24 @@ pub fn parse_vpd_pose(data: &[u8]) -> Result<VpdParsedPose, ImportError> {
     }
     let mut lines = text.lines().map(str::trim).filter(|line| !line.is_empty());
     let _header = lines.next();
-    let model_file = strip_comment(lines.next().unwrap_or(""))
-        .trim_end_matches(';')
-        .trim()
-        .to_owned();
-    let count_line = lines.next().unwrap_or("0;");
-    let declared_count = count_line
+    let model_file = strip_comment(lines.next().ok_or(ImportError::UnsupportedFormat {
+        format: "VPD",
+        detail: "missing model file",
+    })?)
+    .trim_end_matches(';')
+    .trim()
+    .to_owned();
+    let count_line = lines.next().ok_or(ImportError::UnsupportedFormat {
+        format: "VPD",
+        detail: "missing bone count",
+    })?;
+    let declared_count = strip_comment(count_line)
         .trim_end_matches(';')
         .parse::<usize>()
-        .unwrap_or(0);
+        .map_err(|_| ImportError::UnsupportedFormat {
+            format: "VPD",
+            detail: "invalid bone count",
+        })?;
     let mut bones = Vec::new();
     while let Some(line) = lines.next() {
         if let Some(rest) = line.strip_prefix("Bone") {
@@ -59,13 +68,38 @@ pub fn parse_vpd_pose(data: &[u8]) -> Result<VpdParsedPose, ImportError> {
                 .map(|name| name.trim().to_owned())
                 .filter(|name| !name.is_empty())
             else {
-                continue;
+                return Err(ImportError::UnsupportedFormat {
+                    format: "VPD",
+                    detail: "invalid bone name",
+                });
             };
-            let translation = lines.next().map(parse_f32_tuple3).unwrap_or([0.0; 3]);
-            let rotation = lines
-                .next()
-                .map(parse_f32_tuple4)
-                .unwrap_or([0.0, 0.0, 0.0, 1.0]);
+            let translation =
+                parse_f32_tuple3(lines.next().ok_or(ImportError::UnsupportedFormat {
+                    format: "VPD",
+                    detail: "missing bone translation",
+                })?)
+                .ok_or(ImportError::UnsupportedFormat {
+                    format: "VPD",
+                    detail: "invalid bone translation",
+                })?;
+            let rotation =
+                lines
+                    .next()
+                    .and_then(parse_f32_tuple4)
+                    .ok_or(ImportError::UnsupportedFormat {
+                        format: "VPD",
+                        detail: "invalid bone rotation",
+                    })?;
+            let closing = lines.next().ok_or(ImportError::UnsupportedFormat {
+                format: "VPD",
+                detail: "missing bone terminator",
+            })?;
+            if strip_comment(closing) != "}" {
+                return Err(ImportError::UnsupportedFormat {
+                    format: "VPD",
+                    detail: "invalid bone terminator",
+                });
+            }
             bones.push(VpdBonePose {
                 name,
                 translation,
@@ -79,7 +113,7 @@ pub fn parse_vpd_pose(data: &[u8]) -> Result<VpdParsedPose, ImportError> {
         model_file,
         bone_count: parsed_bone_count,
         bones,
-        diagnostics: if declared_count != 0 && declared_count != parsed_bone_count {
+        diagnostics: if declared_count != parsed_bone_count {
             vec![VpdDiagnostic {
                 level: "warning",
                 code: "VPD_DECLARED_COUNT_MISMATCH",
@@ -114,30 +148,24 @@ pub fn export_vpd_pose(pose: &VpdParsedPose) -> Vec<u8> {
     encode_sjis(&text)
 }
 
-fn parse_f32_tuple3(line: &str) -> [f32; 3] {
-    let values = parse_numbers(line);
-    [
-        values.first().copied().unwrap_or(0.0),
-        values.get(1).copied().unwrap_or(0.0),
-        values.get(2).copied().unwrap_or(0.0),
-    ]
+fn parse_f32_tuple3(line: &str) -> Option<[f32; 3]> {
+    parse_numbers(line).and_then(|values| values.try_into().ok())
 }
 
-fn parse_f32_tuple4(line: &str) -> [f32; 4] {
-    let values = parse_numbers(line);
-    [
-        values.first().copied().unwrap_or(0.0),
-        values.get(1).copied().unwrap_or(0.0),
-        values.get(2).copied().unwrap_or(0.0),
-        values.get(3).copied().unwrap_or(1.0),
-    ]
+fn parse_f32_tuple4(line: &str) -> Option<[f32; 4]> {
+    parse_numbers(line).and_then(|values| values.try_into().ok())
 }
 
-fn parse_numbers(line: &str) -> Vec<f32> {
+fn parse_numbers(line: &str) -> Option<Vec<f32>> {
     strip_comment(line)
         .trim_matches(|c: char| c == ';' || c == '{' || c == '}')
         .split(',')
-        .filter_map(|part| part.trim().parse::<f32>().ok())
+        .map(|part| {
+            part.trim()
+                .parse::<f32>()
+                .ok()
+                .filter(|value| value.is_finite())
+        })
         .collect()
 }
 
@@ -189,5 +217,19 @@ mod tests {
             keys,
             vec!["boneCount", "bones", "diagnostics", "format", "modelFile"]
         );
+    }
+
+    #[test]
+    fn rejects_truncated_or_malformed_bone_records() {
+        for source in [
+            "Vocaloid Pose Data file\r\n",
+            "Vocaloid Pose Data file\r\n\r\nmodel.pmx;\r\n",
+            "Vocaloid Pose Data file\r\n\r\nmodel.pmx;\r\n1;\r\nBone0{左腕\r\n",
+            "Vocaloid Pose Data file\r\n\r\nmodel.pmx;\r\n1;\r\nBone0{左腕\r\n0,0,0;\r\n0,0,0,1;\r\n",
+            "Vocaloid Pose Data file\r\n\r\nmodel.pmx;\r\n1;\r\nBone0{左腕\r\ninvalid;\r\n0,0,0,1;\r\n}\r\n",
+            "Vocaloid Pose Data file\r\n\r\nmodel.pmx;\r\n1;\r\nBone0{左腕\r\nNaN,0,0;\r\n0,0,0,1;\r\n}\r\n",
+        ] {
+            assert!(parse_vpd_pose(&encode_sjis(source)).is_err(), "{source:?}");
+        }
     }
 }

--- a/tools/check_ffi_header_symbols.py
+++ b/tools/check_ffi_header_symbols.py
@@ -589,6 +589,17 @@ VMD_FROM_PARTS_FUNCTIONS = {
     ),
 }
 
+VPD_JSON_FUNCTIONS = {
+    "mmd_runtime_export_vpd_pose_json": (
+        "ffi_byte_buffer",
+        [("json", "const_u8_ptr"), ("json_len", "usize")],
+    ),
+    "mmd_runtime_parse_vpd_pose_json": (
+        "ffi_byte_buffer",
+        [("data", "const_u8_ptr"), ("len", "usize")],
+    ),
+}
+
 
 def rust_exported_symbols(text: str) -> set[str]:
     lines = text.splitlines()
@@ -860,41 +871,22 @@ def check_abi_shapes(rust_text: str, header_text: str) -> list[str]:
             errors.append(
                 f"struct {rust_name}/{c_alias}: Rust={rust_fields}, header={c_fields}, expected={expected}"
             )
-    for name, expected in GENERIC_FUNCTIONS.items():
-        rust_shape = rust_function_shape(rust_text, name)
-        c_shape = c_function_shape(header_text, name)
-        if rust_shape != expected or c_shape != expected or rust_shape != c_shape:
-            errors.append(
-                f"function {name}: Rust={rust_shape}, header={c_shape}, expected={expected}"
-            )
-    for name, expected in CLIP_TRACK_FUNCTIONS.items():
-        rust_shape = rust_function_shape(rust_text, name)
-        c_shape = c_function_shape(header_text, name)
-        if rust_shape != expected or c_shape != expected or rust_shape != c_shape:
-            errors.append(
-                f"function {name}: Rust={rust_shape}, header={c_shape}, expected={expected}"
-            )
-    for name, expected in VMD_SHARED_CONTEXT_FUNCTIONS.items():
-        rust_shape = rust_function_shape(rust_text, name)
-        c_shape = c_function_shape(header_text, name)
-        if rust_shape != expected or c_shape != expected or rust_shape != c_shape:
-            errors.append(
-                f"function {name}: Rust={rust_shape}, header={c_shape}, expected={expected}"
-            )
-    for name, expected in PHYSICS_PARAM_FUNCTIONS.items():
-        rust_shape = rust_function_shape(rust_text, name)
-        c_shape = c_function_shape(header_text, name)
-        if rust_shape != expected or c_shape != expected or rust_shape != c_shape:
-            errors.append(
-                f"function {name}: Rust={rust_shape}, header={c_shape}, expected={expected}"
-            )
-    for name, expected in VMD_FROM_PARTS_FUNCTIONS.items():
-        rust_shape = rust_function_shape(rust_text, name)
-        c_shape = c_function_shape(header_text, name)
-        if rust_shape != expected or c_shape != expected or rust_shape != c_shape:
-            errors.append(
-                f"function {name}: Rust={rust_shape}, header={c_shape}, expected={expected}"
-            )
+    function_groups = (
+        GENERIC_FUNCTIONS,
+        CLIP_TRACK_FUNCTIONS,
+        VMD_SHARED_CONTEXT_FUNCTIONS,
+        PHYSICS_PARAM_FUNCTIONS,
+        VMD_FROM_PARTS_FUNCTIONS,
+        VPD_JSON_FUNCTIONS,
+    )
+    for functions in function_groups:
+        for name, expected in functions.items():
+            rust_shape = rust_function_shape(rust_text, name)
+            c_shape = c_function_shape(header_text, name)
+            if rust_shape != expected or c_shape != expected or rust_shape != c_shape:
+                errors.append(
+                    f"function {name}: Rust={rust_shape}, header={c_shape}, expected={expected}"
+                )
     return errors
 
 


### PR DESCRIPTION
## Summary
- expose the existing mmd-anim-format VPD codec through JSON-based C ABI encode and parse entry points
- preserve Rust-owned byte-buffer, ffi_guard, and thread-local last-error contracts
- reject null/empty input, malformed JSON/VPD, invalid Shift-JIS, lossy text export, and truncated VPD records
- extend the public header and ABI shape checks

## Validation
- cargo fmt --all -- --check
- cargo test -p mmd-anim-format (323 passed)
- cargo test -p mmd-anim-ffi (126 passed)
- cargo test --workspace (924 passed, 3 ignored)
- cargo clippy --workspace --all-targets -- -D warnings
- cargo doc --workspace --no-deps
- python tools/check_ffi_header_symbols.py
- python tools/check_python_abi_drift.py
- pwsh -NoProfile -File crates/mmd-anim-ffi/scripts/smoke.ps1
- git diff --check

## Scope
No maya_mmd_tools, CLI, or WASM surface changes. VPD serialization and parsing remain owned by crates/mmd-anim-format/src/vpd.rs.