### PR TITLE
feat(package): validate KTX2 UASTC payloads

### DIFF
--- a/crates/mmd-anim-cli/src/commands/package.rs
+++ b/crates/mmd-anim-cli/src/commands/package.rs
@@ -244,7 +244,7 @@ fn verify_package(package_path: &Path, key_path: &Path, strict_codecs: bool) -> 
             .join(",");
         println!("unknown_codecs: {ids}");
     }
-    println!("texture_payload_validation: manifest metadata only; KTX2 payload/DFD deferred");
+    println!("texture_payload_validation: KTX2 header/DFD/mip ranges validated");
     Ok(ExitCode::SUCCESS)
 }
 
@@ -1185,30 +1185,11 @@ mod tests {
     }
 
     #[test]
-    fn pack_and_unpack_roundtrip_minimal_pmx_without_external_assets() {
+    fn pack_and_unpack_roundtrip_minimal_pmx_and_ktx2_without_external_assets() {
         let root = tempfile_path("roundtrip-input");
-        fs::create_dir_all(root.join("model")).unwrap();
         let model = minimal_pmx_prefix();
-        fs::write(root.join("model/model.pmx"), &model).unwrap();
-        let config = json!({
-            "defaultModelEntryId": 1,
-            "entries": [{
-                "id": 1,
-                "path": "model/model.pmx",
-                "kind": "model",
-                "codec": "pmx",
-                "compression": "none"
-            }],
-            "modelBindings": [{
-                "modelEntryId": 1,
-                "textureBindings": []
-            }]
-        });
-        fs::write(
-            root.join("mmdpack.json"),
-            serde_json::to_vec(&config).unwrap(),
-        )
-        .unwrap();
+        let texture = minimal_ktx2_uastc_4x4();
+        write_ktx2_pack_fixture(&root, &texture, ktx2_texture_metadata());
         let package_path = tempfile_path("roundtrip.mmdpack");
         let key_path = tempfile_path("roundtrip.key");
         let output_dir = tempfile_path("roundtrip-output");
@@ -1219,11 +1200,42 @@ mod tests {
         verify_package(&package_path, &key_path, true).unwrap();
         unpack_package(&package_path, &output_dir, &key_path).unwrap();
         assert_eq!(fs::read(output_dir.join("model/model.pmx")).unwrap(), model);
+        assert_eq!(
+            fs::read(output_dir.join("texture/diffuse.ktx2")).unwrap(),
+            texture
+        );
 
         let _ = fs::remove_dir_all(root);
         let _ = fs::remove_file(package_path);
         let _ = fs::remove_file(key_path);
         let _ = fs::remove_dir_all(output_dir);
+    }
+
+    #[test]
+    fn pack_rejects_invalid_ktx2_metadata_and_payload_before_publish() {
+        let mut mismatched_metadata = ktx2_texture_metadata();
+        mismatched_metadata["width"] = Value::from(8);
+        let mut malformed_payload = minimal_ktx2_uastc_4x4();
+        malformed_payload[0] ^= 0xff;
+        let cases = [
+            ("metadata", minimal_ktx2_uastc_4x4(), mismatched_metadata),
+            ("payload", malformed_payload, ktx2_texture_metadata()),
+        ];
+
+        for (name, texture, metadata) in cases {
+            let root = tempfile_path(&format!("ktx2-invalid-{name}-input"));
+            write_ktx2_pack_fixture(&root, &texture, metadata);
+            let package_path = tempfile_path(&format!("ktx2-invalid-{name}.mmdpack"));
+            let key_path = tempfile_path(&format!("ktx2-invalid-{name}.key"));
+
+            assert!(pack_package(&root, None, &package_path, &key_path).is_err());
+            assert!(!package_path.exists());
+            assert!(!key_path.exists());
+
+            let _ = fs::remove_dir_all(root);
+            let _ = fs::remove_file(package_path);
+            let _ = fs::remove_file(key_path);
+        }
     }
 
     #[test]
@@ -1283,6 +1295,96 @@ mod tests {
         bytes.extend_from_slice(&0_i32.to_le_bytes());
         bytes.extend_from_slice(&0_i32.to_le_bytes());
         bytes.extend_from_slice(&0_i32.to_le_bytes());
+        bytes
+    }
+
+    fn write_ktx2_pack_fixture(root: &Path, texture: &[u8], metadata: Value) {
+        fs::create_dir_all(root.join("model")).unwrap();
+        fs::create_dir_all(root.join("texture")).unwrap();
+        fs::write(root.join("model/model.pmx"), minimal_pmx_prefix()).unwrap();
+        fs::write(root.join("texture/diffuse.ktx2"), texture).unwrap();
+        let config = json!({
+            "defaultModelEntryId": 1,
+            "entries": [
+                {
+                    "id": 1,
+                    "path": "model/model.pmx",
+                    "kind": "model",
+                    "codec": "pmx",
+                    "compression": "none"
+                },
+                {
+                    "id": 2,
+                    "path": "texture/diffuse.ktx2",
+                    "kind": "texture",
+                    "codec": "ktx2-uastc-v1",
+                    "compression": "none",
+                    "texture": metadata
+                }
+            ],
+            "modelBindings": [{"modelEntryId": 1, "textureBindings": []}]
+        });
+        fs::write(
+            root.join("mmdpack.json"),
+            serde_json::to_vec(&config).unwrap(),
+        )
+        .unwrap();
+    }
+
+    fn ktx2_texture_metadata() -> Value {
+        json!({
+            "width": 4,
+            "height": 4,
+            "mipCount": 1,
+            "colorSpace": "srgb",
+            "usage": "color",
+            "channelModel": "rgba",
+            "swizzle": "rgba",
+            "alphaMode": "straight",
+            "origin": "top-left"
+        })
+    }
+
+    fn minimal_ktx2_uastc_4x4() -> Vec<u8> {
+        let mut bytes = Vec::with_capacity(176);
+        bytes.extend_from_slice(b"\xABKTX 20\xBB\r\n\x1A\n");
+        for value in [
+            0_u32, // vkFormat: DFD describes the UASTC block format.
+            1,     // typeSize
+            4,     // pixelWidth
+            4,     // pixelHeight
+            0,     // pixelDepth
+            0,     // layerCount
+            1,     // faceCount
+            1,     // levelCount
+            0,     // supercompressionScheme
+            104,   // dfdByteOffset (after the 80-byte header and level index)
+            44,    // dfdByteLength
+            0,     // kvdByteOffset
+            0,     // kvdByteLength
+        ] {
+            bytes.extend_from_slice(&value.to_le_bytes());
+        }
+        bytes.extend_from_slice(&0_u64.to_le_bytes()); // sgdByteOffset
+        bytes.extend_from_slice(&0_u64.to_le_bytes()); // sgdByteLength
+        bytes.extend_from_slice(&160_u64.to_le_bytes()); // level byte offset
+        bytes.extend_from_slice(&16_u64.to_le_bytes()); // level byte length
+        bytes.extend_from_slice(&16_u64.to_le_bytes()); // uncompressed level length
+        bytes.extend_from_slice(&[
+            0x2c, 0x00, 0x00, 0x00, // total DFD size
+            0x00, 0x00, // vendorId
+            0x00, 0x00, // descriptorType: basic
+            0x02, 0x00, // versionNumber
+            0x28, 0x00, // descriptor block size
+            0xa6, 0x01, 0x02, 0x00, // UASTC color model, primaries, transfer, flags
+            0x03, 0x03, 0x00, 0x00, // 4x4 texel block dimensions
+            0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // 16-byte plane
+            0x00, 0x00, 0x7f, 0x03, 0x00, 0x00, 0x00, 0x00, // RGBA sample
+            0x00, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0xff,
+        ]);
+        assert_eq!(bytes.len(), 148);
+        bytes.resize(160, 0);
+        bytes.extend_from_slice(&[0; 16]);
         bytes
     }
 

--- a/crates/mmd-anim-package/src/error.rs
+++ b/crates/mmd-anim-package/src/error.rs
@@ -47,6 +47,8 @@ pub enum MmdPackageError {
     UnsupportedCodec(String),
     #[error("invalid zstd-v1 payload: {0}")]
     InvalidZstd(String),
+    #[error("invalid KTX2 UASTC payload: {0}")]
+    InvalidKtx2(String),
 }
 
 pub(crate) type Result<T> = std::result::Result<T, MmdPackageError>;

--- a/crates/mmd-anim-package/src/lib.rs
+++ b/crates/mmd-anim-package/src/lib.rs
@@ -41,6 +41,23 @@ const MAX_CREDITS: usize = 4_096;
 const MAX_LICENSE_REFS_PER_ENTRY: usize = 64;
 const MAX_TEXTURE_DIMENSION: u32 = 16_384;
 const MAX_TEXTURE_MIP_COUNT: usize = 32;
+const KTX2_HEADER_LEN: usize = 80;
+const KTX2_LEVEL_INDEX_ENTRY_LEN: usize = 24;
+const KTX2_ZSTD_SUPERCOMPRESSION: u32 = 2;
+const KTX2_DFD_SIZE: usize = 44;
+const KTX2_DFD_BLOCK_SIZE: usize = 40;
+const KTX2_MAX_KVD_BYTES: u64 = 16 * 1024 * 1024;
+const KTX2_IDENTIFIER: &[u8; 12] = b"\xabKTX 20\xbb\r\n\x1a\n";
+
+#[derive(Clone, Debug)]
+struct Ktx2TextureMetadata {
+    width: u32,
+    height: u32,
+    mip_count: usize,
+    color_space: String,
+    channel_model: String,
+    swizzle: String,
+}
 
 /// Parsed fixed header for the current draft wire format.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -190,8 +207,8 @@ pub struct MmdPackageEntry {
     pub decoded_size: u64,
 }
 
-/// Controls package-layer verification. Codec payload semantics are handled by
-/// the later codec/runtime integration layers.
+/// Controls package-layer verification. Known codec payload checks, including
+/// the private KTX2 profile, run while entries are decoded.
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct MmdPackageVerifyOptions {
     /// Reject manifest entries whose codec token is not known to this crate.
@@ -215,6 +232,7 @@ pub struct MmdPackage {
     header: MmdPackageHeader,
     manifest: MmdPackageManifest,
     model_bindings: Vec<MmdModelBinding>,
+    ktx2_metadata: HashMap<u32, Ktx2TextureMetadata>,
     payload_base: usize,
     entries_by_id: HashMap<u32, usize>,
     entries_by_path: HashMap<String, usize>,
@@ -274,7 +292,7 @@ impl MmdPackage {
         let manifest = parse_manifest(&manifest_value, &limits)?;
         validate_layout(&manifest.entries, bytes.len(), manifest_end, &limits)?;
         let model_bindings = validate_defaults(&manifest_value, &manifest)?;
-        validate_entry_metadata(&manifest_value, &manifest)?;
+        let ktx2_metadata = validate_entry_metadata(&manifest_value, &manifest)?;
 
         let entries_by_id = strict_json::index_by_id(&manifest.entries, |entry| entry.id);
         let entries_by_path = manifest
@@ -290,6 +308,7 @@ impl MmdPackage {
             header,
             manifest,
             model_bindings,
+            ktx2_metadata,
             payload_base: manifest_end,
             entries_by_id,
             entries_by_path,
@@ -433,13 +452,21 @@ impl MmdPackage {
             )
             .map_err(|_| MmdPackageError::AuthenticationFailed("entry"))?;
 
-        match entry.compression {
+        let decoded = match entry.compression {
             MmdPackageCompression::None => {
                 require_decoded_size(plaintext.len(), entry.decoded_size)?;
-                Ok(plaintext)
+                plaintext
             }
-            MmdPackageCompression::ZstdV1 => decode_zstd(&plaintext, entry.decoded_size),
+            MmdPackageCompression::ZstdV1 => decode_zstd(&plaintext, entry.decoded_size)?,
+        };
+        if entry.codec == "ktx2-uastc-v1" {
+            let metadata = self
+                .ktx2_metadata
+                .get(&entry.id)
+                .expect("validated KTX2 metadata is present");
+            validate_ktx2_payload(&decoded, entry.compression, metadata)?;
         }
+        Ok(decoded)
     }
 }
 
@@ -581,10 +608,14 @@ fn validate_json_value(value: &Value, depth: usize, nodes: &mut usize) -> Result
     }
 }
 
-fn validate_entry_metadata(root: &Value, manifest: &MmdPackageManifest) -> Result<()> {
+fn validate_entry_metadata(
+    root: &Value,
+    manifest: &MmdPackageManifest,
+) -> Result<HashMap<u32, Ktx2TextureMetadata>> {
     let root_object = strict_json::object(root).expect("manifest root was checked");
     let license_keys = validate_licenses(root_object)?;
     validate_credits(root_object)?;
+    let mut ktx2_metadata = HashMap::new();
 
     for entry in &manifest.entries {
         let object = manifest_entry_object(root, entry.id)?;
@@ -614,7 +645,12 @@ fn validate_entry_metadata(root: &Value, manifest: &MmdPackageManifest) -> Resul
                     entry.id
                 ));
             }
-            validate_texture_metadata(texture, entry)?;
+            if entry.codec == "ktx2-uastc-v1" {
+                let metadata = parse_ktx2_metadata(texture, entry.id)?;
+                ktx2_metadata.insert(entry.id, metadata);
+            } else {
+                validate_texture_metadata(texture, entry)?;
+            }
         } else if entry.kind == MmdPackageEntryKind::Texture {
             return invalid_manifest(format!(
                 "texture entry {} requires texture metadata",
@@ -643,7 +679,7 @@ fn validate_entry_metadata(root: &Value, manifest: &MmdPackageManifest) -> Resul
 
         validate_license_refs(object, entry.id, license_keys.as_ref())?;
     }
-    Ok(())
+    Ok(ktx2_metadata)
 }
 
 fn validate_licenses(root: &Map<String, Value>) -> Result<Option<HashSet<String>>> {
@@ -808,7 +844,7 @@ fn validate_texture_metadata(value: &Value, entry: &MmdPackageEntry) -> Result<(
     })?;
     match entry.codec.as_str() {
         "uastc-ldr-4x4-v1" => validate_raw_uastc_metadata(object, entry),
-        "ktx2-uastc-v1" => validate_ktx2_metadata(object),
+        "ktx2-uastc-v1" => parse_ktx2_metadata(value, entry.id).map(|_| ()),
         _ => Ok(()),
     }
 }
@@ -914,10 +950,492 @@ fn validate_raw_uastc_metadata(object: &Map<String, Value>, entry: &MmdPackageEn
     Ok(())
 }
 
-fn validate_ktx2_metadata(object: &Map<String, Value>) -> Result<()> {
-    // This is deliberately a summary-only check. KTX2 header/DFD matching is
-    // owned by the later texture pipeline and is not covered at package open.
-    validate_texture_summary(object).map(|_| ())
+fn parse_ktx2_metadata(value: &Value, entry_id: u32) -> Result<Ktx2TextureMetadata> {
+    let object = value.as_object().ok_or_else(|| {
+        MmdPackageError::InvalidManifest(format!(
+            "texture metadata for entry {} must be an object",
+            entry_id
+        ))
+    })?;
+    let (width, height, mip_count) = validate_texture_summary(object)?;
+    Ok(Ktx2TextureMetadata {
+        width,
+        height,
+        mip_count,
+        color_space: field(strict_json::required_str(object, "colorSpace"))?.to_owned(),
+        channel_model: field(strict_json::required_str(object, "channelModel"))?.to_owned(),
+        swizzle: field(strict_json::required_str(object, "swizzle"))?.to_owned(),
+    })
+}
+
+fn validate_ktx2_payload(
+    payload: &[u8],
+    entry_compression: MmdPackageCompression,
+    metadata: &Ktx2TextureMetadata,
+) -> Result<()> {
+    if payload.len() < KTX2_HEADER_LEN {
+        return invalid_ktx2("payload is shorter than the KTX2 header");
+    }
+    if payload[..12] != *KTX2_IDENTIFIER {
+        return invalid_ktx2("invalid KTX2 identifier");
+    }
+
+    let vk_format = ktx2_u32(payload, 12, "vkFormat")?;
+    let type_size = ktx2_u32(payload, 16, "typeSize")?;
+    let width = ktx2_u32(payload, 20, "pixelWidth")?;
+    let height = ktx2_u32(payload, 24, "pixelHeight")?;
+    let depth = ktx2_u32(payload, 28, "pixelDepth")?;
+    let layer_count = ktx2_u32(payload, 32, "layerCount")?;
+    let face_count = ktx2_u32(payload, 36, "faceCount")?;
+    let level_count = ktx2_u32(payload, 40, "levelCount")?;
+    let supercompression = ktx2_u32(payload, 44, "supercompressionScheme")?;
+    let dfd_offset = ktx2_u32(payload, 48, "dfdByteOffset")? as u64;
+    let dfd_length = ktx2_u32(payload, 52, "dfdByteLength")? as u64;
+    let kvd_offset = ktx2_u32(payload, 56, "kvdByteOffset")? as u64;
+    let kvd_length = ktx2_u32(payload, 60, "kvdByteLength")? as u64;
+    let sgd_offset = ktx2_u64(payload, 64, "sgdByteOffset")?;
+    let sgd_length = ktx2_u64(payload, 72, "sgdByteLength")?;
+
+    if vk_format != 0 {
+        return invalid_ktx2(format!(
+            "UASTC KTX2 vkFormat must be undefined, got {vk_format}"
+        ));
+    }
+    if type_size != 1 {
+        return invalid_ktx2(format!("UASTC KTX2 typeSize must be 1, got {type_size}"));
+    }
+    if width != metadata.width || height != metadata.height {
+        return invalid_ktx2(format!(
+            "KTX2 dimensions {width}x{height} do not match manifest {}x{}",
+            metadata.width, metadata.height
+        ));
+    }
+    if depth != 0 {
+        return invalid_ktx2(format!("2D KTX2 pixelDepth must be 0, got {depth}"));
+    }
+    if layer_count > 1 {
+        return invalid_ktx2(format!(
+            "KTX2 layerCount must be 0 or 1 for one effective layer, got {layer_count}"
+        ));
+    }
+    if face_count != 1 {
+        return invalid_ktx2(format!("2D KTX2 faceCount must be 1, got {face_count}"));
+    }
+    if level_count == 0 || level_count as usize != metadata.mip_count {
+        return invalid_ktx2(format!(
+            "KTX2 levelCount {level_count} does not match manifest mipCount {}",
+            metadata.mip_count
+        ));
+    }
+    if level_count as usize > MAX_TEXTURE_MIP_COUNT {
+        return invalid_ktx2(format!(
+            "KTX2 levelCount {level_count} exceeds the supported limit"
+        ));
+    }
+    let mut max_dimension = width.max(height);
+    let mut max_level_count = 1_u32;
+    while max_dimension > 1 {
+        max_dimension = (max_dimension / 2).max(1);
+        max_level_count += 1;
+    }
+    if level_count > max_level_count {
+        return invalid_ktx2(format!(
+            "KTX2 levelCount {level_count} exceeds the mip chain for {width}x{height}"
+        ));
+    }
+    if supercompression != 0 && supercompression != KTX2_ZSTD_SUPERCOMPRESSION {
+        return invalid_ktx2(format!(
+            "unsupported KTX2 supercompression scheme {supercompression}"
+        ));
+    }
+    if supercompression == KTX2_ZSTD_SUPERCOMPRESSION
+        && entry_compression != MmdPackageCompression::None
+    {
+        return invalid_ktx2("KTX2 internal Zstd requires MMDPACK entry compression none");
+    }
+    if sgd_length != 0 || sgd_offset != 0 {
+        return invalid_ktx2("KTX2 UASTC must not contain supercompression global data");
+    }
+
+    let level_count = level_count as usize;
+    let index_end = KTX2_HEADER_LEN
+        .checked_add(
+            level_count
+                .checked_mul(KTX2_LEVEL_INDEX_ENTRY_LEN)
+                .ok_or(MmdPackageError::IntegerOverflow("KTX2 level index"))?,
+        )
+        .ok_or(MmdPackageError::IntegerOverflow("KTX2 level index"))?;
+    let mut ranges = vec![(0_u64, index_end as u64)];
+    if !dfd_offset.is_multiple_of(4) {
+        return invalid_ktx2("KTX2 dfdByteOffset must be 4-byte aligned");
+    }
+    add_ktx2_range(&mut ranges, payload, dfd_offset, dfd_length, "KTX2 DFD")?;
+    if dfd_length != KTX2_DFD_SIZE as u64 {
+        return invalid_ktx2(format!(
+            "KTX2 UASTC DFD must be {KTX2_DFD_SIZE} bytes, got {dfd_length}"
+        ));
+    }
+    if kvd_length != 0 {
+        check_limit("KTX2 key/value bytes", kvd_length, KTX2_MAX_KVD_BYTES)?;
+        if !kvd_offset.is_multiple_of(4) {
+            return invalid_ktx2("KTX2 kvdByteOffset must be 4-byte aligned");
+        }
+        add_ktx2_range(
+            &mut ranges,
+            payload,
+            kvd_offset,
+            kvd_length,
+            "KTX2 key/value data",
+        )?;
+    } else if kvd_offset != 0 {
+        return invalid_ktx2("KTX2 kvdByteOffset must be zero when kvdByteLength is zero");
+    }
+
+    let dfd = ktx2_range(payload, dfd_offset, dfd_length, "KTX2 DFD")?;
+    validate_ktx2_dfd(dfd, supercompression, metadata)?;
+    let (swizzle, _orientation) = if kvd_length == 0 {
+        ("rgba".to_owned(), "rd".to_owned())
+    } else {
+        parse_ktx2_kvd(ktx2_range(
+            payload,
+            kvd_offset,
+            kvd_length,
+            "KTX2 key/value data",
+        )?)?
+    };
+    if swizzle != metadata.swizzle {
+        return invalid_ktx2(format!(
+            "KTX2 swizzle {swizzle:?} does not match manifest {:?}",
+            metadata.swizzle
+        ));
+    }
+
+    let mut mip_width = width;
+    let mut mip_height = height;
+    let mut levels = Vec::with_capacity(level_count);
+    for level in 0..level_count {
+        let level_index_offset = KTX2_HEADER_LEN
+            .checked_add(
+                level
+                    .checked_mul(KTX2_LEVEL_INDEX_ENTRY_LEN)
+                    .ok_or(MmdPackageError::IntegerOverflow("KTX2 level index offset"))?,
+            )
+            .ok_or(MmdPackageError::IntegerOverflow("KTX2 level index offset"))?;
+        let byte_offset = ktx2_u64(payload, level_index_offset, "KTX2 level byteOffset")?;
+        let byte_length = ktx2_u64(payload, level_index_offset + 8, "KTX2 level byteLength")?;
+        let uncompressed_byte_length = ktx2_u64(
+            payload,
+            level_index_offset + 16,
+            "KTX2 level uncompressedByteLength",
+        )?;
+        let expected_size = (mip_width as u64)
+            .div_ceil(4)
+            .checked_mul((mip_height as u64).div_ceil(4))
+            .and_then(|size| size.checked_mul(16))
+            .ok_or(MmdPackageError::IntegerOverflow("KTX2 UASTC mip size"))?;
+        if uncompressed_byte_length != expected_size {
+            return invalid_ktx2(format!(
+                "KTX2 mip {level} uncompressed size {uncompressed_byte_length} does not match expected UASTC size {expected_size}"
+            ));
+        }
+        if byte_length == 0 {
+            return invalid_ktx2(format!("KTX2 mip {level} has an empty level"));
+        }
+        if supercompression == 0 && byte_length != uncompressed_byte_length {
+            return invalid_ktx2(format!(
+                "KTX2 mip {level} byteLength {byte_length} does not match uncompressedByteLength {uncompressed_byte_length}"
+            ));
+        }
+        if supercompression == 0 && byte_offset % 16 != 0 {
+            return invalid_ktx2(format!(
+                "KTX2 uncompressed mip {level} offset {byte_offset} is not 16-byte aligned"
+            ));
+        }
+        add_ktx2_range(
+            &mut ranges,
+            payload,
+            byte_offset,
+            byte_length,
+            "KTX2 level data",
+        )?;
+        levels.push((byte_offset, byte_length, uncompressed_byte_length));
+        mip_width = (mip_width / 2).max(1);
+        mip_height = (mip_height / 2).max(1);
+    }
+
+    if supercompression == KTX2_ZSTD_SUPERCOMPRESSION {
+        for (level, (byte_offset, byte_length, uncompressed_byte_length)) in
+            levels.into_iter().enumerate()
+        {
+            let compressed = ktx2_range(payload, byte_offset, byte_length, "KTX2 level data")?;
+            validate_ktx2_zstd_level(compressed, uncompressed_byte_length).map_err(|error| {
+                match error {
+                    MmdPackageError::InvalidKtx2(message) => {
+                        MmdPackageError::InvalidKtx2(format!("mip {level}: {message}"))
+                    }
+                    other => other,
+                }
+            })?;
+        }
+    }
+    Ok(())
+}
+
+fn validate_ktx2_dfd(
+    dfd: &[u8],
+    supercompression: u32,
+    metadata: &Ktx2TextureMetadata,
+) -> Result<()> {
+    if ktx2_u32(dfd, 0, "DFD totalSize")? as usize != KTX2_DFD_SIZE {
+        return invalid_ktx2("KTX2 DFD totalSize does not match its fixed UASTC block");
+    }
+    if ktx2_u32(dfd, 4, "DFD descriptor type")? != 0 {
+        return invalid_ktx2("KTX2 UASTC DFD must be a vendor-neutral basic descriptor");
+    }
+    if ktx2_u16(dfd, 8, "DFD version")? != 2
+        || ktx2_u16(dfd, 10, "DFD descriptor block size")? != KTX2_DFD_BLOCK_SIZE as u16
+    {
+        return invalid_ktx2("KTX2 UASTC DFD has an unsupported descriptor version or size");
+    }
+    if dfd[12] != 166 {
+        return invalid_ktx2(format!(
+            "KTX2 DFD color model must be UASTC (166), got {}",
+            dfd[12]
+        ));
+    }
+    if dfd[13] != 0 && dfd[13] != 1 {
+        return invalid_ktx2(format!(
+            "KTX2 UASTC DFD color primaries {} are outside this profile",
+            dfd[13]
+        ));
+    }
+    let expected_transfer = match metadata.color_space.as_str() {
+        "linear" => 1,
+        "srgb" => 2,
+        _ => unreachable!("texture summary validates colorSpace"),
+    };
+    if dfd[14] != expected_transfer {
+        return invalid_ktx2(format!(
+            "KTX2 DFD transfer function {} does not match manifest {}",
+            dfd[14], metadata.color_space
+        ));
+    }
+    if dfd[15] & 1 != 0 {
+        return invalid_ktx2("KTX2 UASTC DFD marks alpha as premultiplied");
+    }
+    if dfd[16..20] != [3, 3, 0, 0] {
+        return invalid_ktx2("KTX2 UASTC DFD must describe 4x4 texel blocks");
+    }
+    if dfd[21..28].iter().any(|byte| *byte != 0)
+        || (supercompression == 0 && dfd[20] != 16)
+        || (supercompression == KTX2_ZSTD_SUPERCOMPRESSION && dfd[20] != 0 && dfd[20] != 16)
+    {
+        return invalid_ktx2("KTX2 UASTC DFD has an invalid bytesPlane layout");
+    }
+
+    let sample = &dfd[28..44];
+    let sample_word = u32::from_le_bytes(sample[..4].try_into().unwrap());
+    let bit_offset = sample_word as u16;
+    let bit_length = ((sample_word >> 16) & 0xff) as u8;
+    let channel_type = (sample_word >> 24) as u8;
+    let channel_id = channel_type & 0x0f;
+    if bit_offset != 0
+        || bit_length != 127
+        || channel_type & 0x80 != 0
+        || sample[4..8].iter().any(|byte| *byte != 0)
+        || sample[8..12].iter().any(|byte| *byte != 0)
+        || sample[12..16] != [0xff; 4]
+    {
+        return invalid_ktx2("KTX2 UASTC DFD sample does not describe one LDR 128-bit block");
+    }
+    let dfd_channel_model = match channel_id {
+        0 => "rgb",
+        3 => "rgba",
+        4 => "r",
+        5 | 6 => "rg",
+        other => {
+            return invalid_ktx2(format!("unsupported KTX2 UASTC DFD channel id {other}"));
+        }
+    };
+    if dfd_channel_model != metadata.channel_model {
+        return invalid_ktx2(format!(
+            "KTX2 DFD channel model {dfd_channel_model:?} does not match manifest {:?}",
+            metadata.channel_model
+        ));
+    }
+    Ok(())
+}
+
+fn parse_ktx2_kvd(kvd: &[u8]) -> Result<(String, String)> {
+    let mut cursor = 0_usize;
+    let mut seen_keys: HashSet<&[u8]> = HashSet::new();
+    let mut swizzle = "rgba".to_owned();
+    let mut orientation = "rd".to_owned();
+    while cursor < kvd.len() {
+        let length_end = cursor
+            .checked_add(4)
+            .ok_or(MmdPackageError::IntegerOverflow("KTX2 key/value length"))?;
+        let length = usize::try_from(ktx2_u32(kvd, cursor, "keyAndValueByteLength")?)
+            .map_err(|_| MmdPackageError::IntegerOverflow("KTX2 key/value length"))?;
+        let value_start = length_end;
+        let value_end = value_start
+            .checked_add(length)
+            .ok_or(MmdPackageError::IntegerOverflow("KTX2 key/value end"))?;
+        if length < 2 || value_end > kvd.len() {
+            return invalid_ktx2("KTX2 key/value pair is truncated or empty");
+        }
+        let pair = &kvd[value_start..value_end];
+        let nul = pair
+            .iter()
+            .position(|byte| *byte == 0)
+            .ok_or_else(|| MmdPackageError::InvalidKtx2("KTX2 key is not NUL-terminated".into()))?;
+        if nul == 0 {
+            return invalid_ktx2("KTX2 key must not be empty");
+        }
+        let key = &pair[..nul];
+        if !seen_keys.insert(key) {
+            return invalid_ktx2("KTX2 key/value keys must be unique");
+        }
+        let value = &pair[nul + 1..];
+        let padding = (4 - (length % 4)) % 4;
+        let padded_end = value_end
+            .checked_add(padding)
+            .ok_or(MmdPackageError::IntegerOverflow("KTX2 key/value padding"))?;
+        if padded_end > kvd.len() || kvd[value_end..padded_end].iter().any(|byte| *byte != 0) {
+            return invalid_ktx2("KTX2 key/value padding is truncated or nonzero");
+        }
+
+        match key {
+            b"KTXswizzle" => {
+                swizzle = ktx2_metadata_string(value, "KTXswizzle")?;
+                if swizzle.len() != 4
+                    || !swizzle
+                        .bytes()
+                        .all(|byte| matches!(byte, b'r' | b'g' | b'b' | b'a' | b'0' | b'1'))
+                {
+                    return invalid_ktx2("KTXswizzle must contain four r/g/b/a/0/1 characters");
+                }
+            }
+            b"KTXorientation" => {
+                orientation = ktx2_metadata_string(value, "KTXorientation")?;
+                if orientation != "rd" {
+                    return invalid_ktx2(format!(
+                        "KTXorientation {orientation:?} is not top-left rd"
+                    ));
+                }
+            }
+            _ => {}
+        }
+        cursor = padded_end;
+    }
+    Ok((swizzle, orientation))
+}
+
+fn ktx2_metadata_string(value: &[u8], name: &'static str) -> Result<String> {
+    let value = value
+        .strip_suffix(&[0])
+        .ok_or_else(|| MmdPackageError::InvalidKtx2(format!("{name} must be NUL-terminated")))?;
+    std::str::from_utf8(value)
+        .map(str::to_owned)
+        .map_err(|_| MmdPackageError::InvalidKtx2(format!("{name} must be UTF-8")))
+}
+
+fn validate_ktx2_zstd_level(compressed: &[u8], expected: u64) -> Result<()> {
+    let frame_size = zstd::zstd_safe::find_frame_compressed_size(compressed)
+        .map_err(|code| MmdPackageError::InvalidKtx2(format!("invalid KTX2 Zstd frame: {code}")))?;
+    if frame_size != compressed.len() {
+        return invalid_ktx2("KTX2 Zstd level must contain exactly one frame");
+    }
+    let mut decoder = zstd::stream::read::Decoder::new(Cursor::new(compressed))
+        .map_err(|error| MmdPackageError::InvalidKtx2(error.to_string()))?;
+    decoder
+        .window_log_max(26)
+        .map_err(|error| MmdPackageError::InvalidKtx2(error.to_string()))?;
+    let mut limited = decoder.take(expected.saturating_add(1));
+    let total = std::io::copy(&mut limited, &mut std::io::sink())
+        .map_err(|error| MmdPackageError::InvalidKtx2(error.to_string()))?;
+    if total != expected {
+        return invalid_ktx2(format!(
+            "KTX2 Zstd level expanded to {total} bytes, expected {expected}"
+        ));
+    }
+    Ok(())
+}
+
+fn add_ktx2_range(
+    ranges: &mut Vec<(u64, u64)>,
+    payload: &[u8],
+    offset: u64,
+    length: u64,
+    name: &'static str,
+) -> Result<()> {
+    let end = offset
+        .checked_add(length)
+        .ok_or(MmdPackageError::IntegerOverflow("KTX2 section end"))?;
+    ktx2_range(payload, offset, length, name)?;
+    if length != 0
+        && ranges
+            .iter()
+            .any(|(start, previous_end)| offset < *previous_end && *start < end)
+    {
+        return invalid_ktx2(format!("KTX2 {name} overlaps another declared section"));
+    }
+    if length != 0 {
+        ranges.push((offset, end));
+    }
+    Ok(())
+}
+
+fn ktx2_range<'a>(
+    payload: &'a [u8],
+    offset: u64,
+    length: u64,
+    name: &'static str,
+) -> Result<&'a [u8]> {
+    let start = usize::try_from(offset)
+        .map_err(|_| MmdPackageError::IntegerOverflow("KTX2 section start"))?;
+    let length = usize::try_from(length)
+        .map_err(|_| MmdPackageError::IntegerOverflow("KTX2 section length"))?;
+    let end = start
+        .checked_add(length)
+        .ok_or(MmdPackageError::IntegerOverflow("KTX2 section end"))?;
+    payload
+        .get(start..end)
+        .ok_or_else(|| MmdPackageError::InvalidKtx2(format!("KTX2 {name} is outside the payload")))
+}
+
+fn ktx2_u16(bytes: &[u8], offset: usize, name: &'static str) -> Result<u16> {
+    let end = offset
+        .checked_add(2)
+        .ok_or(MmdPackageError::IntegerOverflow("KTX2 field end"))?;
+    let bytes = bytes
+        .get(offset..end)
+        .ok_or_else(|| MmdPackageError::InvalidKtx2(format!("KTX2 {name} is truncated")))?;
+    Ok(u16::from_le_bytes(bytes.try_into().unwrap()))
+}
+
+fn ktx2_u32(bytes: &[u8], offset: usize, name: &'static str) -> Result<u32> {
+    let end = offset
+        .checked_add(4)
+        .ok_or(MmdPackageError::IntegerOverflow("KTX2 field end"))?;
+    let bytes = bytes
+        .get(offset..end)
+        .ok_or_else(|| MmdPackageError::InvalidKtx2(format!("KTX2 {name} is truncated")))?;
+    Ok(u32::from_le_bytes(bytes.try_into().unwrap()))
+}
+
+fn ktx2_u64(bytes: &[u8], offset: usize, name: &'static str) -> Result<u64> {
+    let end = offset
+        .checked_add(8)
+        .ok_or(MmdPackageError::IntegerOverflow("KTX2 field end"))?;
+    let bytes = bytes
+        .get(offset..end)
+        .ok_or_else(|| MmdPackageError::InvalidKtx2(format!("KTX2 {name} is truncated")))?;
+    Ok(u64::from_le_bytes(bytes.try_into().unwrap()))
+}
+
+fn invalid_ktx2<T>(message: impl Into<String>) -> Result<T> {
+    Err(MmdPackageError::InvalidKtx2(message.into()))
 }
 
 fn texture_dimension(object: &Map<String, Value>, field_name: &'static str) -> Result<u32> {

--- a/crates/mmd-anim-package/src/pack.rs
+++ b/crates/mmd-anim-package/src/pack.rs
@@ -10,7 +10,7 @@ use zeroize::Zeroizing;
 use super::{
     GCM_TAG_LEN, MMDPACK_HEADER_LEN, MmdPackage, MmdPackageCompression, MmdPackageEntry,
     MmdPackageEntryKind, MmdPackageError, MmdPackageLimits, check_limit, entry_aad, entry_nonce,
-    manifest_nonce,
+    manifest_nonce, parse_ktx2_metadata, validate_ktx2_payload,
 };
 
 #[derive(Debug, Error)]
@@ -103,8 +103,7 @@ pub struct MmdPackagePackEntry {
     pub media_type: Option<String>,
     pub motion: Option<MmdPackageMotionMetadata>,
     /// Draft codec-specific texture metadata. Package-layer shape validation
-    /// applies to known UASTC/KTX2 profiles; payload semantics belong to the
-    /// later texture-pipeline slice.
+    /// applies to known UASTC/KTX2 profiles.
     pub texture: Option<Value>,
 }
 
@@ -298,6 +297,21 @@ fn validate_input_metadata(input: &MmdPackagePackInput) -> PackResult<()> {
             }
             _ => {}
         }
+        if entry.codec == "ktx2-uastc-v1" {
+            if entry.kind != MmdPackageEntryKind::Texture {
+                return Err(MmdPackagePackError::PackingFailed(format!(
+                    "codec ktx2-uastc-v1 requires texture kind for entry {}",
+                    entry.id
+                )));
+            }
+            let texture = entry.texture.as_ref().ok_or_else(|| {
+                MmdPackagePackError::PackingFailed(format!(
+                    "texture entry {} requires texture metadata",
+                    entry.id
+                ))
+            })?;
+            parse_ktx2_metadata(texture, entry.id)?;
+        }
         if entry.kind != MmdPackageEntryKind::Motion && entry.motion.is_some() {
             return Err(MmdPackagePackError::PackingFailed(format!(
                 "non-motion entry {} cannot contain motion metadata",
@@ -322,28 +336,41 @@ fn encode_entries(
     let mut encoded_entries = Vec::with_capacity(inputs.len());
     for input in inputs {
         let decoded_size = input.decoded.len() as u64;
-        let (compression, encoded) = match input.compression {
-            MmdPackagePackCompression::None => (
-                MmdPackageCompression::None,
-                std::mem::take(&mut input.decoded),
-            ),
+        let compressed = match input.compression {
+            MmdPackagePackCompression::None => None,
             MmdPackagePackCompression::ZstdV1 => {
                 let compressed = compress_zstd(&input.decoded)?;
-                input.decoded.clear();
-                (MmdPackageCompression::ZstdV1, compressed)
+                Some(compressed)
             }
             MmdPackagePackCompression::AutoZstdV1 => {
                 let compressed = compress_zstd(&input.decoded)?;
                 if compressed.len() < input.decoded.len() {
-                    input.decoded.clear();
-                    (MmdPackageCompression::ZstdV1, compressed)
+                    Some(compressed)
                 } else {
-                    (
-                        MmdPackageCompression::None,
-                        std::mem::take(&mut input.decoded),
-                    )
+                    None
                 }
             }
+        };
+        let compression = if compressed.is_some() {
+            MmdPackageCompression::ZstdV1
+        } else {
+            MmdPackageCompression::None
+        };
+        if input.codec == "ktx2-uastc-v1" {
+            let texture = input.texture.as_ref().ok_or_else(|| {
+                MmdPackagePackError::PackingFailed(format!(
+                    "texture entry {} requires texture metadata",
+                    input.id
+                ))
+            })?;
+            let metadata = parse_ktx2_metadata(texture, input.id)?;
+            validate_ktx2_payload(&input.decoded, compression, &metadata)?;
+        }
+        let encoded = if let Some(compressed) = compressed {
+            input.decoded.clear();
+            compressed
+        } else {
+            std::mem::take(&mut input.decoded)
         };
         let cipher_size = (encoded.len() as u64)
             .checked_add(GCM_TAG_LEN)

--- a/crates/mmd-anim-package/tests/bindings.rs
+++ b/crates/mmd-anim-package/tests/bindings.rs
@@ -22,11 +22,11 @@ fn package_with_bindings(texture_bindings: Vec<MmdTextureBinding>) -> MmdPackage
     if !texture_bindings.is_empty() {
         entries.push(MmdPackagePackEntry {
             id: 2,
-            path: "texture/diffuse.ktx2".into(),
+            path: "texture/diffuse.bin".into(),
             kind: MmdPackageEntryKind::Texture,
-            codec: "ktx2-uastc-v1".into(),
+            codec: "uastc-ldr-4x4-v1".into(),
             compression: MmdPackagePackCompression::None,
-            decoded: vec![0],
+            decoded: vec![0; 16],
             media_type: None,
             motion: None,
             texture: Some(json!({
@@ -38,7 +38,9 @@ fn package_with_bindings(texture_bindings: Vec<MmdTextureBinding>) -> MmdPackage
                 "channelModel": "rgba",
                 "swizzle": "rgba",
                 "alphaMode": "straight",
-                "origin": "top-left"
+                "origin": "top-left",
+                "blockOrder": "row-major-top-left",
+                "mips": [{"width": 1, "height": 1, "offset": 0, "size": 16}]
             })),
         });
     }

--- a/crates/mmd-anim-package/tests/manifest.rs
+++ b/crates/mmd-anim-package/tests/manifest.rs
@@ -3,8 +3,9 @@ use std::sync::Arc;
 use aes_gcm::aead::{Aead, Payload};
 use aes_gcm::{Aes256Gcm, KeyInit, Nonce};
 use mmd_anim_package::{
-    MMDPACK_HEADER_LEN, MmdPackage, MmdPackageCompression, MmdPackageEntryKind, MmdPackageError,
-    MmdPackageLimits,
+    MMDPACK_HEADER_LEN, MmdModelBinding, MmdPackage, MmdPackageCompression, MmdPackageEntryKind,
+    MmdPackageError, MmdPackageLimits, MmdPackagePackCompression, MmdPackagePackEntry,
+    MmdPackagePackError, MmdPackagePackInput, MmdPackagePacker,
 };
 use serde_json::{Map, Value, json};
 
@@ -67,6 +68,140 @@ fn ktx2_texture_metadata() -> Value {
         "alphaMode": "straight",
         "origin": "top-left",
     })
+}
+
+fn valid_ktx2_payload() -> Vec<u8> {
+    let mut payload = Vec::new();
+    payload.extend_from_slice(b"\xabKTX 20\xbb\r\n\x1a\n");
+    for value in [0_u32, 1, 1, 1, 0, 0, 1, 1, 0, 104, 44, 0, 0] {
+        payload.extend_from_slice(&value.to_le_bytes());
+    }
+    payload.extend_from_slice(&0_u64.to_le_bytes());
+    payload.extend_from_slice(&0_u64.to_le_bytes());
+    payload.extend_from_slice(&160_u64.to_le_bytes());
+    payload.extend_from_slice(&16_u64.to_le_bytes());
+    payload.extend_from_slice(&16_u64.to_le_bytes());
+
+    payload.extend_from_slice(&44_u32.to_le_bytes());
+    payload.extend_from_slice(&0_u32.to_le_bytes());
+    payload.extend_from_slice(&0x0028_0002_u32.to_le_bytes());
+    payload.extend_from_slice(&0x0002_01a6_u32.to_le_bytes());
+    payload.extend_from_slice(&[3, 3, 0, 0, 16, 0, 0, 0, 0, 0, 0, 0]);
+    payload.extend_from_slice(&0x037f_0000_u32.to_le_bytes());
+    payload.extend_from_slice(&[0; 4]);
+    payload.extend_from_slice(&[0; 4]);
+    payload.extend_from_slice(&[0xff; 4]);
+    payload.extend_from_slice(&[0; 12]);
+    payload.extend_from_slice(&[0; 16]);
+    assert_eq!(payload.len(), 176);
+    payload
+}
+
+fn valid_ktx2_zstd_payload(data: &[u8], bytes_plane: u8) -> Vec<u8> {
+    let compressed = zstd::bulk::compress(data, 3).unwrap();
+    let mut payload = valid_ktx2_payload();
+    payload[44..48].copy_from_slice(&2_u32.to_le_bytes());
+    payload[104 + 20] = bytes_plane;
+    payload[88..96].copy_from_slice(&(compressed.len() as u64).to_le_bytes());
+    payload.truncate(160);
+    payload.extend_from_slice(&compressed);
+    payload
+}
+
+fn valid_ktx2_payload_with_swizzle_kvd() -> Vec<u8> {
+    let mut payload = valid_ktx2_payload();
+    let level = payload.split_off(160);
+    payload.truncate(148);
+    payload[56..60].copy_from_slice(&148_u32.to_le_bytes());
+    payload[60..64].copy_from_slice(&20_u32.to_le_bytes());
+    payload.extend_from_slice(&16_u32.to_le_bytes());
+    payload.extend_from_slice(b"KTXswizzle\0rgba\0");
+    payload.extend_from_slice(&[0; 8]);
+    assert_eq!(payload.len(), 176);
+    payload[80..88].copy_from_slice(&176_u64.to_le_bytes());
+    payload.extend_from_slice(&level);
+    payload
+}
+
+fn incompressible_ktx2_zstd_payload() -> Vec<u8> {
+    let compressed = zstd::bulk::compress(&[0; 16], 3).unwrap();
+    let mut payload = valid_ktx2_payload();
+    let mut state = 0x6d2b_79f5_u32;
+    let mut pair = b"probe\0".to_vec();
+    for _ in 0..(256 * 1024) {
+        state ^= state << 13;
+        state ^= state >> 17;
+        state ^= state << 5;
+        pair.push((state >> 24) as u8);
+    }
+    pair.push(0);
+
+    payload.truncate(148);
+    let kvd_length = (4 + pair.len() + 3) & !3;
+    let level_offset = (148 + kvd_length + 15) & !15;
+    payload[44..48].copy_from_slice(&2_u32.to_le_bytes());
+    payload[104 + 20] = 16;
+    payload[56..60].copy_from_slice(&148_u32.to_le_bytes());
+    payload[60..64].copy_from_slice(&(kvd_length as u32).to_le_bytes());
+    payload.extend_from_slice(&(pair.len() as u32).to_le_bytes());
+    payload.extend_from_slice(&pair);
+    payload.resize(level_offset, 0);
+    payload[80..88].copy_from_slice(&(level_offset as u64).to_le_bytes());
+    payload[88..96].copy_from_slice(&(compressed.len() as u64).to_le_bytes());
+    payload.extend_from_slice(&compressed);
+    payload
+}
+
+fn open_ktx2(payload: &[u8]) -> Result<MmdPackage, MmdPackageError> {
+    open(
+        manifest(vec![
+            model_entry(),
+            texture_entry(2, "ktx2-uastc-v1", ktx2_texture_metadata()),
+        ]),
+        &[b"PMX", payload],
+        MmdPackageLimits::default(),
+    )
+}
+
+fn pack_ktx2(
+    payload: Vec<u8>,
+    compression: MmdPackagePackCompression,
+) -> Result<mmd_anim_package::MmdPackedPackage, MmdPackagePackError> {
+    MmdPackagePacker::pack(
+        MmdPackagePackInput {
+            default_model_entry_id: 1,
+            default_motion_entry_id: None,
+            entries: vec![
+                MmdPackagePackEntry {
+                    id: 1,
+                    path: "model/model.pmx".into(),
+                    kind: MmdPackageEntryKind::Model,
+                    codec: "pmx".into(),
+                    compression: MmdPackagePackCompression::None,
+                    decoded: b"PMX".to_vec(),
+                    media_type: None,
+                    motion: None,
+                    texture: None,
+                },
+                MmdPackagePackEntry {
+                    id: 2,
+                    path: "texture/2.ktx2".into(),
+                    kind: MmdPackageEntryKind::Texture,
+                    codec: "ktx2-uastc-v1".into(),
+                    compression,
+                    decoded: payload,
+                    media_type: None,
+                    motion: None,
+                    texture: Some(ktx2_texture_metadata()),
+                },
+            ],
+            model_bindings: vec![MmdModelBinding {
+                model_entry_id: 1,
+                texture_bindings: vec![],
+            }],
+        },
+        MmdPackageLimits::default(),
+    )
 }
 
 fn manifest(entries: Vec<Value>) -> Value {
@@ -163,7 +298,7 @@ fn invalid_manifest_message(result: Result<MmdPackage, MmdPackageError>, needle:
 }
 
 #[test]
-fn accepts_valid_raw_uastc_and_ktx2_summary_metadata() {
+fn accepts_valid_raw_uastc_and_ktx2_payload() {
     let raw = open(
         manifest(vec![
             model_entry(),
@@ -181,7 +316,7 @@ fn accepts_valid_raw_uastc_and_ktx2_summary_metadata() {
             model_entry(),
             texture_entry(2, "ktx2-uastc-v1", ktx2_texture_metadata()),
         ]),
-        &[b"PMX", b"not-a-real-ktx2-payload"],
+        &[b"PMX", &valid_ktx2_payload()],
         MmdPackageLimits::default(),
     )
     .unwrap();
@@ -189,7 +324,204 @@ fn accepts_valid_raw_uastc_and_ktx2_summary_metadata() {
         ktx2.manifest().entries[1].compression,
         MmdPackageCompression::None
     );
-    assert_eq!(ktx2.read_entry(2).unwrap(), b"not-a-real-ktx2-payload");
+    assert_eq!(ktx2.read_entry(2).unwrap().len(), 176);
+    assert_eq!(ktx2.read("texture/2.bin").unwrap().len(), 176);
+}
+
+#[test]
+fn rejects_ktx2_payload_manifest_mismatch_and_truncation_on_read_and_verify() {
+    let payload = valid_ktx2_payload();
+    let mut mismatch = ktx2_texture_metadata();
+    mismatch["width"] = 2.into();
+    let package = open(
+        manifest(vec![
+            model_entry(),
+            texture_entry(2, "ktx2-uastc-v1", mismatch),
+        ]),
+        &[b"PMX", &payload],
+        MmdPackageLimits::default(),
+    )
+    .unwrap();
+    assert!(matches!(
+        package.read_entry(2),
+        Err(MmdPackageError::InvalidKtx2(message)) if message.contains("dimensions")
+    ));
+    assert!(matches!(
+        package.read("texture/2.bin"),
+        Err(MmdPackageError::InvalidKtx2(message)) if message.contains("dimensions")
+    ));
+    assert!(matches!(
+        package.verify(Default::default()),
+        Err(MmdPackageError::InvalidKtx2(message)) if message.contains("dimensions")
+    ));
+
+    let package = open(
+        manifest(vec![
+            model_entry(),
+            texture_entry(2, "ktx2-uastc-v1", ktx2_texture_metadata()),
+        ]),
+        &[b"PMX", &payload[..payload.len() - 1]],
+        MmdPackageLimits::default(),
+    )
+    .unwrap();
+    assert!(matches!(
+        package.read_entry(2),
+        Err(MmdPackageError::InvalidKtx2(message)) if message.contains("outside")
+    ));
+}
+
+#[test]
+fn rejects_ktx2_dfd_mismatch_and_bad_level_ranges() {
+    let mut dfd_mismatch = valid_ktx2_payload();
+    dfd_mismatch[104 + 14] = 1;
+    let package = open_ktx2(&dfd_mismatch).unwrap();
+    assert!(matches!(
+        package.read_entry(2),
+        Err(MmdPackageError::InvalidKtx2(message)) if message.contains("transfer function")
+    ));
+
+    let mut unaligned = valid_ktx2_payload();
+    unaligned[80..88].copy_from_slice(&161_u64.to_le_bytes());
+    let package = open_ktx2(&unaligned).unwrap();
+    assert!(matches!(
+        package.read_entry(2),
+        Err(MmdPackageError::InvalidKtx2(message)) if message.contains("16-byte aligned")
+    ));
+
+    let mut overlap = valid_ktx2_zstd_payload(&[0; 16], 16);
+    overlap[80..88].copy_from_slice(&104_u64.to_le_bytes());
+    let package = open_ktx2(&overlap).unwrap();
+    assert!(matches!(
+        package.read_entry(2),
+        Err(MmdPackageError::InvalidKtx2(message)) if message.contains("overlaps")
+    ));
+}
+
+#[test]
+fn rejects_ktx2_metadata_without_required_kvd_terminator() {
+    let mut payload = valid_ktx2_payload_with_swizzle_kvd();
+    payload[148 + 4 + 15] = b'x';
+    let package = open_ktx2(&payload).unwrap();
+    assert!(matches!(
+        package.read_entry(2),
+        Err(MmdPackageError::InvalidKtx2(message)) if message.contains("KTXswizzle must be NUL-terminated")
+    ));
+}
+
+#[test]
+fn validates_ktx2_internal_zstd_current_and_legacy_byte_plane_sizes() {
+    for bytes_plane in [16, 0] {
+        let payload = valid_ktx2_zstd_payload(&[0; 16], bytes_plane);
+        let package = open_ktx2(&payload).unwrap();
+        assert_eq!(package.read_entry(2).unwrap(), payload);
+    }
+
+    let payload = valid_ktx2_zstd_payload(&[0; 15], 16);
+    let package = open_ktx2(&payload).unwrap();
+    assert!(matches!(
+        package.read_entry(2),
+        Err(MmdPackageError::InvalidKtx2(message)) if message.contains("expanded to 15 bytes")
+    ));
+
+    let mut payload = valid_ktx2_zstd_payload(&[0; 16], 16);
+    payload[160] ^= 0xff;
+    let package = open_ktx2(&payload).unwrap();
+    assert!(matches!(
+        package.read_entry(2),
+        Err(MmdPackageError::InvalidKtx2(_))
+    ));
+}
+
+#[test]
+fn selects_effective_outer_compression_before_ktx2_validation() {
+    let payload = incompressible_ktx2_zstd_payload();
+    let packed = pack_ktx2(payload.clone(), MmdPackagePackCompression::AutoZstdV1).unwrap();
+    let package = MmdPackage::open_bytes(
+        Arc::from(packed.bytes()),
+        *packed.key(),
+        MmdPackageLimits::default(),
+    )
+    .unwrap();
+    assert_eq!(
+        package.manifest().entries[1].compression,
+        MmdPackageCompression::None
+    );
+    assert_eq!(package.read_entry(2).unwrap(), payload);
+
+    let explicit = pack_ktx2(
+        valid_ktx2_zstd_payload(&[0; 16], 16),
+        MmdPackagePackCompression::None,
+    )
+    .unwrap();
+    let package = MmdPackage::open_bytes(
+        Arc::from(explicit.bytes()),
+        *explicit.key(),
+        MmdPackageLimits::default(),
+    )
+    .unwrap();
+    assert_eq!(
+        package.manifest().entries[1].compression,
+        MmdPackageCompression::None
+    );
+    assert!(package.read_entry(2).is_ok());
+
+    let result = pack_ktx2(
+        valid_ktx2_zstd_payload(&[0; 16], 16),
+        MmdPackagePackCompression::AutoZstdV1,
+    );
+    assert!(matches!(
+        result,
+        Err(MmdPackagePackError::Package(
+            MmdPackageError::InvalidKtx2(message)
+        )) if message.contains("internal Zstd requires MMDPACK entry compression none")
+    ));
+}
+
+#[test]
+fn pack_rejects_ktx2_before_payload_is_consumed() {
+    let mut payload = valid_ktx2_payload();
+    payload[104 + 12] = 0;
+    let result = MmdPackagePacker::pack(
+        MmdPackagePackInput {
+            default_model_entry_id: 1,
+            default_motion_entry_id: None,
+            entries: vec![
+                MmdPackagePackEntry {
+                    id: 1,
+                    path: "model/model.pmx".into(),
+                    kind: MmdPackageEntryKind::Model,
+                    codec: "pmx".into(),
+                    compression: MmdPackagePackCompression::None,
+                    decoded: b"PMX".to_vec(),
+                    media_type: None,
+                    motion: None,
+                    texture: None,
+                },
+                MmdPackagePackEntry {
+                    id: 2,
+                    path: "texture/2.ktx2".into(),
+                    kind: MmdPackageEntryKind::Texture,
+                    codec: "ktx2-uastc-v1".into(),
+                    compression: MmdPackagePackCompression::None,
+                    decoded: payload,
+                    media_type: None,
+                    motion: None,
+                    texture: Some(ktx2_texture_metadata()),
+                },
+            ],
+            model_bindings: vec![MmdModelBinding {
+                model_entry_id: 1,
+                texture_bindings: vec![],
+            }],
+        },
+        MmdPackageLimits::default(),
+    );
+    assert!(matches!(
+        result,
+        Err(mmd_anim_package::MmdPackagePackError::Package(
+            MmdPackageError::InvalidKtx2(message)
+        )) if message.contains("color model")
+    ));
 }
 
 #[test]

--- a/crates/mmd-anim-package/tests/packer.rs
+++ b/crates/mmd-anim-package/tests/packer.rs
@@ -254,6 +254,29 @@ fn rejects_invalid_input_and_limits() {
 }
 
 #[test]
+fn rejects_ktx2_codec_on_non_texture_before_encoding() {
+    let result = MmdPackagePacker::pack(
+        input(vec![MmdPackagePackEntry {
+            id: 1,
+            path: "model/model.pmx".into(),
+            kind: MmdPackageEntryKind::Model,
+            codec: "ktx2-uastc-v1".into(),
+            compression: MmdPackagePackCompression::None,
+            decoded: vec![0],
+            media_type: None,
+            motion: None,
+            texture: None,
+        }]),
+        MmdPackageLimits::default(),
+    );
+    assert!(matches!(
+        result,
+        Err(MmdPackagePackError::PackingFailed(message))
+            if message.contains("requires texture kind")
+    ));
+}
+
+#[test]
 fn generated_entry_tampering_is_rejected() {
     let packed = MmdPackagePacker::pack(
         input(vec![model(


### PR DESCRIPTION
KTX2 entries previously checked only Manifest metadata, allowing malformed or mismatched payloads through package reads and packing. Validate the draft UASTC LDR profile's header, DFD, orientation/swizzle, mip bounds and internal Zstd data against the Manifest at entry decode and before packing consumes the payload. Package opening remains lazy and unpack preserves codec payload bytes.

Use the effective outer compression selected by AutoZstdV1 for validation, so an internal-Zstd KTX2 can be packed when Auto chooses none. Update CLI diagnostics and cover invalid inputs being rejected before package/key publication.

Validation:
- cargo test --workspace: 993 passed, 0 failed, 3 existing ignored tests.
- cargo fmt --all -- --check: passed.
- cargo clippy --workspace --all-targets -- -D warnings: passed.
- Three real KTX/Basis Universal files, including internal Zstd: pack/verify/unpack preserved SHA-256; metadata mismatch rejected without publishing output files.
- Additional real-file AutoZstdV1 regression: effective compression none and byte-preserving roundtrip confirmed.
- Independent review's AutoZstdV1 finding addressed and regression-tested.

Browser/GPU validation and V1 backend/profile freezing remain deferred.
